### PR TITLE
fix: restore the active file when reopening a folder tab

### DIFF
--- a/docs/features/multi-tab.md
+++ b/docs/features/multi-tab.md
@@ -221,6 +221,7 @@ When a tab's file or folder cannot be accessed after a browser reopen, the UI ke
 - **Banner**: sticky restore-access banner at the top of the document with an "Open file" / "Open folder" action
 - **Disabled actions**: comment creation, comment merge/review panels, and share-management actions stay disabled until access is restored
 - **No renderable file context**: show the full restore placeholder with an "Open file" / "Open folder" button
+- **Manual folder reopen**: when the user reopens a degraded folder tab and the last active file path still exists, restore that file immediately instead of dropping back to an empty folder view
 
 While `restoreError` is set, host-side review actions are disabled because the tab no longer has confirmed live write access.
 

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -765,22 +765,39 @@ export function createWorkspaceControllerActions<
 
           await saveHandle(`tab:${tabId}:directory`, result.handle);
           const tree = await buildFileTree(result.handle);
+          const restoredFile = await restoreActiveFileFromTree({
+            tree,
+            activeFilePath: tab.activeFilePath,
+            persistedFileName: tab.fileName,
+            persistedRawContent: tab.rawContent,
+          });
           set((state) => ({
             tabs: buildUpdatedTabs(state.tabs, tabId, () => ({
               directoryHandle: result.handle,
               directoryName: result.name,
               label: result.name,
               fileTree: tree,
-              fileHandle: null,
-              fileName: null,
-              rawContent: "",
-              activeFilePath: null,
-              writeAllowed: true,
-              restoreError: null,
+              fileHandle: restoredFile.fileHandle,
+              fileName: restoredFile.fileName,
+              rawContent: restoredFile.rawContent,
+              writeAllowed: restoredFile.restoreMessage === null,
+              commentPanelOpen:
+                restoredFile.restoreMessage === null
+                  ? tab.commentPanelOpen
+                  : false,
+              sharedPanelOpen:
+                restoredFile.restoreMessage === null
+                  ? tab.sharedPanelOpen
+                  : false,
+              restoreError: restoredFile.restoreMessage,
             })),
           }));
 
-          if (get().activeTabId === tabId && tree.length > 0) {
+          if (
+            get().activeTabId === tabId &&
+            tree.length > 0 &&
+            restoredFile.restoreMessage === null
+          ) {
             await scanAllFileComments();
           }
         } catch (error) {

--- a/src/modules/workspace/test/tabRestore.test.ts
+++ b/src/modules/workspace/test/tabRestore.test.ts
@@ -8,6 +8,7 @@ vi.mock("../storage", async (importOriginal) => {
     getHandle: vi.fn(),
     removeHandle: vi.fn(),
     buildFileTree: vi.fn(),
+    openDirectory: vi.fn(),
     readFile: vi.fn(),
   };
 });
@@ -17,7 +18,13 @@ import { createDefaultTab } from "../../../types/tab";
 import type { FileTreeNode } from "../../../types/fileTree";
 import { resetTestStore, setTestState } from "../../../testing/testHelpers";
 import { getActiveTab } from "../selectors";
-import { buildFileTree, getHandle, readFile } from "../storage";
+import {
+  buildFileTree,
+  getHandle,
+  openDirectory,
+  readFile,
+  saveHandle,
+} from "../storage";
 
 beforeEach(() => {
   resetTestStore();
@@ -282,6 +289,80 @@ describe("store.restoreTabs", () => {
     const tab = useAppStore.getState().tabs.find((t) => t.id === "file-tab");
     expect(tab?.restoreError).toBeNull();
     expect(tab?.rawContent).toBe("# Fresh content");
+    expect(tab?.writeAllowed).toBe(true);
+  });
+});
+
+describe("store.reopenTab", () => {
+  it("reopens a folder tab and restores its previous active file", async () => {
+    const directoryHandle = {
+      kind: "directory",
+      name: "project",
+    };
+    const recoveredFileHandle = {
+      kind: "file",
+      name: "readme.md",
+      getFile: vi.fn().mockResolvedValue({
+        text: vi.fn().mockResolvedValue("# Updated"),
+      }),
+    };
+    const tree: FileTreeNode[] = [
+      {
+        kind: "directory",
+        name: "docs",
+        path: "docs",
+        children: [
+          {
+            kind: "file",
+            name: "readme.md",
+            path: "docs/readme.md",
+            handle: recoveredFileHandle,
+          },
+        ],
+      },
+    ];
+    const fileTab = createDefaultTab({
+      id: "folder-tab",
+      label: "project",
+      directoryName: "project",
+      fileName: "readme.md",
+      rawContent: "# Persisted",
+      activeFilePath: "docs/readme.md",
+      commentPanelOpen: true,
+      sharedPanelOpen: true,
+      restoreError:
+        'Live access to folder "project" is unavailable. Open the folder again to restore "readme.md" and resume commenting.',
+      writeAllowed: false,
+    });
+
+    useAppStore.setState({
+      tabs: [fileTab],
+      activeTabId: fileTab.id,
+    });
+
+    vi.mocked(openDirectory).mockResolvedValue({
+      handle: directoryHandle,
+      name: "project",
+    });
+    vi.mocked(buildFileTree).mockResolvedValue(tree);
+    vi.mocked(readFile).mockResolvedValue("# Updated");
+
+    await useAppStore.getState().reopenTab(fileTab.id);
+
+    const tab = getActiveTab(useAppStore.getState());
+    expect(openDirectory).toHaveBeenCalled();
+    expect(saveHandle).toHaveBeenCalledWith(
+      `tab:${fileTab.id}:directory`,
+      directoryHandle,
+    );
+    expect(tab?.directoryHandle).toBe(directoryHandle);
+    expect(tab?.fileHandle).toBe(recoveredFileHandle);
+    expect(tab?.fileName).toBe("readme.md");
+    expect(tab?.rawContent).toBe("# Updated");
+    expect(tab?.activeFilePath).toBe("docs/readme.md");
+    expect(tab?.commentPanelOpen).toBe(true);
+    expect(tab?.sharedPanelOpen).toBe(true);
+    expect(tab?.restoreError).toBeNull();
     expect(tab?.writeAllowed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- restore the previously active file when a degraded folder tab is reopened
- preserve the existing restore-needed behavior if that file still cannot be found in the reopened folder
- document the manual folder-reopen recovery behavior in the multi-tab spec

## Testing
- yarn test

Partially addresses #40
