### PR TITLE
feat: auto-refresh peer shares when safe

### DIFF
--- a/docs/features/peer-sharing.md
+++ b/docs/features/peer-sharing.md
@@ -184,6 +184,15 @@ When the host edits shared files locally, peers don't see changes automatically.
 - **"Push update" button** — appears in the header toolbar whenever there are active (non-expired) shares. Clicking it re-encrypts the current file/folder content and uploads it to the Worker, replacing the old blob. The same link keeps working; peers click "Get latest" to fetch the updated content.
 - Peers viewing the shared document see a **"Get latest" button** in their header. Clicking it fetches the latest content from the Worker. The peer's currently viewed file is preserved — if the file still exists in the updated payload, the peer stays on it; otherwise, the view falls back to the first file.
 
+Obsolete note:
+
+- The always-visible peer-side **"Get latest" button** described above is the older manual-refresh model and should be treated as obsolete.
+- Canonical behavior now uses **safe auto-update**:
+  - when a peer has no local comment work in progress, a host `document:updated` event reloads the latest shared content automatically
+  - when a peer has local comment work in progress, the app marks the view stale, shows a blocking refresh notice, and does not auto-refresh
+  - refreshing from that stale state discards unsent peer comments tied to the older snapshot before the peer continues reviewing
+- Reconnect uses the same safe auto-update rule. It checks whether the shared content is actually newer before deciding whether to auto-refresh or block on a manual refresh.
+
 ### 7.5 Manage Shared Documents
 
 The host has a "Shared" panel showing all active shares:
@@ -223,7 +232,7 @@ The host has a "Shared" panel showing all active shares:
 4. Host clicks "Merge" — app inserts CriticMarkup into the local files.
 5. Host tells LLM CLI: "Address the comments in this file."
 6. LLM reads CriticMarkup, makes fixes, removes the markup.
-7. Host clicks "Push update" in the header to push revised content to Worker. Peers click "Get latest" to see the updates.
+7. Host clicks "Push update" in the header to push revised content to Worker. Obsolete flow: peers click "Get latest" to see the updates. Canonical flow: peers auto-refresh when it is safe, otherwise the app blocks on a refresh notice until they load the latest snapshot.
 
 ---
 

--- a/docs/features/realtime-collaboration.md
+++ b/docs/features/realtime-collaboration.md
@@ -172,6 +172,14 @@ When WebRTC is active, peer comments appear in the host's margin within 1 second
 
 When the host clicks "Update" to push revised content to the Worker, connected peers receive a notification: "Document has been updated. Reload to see changes." Clicking reloads the content from the Worker. Previously resolved comments (removed by the LLM) disappear from the peer's view.
 
+Obsolete note:
+
+- The strictly manual reload-on-notification flow above is obsolete.
+- Canonical behavior now uses safe auto-update:
+  - auto-refresh immediately when the peer has no local comment work in progress
+  - block on refresh when the peer has local unsent comments or an open draft comment form
+  - discard unsent peer comments that belonged to the older snapshot when the peer refreshes from that stale state
+
 ### 6.5 Connection Status Indicator
 
 A small status indicator in the UI shows the current state:

--- a/docs/features/realtime-comments/spec.md
+++ b/docs/features/realtime-comments/spec.md
@@ -24,7 +24,8 @@ Host-authored local comments remain local-only. They are merged directly into th
 - As a host reconnecting after a disconnect, I want the current unresolved comment set restored from the backend without merge-by-ID heuristics.
 - As a peer reopening a shared document, I want the document content to reload cleanly and I want previously submitted comments to avoid duplicate submission.
 - As a peer reconnecting with unsent comments on multiple shared files, I want all unsent comments retried instead of only the currently open file.
-- As a peer viewing a shared document, I want to know when the host pushed updated content so I can refresh deliberately.
+- As a peer viewing a shared document with no local comment work in progress, I want newer shared content to load automatically so I stay on the latest version.
+- As a peer with local unsent comment work, I want automatic refresh to stop so I do not keep reviewing against content that just changed.
 - As a host adding my own local comments, I want them to stay private and local because they are already part of my working copy.
 
 ## 3. Scope
@@ -37,7 +38,7 @@ Host-authored local comments remain local-only. They are merged directly into th
 - `comments:snapshot` on host subscribe/reconnect
 - host/peer role distinction on subscribe
 - `ConnectionStatus` UI for relay state
-- `ContentUpdateBanner` for peer-side document refresh notification
+- `ContentUpdateBanner` for peer-side stale-content notification when auto-refresh is blocked
 - encrypted share content in KV
 - encrypted comment payloads over the relay
 
@@ -171,8 +172,16 @@ Peer comment payloads are encrypted before they are sent in `comment:add`. The D
 
 1. Host pushes new encrypted share content to KV.
 2. Host sends encrypted `document:updated`.
-3. Peer shows `ContentUpdateBanner`.
-4. Peer refreshes share content from KV when the user chooses to refresh.
+3. If the peer has no local unsent comment work, the app refreshes shared content automatically.
+4. If the peer has local unsent comment work, the app marks the view stale and shows `ContentUpdateBanner`.
+5. While stale, the peer cannot continue submitting comments against the older snapshot.
+6. Refreshing from the banner reloads share content from KV and discards unsent peer comments that were tied to the older snapshot.
+
+Obsolete note:
+
+- The older banner-only manual-refresh model is obsolete.
+- The older always-visible peer-side `Get latest` button is also obsolete.
+- The canonical behavior is now safe auto-refresh: auto-refresh when there is no local peer comment work, otherwise block on refresh.
 
 ## 8. Acceptance Criteria
 
@@ -180,7 +189,7 @@ Peer comment payloads are encrypted before they are sent in `comment:add`. The D
 2. A reconnecting host receives a full unresolved snapshot from the Durable Object.
 3. A resolved or dismissed peer comment no longer appears in later host snapshots for that share.
 4. A peer comment is marked submitted only after `comment:add:ack`.
-5. Peer-side content refresh notification works without changing the encrypted share-content model.
+5. Peer-side content updates use safe auto-refresh without changing the encrypted share-content model.
 6. Host-only resolve authority is enforced by `hostSecret` on subscribe.
 7. Reconnect resend includes unsent peer comments across all shared files, not only the currently open peer file.
 8. Host-authored local comments are never inserted into Durable Object comment storage.

--- a/docs/features/realtime-comments/spec.md
+++ b/docs/features/realtime-comments/spec.md
@@ -24,7 +24,8 @@ Host-authored local comments remain local-only. They are merged directly into th
 - As a host reconnecting after a disconnect, I want the current unresolved comment set restored from the backend without merge-by-ID heuristics.
 - As a peer reopening a shared document, I want the document content to reload cleanly and I want previously submitted comments to avoid duplicate submission.
 - As a peer reconnecting with unsent comments on multiple shared files, I want all unsent comments retried instead of only the currently open file.
-- As a peer viewing a shared document, I want to know when the host pushed updated content so I can refresh deliberately.
+- As a peer viewing a shared document with no local comment work in progress, I want newer shared content to load automatically so I stay on the latest version.
+- As a peer with local unsent comment work, I want automatic refresh to stop so I do not keep reviewing against content that just changed.
 - As a host adding my own local comments, I want them to stay private and local because they are already part of my working copy.
 
 ## 3. Scope
@@ -37,7 +38,7 @@ Host-authored local comments remain local-only. They are merged directly into th
 - `comments:snapshot` on host subscribe/reconnect
 - host/peer role distinction on subscribe
 - `ConnectionStatus` UI for relay state
-- `ContentUpdateBanner` for peer-side document refresh notification
+- `ContentUpdateBanner` for peer-side stale-content notification when auto-refresh is blocked
 - encrypted share content in KV
 - encrypted comment payloads over the relay
 
@@ -174,8 +175,16 @@ Opening the host share dialog is not part of share creation itself. For folder s
 
 1. Host pushes new encrypted share content to KV.
 2. Host sends encrypted `document:updated`.
-3. Peer shows `ContentUpdateBanner`.
-4. Peer refreshes share content from KV when the user chooses to refresh.
+3. If the peer has no local unsent comment work, the app refreshes shared content automatically.
+4. If the peer has local unsent comment work, the app marks the view stale and shows `ContentUpdateBanner`.
+5. While stale, the peer cannot continue submitting comments against the older snapshot.
+6. Refreshing from the banner reloads share content from KV and discards unsent peer comments that were tied to the older snapshot.
+
+Obsolete note:
+
+- The older banner-only manual-refresh model is obsolete.
+- The older always-visible peer-side `Get latest` button is also obsolete.
+- The canonical behavior is now safe auto-refresh: auto-refresh when there is no local peer comment work, otherwise block on refresh.
 
 ## 8. Acceptance Criteria
 
@@ -183,7 +192,7 @@ Opening the host share dialog is not part of share creation itself. For folder s
 2. A reconnecting host receives a full unresolved snapshot from the Durable Object.
 3. A resolved or dismissed peer comment no longer appears in later host snapshots for that share.
 4. A peer comment is marked submitted only after `comment:add:ack`.
-5. Peer-side content refresh notification works without changing the encrypted share-content model.
+5. Peer-side content updates use safe auto-refresh without changing the encrypted share-content model.
 6. Host-only resolve authority is enforced by `hostSecret` on subscribe.
 7. Reconnect resend includes unsent peer comments across all shared files, not only the currently open peer file.
 8. Host-authored local comments are never inserted into Durable Object comment storage.

--- a/docs/features/realtime-comments/technical-design.md
+++ b/docs/features/realtime-comments/technical-design.md
@@ -130,6 +130,7 @@ Existing `TabState` fields remain the source of host review state:
 - `relayStatus`
 - `documentUpdateAvailable`
 - peer-mode share content fields
+- `peerDraftCommentOpen`
 - `myPeerComments`
 - `submittedPeerCommentIds`
 
@@ -169,8 +170,16 @@ The WebSocket instance and timers stay in `src/services/relay.ts`, not in the Zu
 
 1. Host updates encrypted share content through `updateShare()`.
 2. Host sends encrypted `document:updated`.
-3. Peer receives the message and sets `documentUpdateAvailable`.
-4. `ContentUpdateBanner` triggers `loadSharedContent()` when the user refreshes.
+3. If the peer has no local comment work in progress, the client refreshes shared content automatically.
+4. If the peer has local unsent comments or an open draft comment form, the client sets `documentUpdateAvailable` instead of reloading immediately.
+5. While `documentUpdateAvailable` is true, the peer cannot submit comments against the older snapshot.
+6. `ContentUpdateBanner` is the blocking refresh path for that stale state and calls `loadSharedContent({ discardUnsubmitted: true })`.
+7. On reconnect, the client first checks the share's latest `Last-Modified` value via `HEAD /share/:docId` and then applies the same safe auto-refresh rule instead of unconditionally reloading content.
+
+Obsolete note:
+
+- The older banner-only manual-refresh flow is obsolete.
+- The older always-visible peer-side `Get latest` button is obsolete.
 
 ## 8. File Responsibilities
 

--- a/docs/features/realtime-comments/technical-design.md
+++ b/docs/features/realtime-comments/technical-design.md
@@ -130,6 +130,7 @@ Existing `TabState` fields remain the source of host review state:
 - `relayStatus`
 - `documentUpdateAvailable`
 - peer-mode share content fields
+- `peerDraftCommentOpen`
 - `myPeerComments`
 - `submittedPeerCommentIds`
 
@@ -176,8 +177,16 @@ The WebSocket instance and timers stay in `src/services/relay.ts`, not in the Zu
 
 1. Host updates encrypted share content through `updateShare()`.
 2. Host sends encrypted `document:updated`.
-3. Peer receives the message and sets `documentUpdateAvailable`.
-4. `ContentUpdateBanner` triggers `loadSharedContent()` when the user refreshes.
+3. If the peer has no local comment work in progress, the client refreshes shared content automatically.
+4. If the peer has local unsent comments or an open draft comment form, the client sets `documentUpdateAvailable` instead of reloading immediately.
+5. While `documentUpdateAvailable` is true, the peer cannot submit comments against the older snapshot.
+6. `ContentUpdateBanner` is the blocking refresh path for that stale state and calls `loadSharedContent({ discardUnsubmitted: true })`.
+7. On reconnect, the client first checks the share's latest `Last-Modified` value via `HEAD /share/:docId` and then applies the same safe auto-refresh rule instead of unconditionally reloading content.
+
+Obsolete note:
+
+- The older banner-only manual-refresh flow is obsolete.
+- The older always-visible peer-side `Get latest` button is obsolete.
 
 ## 8. File Responsibilities
 

--- a/src/modules/peer-review/controller.ts
+++ b/src/modules/peer-review/controller.ts
@@ -4,6 +4,7 @@ import {
   relayCommentAdd,
   startRelayForDoc,
 } from "../relay";
+import type { RelayState } from "../relay";
 import { ShareStorage } from "../sharing";
 import { WORKER_URL } from "../../config";
 import { parseShareHash } from "../../utils/shareUrl";
@@ -22,6 +23,7 @@ function getPeerReviewStorage(): ShareStorage | null {
 export async function loadPeerSharedContent<StoreState extends PeerReviewState>(
   get: () => StoreState,
   set: SetState<StoreState>,
+  options?: { discardUnsubmitted?: boolean },
 ): Promise<void> {
   const parsed = parseShareHash();
   if (!parsed) {
@@ -31,11 +33,15 @@ export async function loadPeerSharedContent<StoreState extends PeerReviewState>(
   if (!storage) {
     return;
   }
+  const hadLoadedContent = get().sharedContent !== null;
   const key = await base64urlToKey(parsed.keyB64);
   const docId = await docIdFromKey(key);
 
   try {
     const payload = await storage.fetchContent(docId, key);
+    const loadedUpdatedAt =
+      (await storage.fetchLastModified(docId).catch(() => null)) ??
+      payload.created_at;
     const currentPath = get().peerActiveFilePath;
     const paths = Object.keys(payload.tree);
     const activePath =
@@ -51,12 +57,28 @@ export async function loadPeerSharedContent<StoreState extends PeerReviewState>(
       peerFileName: activePath,
       peerActiveFilePath: activePath,
       peerActiveDocId: docId,
+      peerLoadedUpdatedAt: loadedUpdatedAt,
+      peerDraftCommentOpen: false,
+      myPeerComments: options?.discardUnsubmitted
+        ? state.myPeerComments.filter((comment) =>
+            state.submittedPeerCommentIds.includes(comment.id),
+          )
+        : state.myPeerComments,
     }));
 
     startRelayForDoc(docId);
   } catch (error) {
-    set({ isPeerMode: true, sharedContent: null });
+    if (!hadLoadedContent) {
+      set({
+        isPeerMode: true,
+        sharedContent: null,
+        peerLoadedUpdatedAt: null,
+      });
+    } else {
+      set({ isPeerMode: true });
+    }
     console.error("[share] Failed to load shared content:", error);
+    throw error;
   }
 }
 
@@ -64,8 +86,14 @@ export async function syncUnsubmittedPeerComments<
   StoreState extends Pick<
     PeerReviewState,
     "myPeerComments" | "submittedPeerCommentIds"
-  >,
->(get: () => StoreState): Promise<void> {
+  > &
+    Pick<RelayState, "documentUpdateAvailable">,
+>(
+  get: () => StoreState,
+): Promise<void> {
+  if (get().documentUpdateAvailable) {
+    return;
+  }
   const parsed = parseShareHash();
   if (!parsed) {
     return;

--- a/src/modules/peer-review/controller.ts
+++ b/src/modules/peer-review/controller.ts
@@ -4,6 +4,7 @@ import {
   relayCommentAdd,
   startRelayForDoc,
 } from "../relay";
+import type { RelayState } from "../relay";
 import { ShareStorage } from "../sharing";
 import { WORKER_URL } from "../../config";
 import { parseShareHash } from "../../utils/shareUrl";
@@ -23,6 +24,7 @@ function getPeerReviewStorage(): ShareStorage | null {
 export async function loadPeerSharedContent<StoreState extends PeerReviewState>(
   get: () => StoreState,
   set: SetState<StoreState>,
+  options?: { discardUnsubmitted?: boolean },
 ): Promise<void> {
   const parsed = parseShareHash();
   if (!parsed) {
@@ -32,11 +34,15 @@ export async function loadPeerSharedContent<StoreState extends PeerReviewState>(
   if (!storage) {
     return;
   }
+  const hadLoadedContent = get().sharedContent !== null;
   const key = await base64urlToKey(parsed.keyB64);
   const docId = await docIdFromKey(key);
 
   try {
     const payload = await storage.fetchContent(docId, key);
+    const loadedUpdatedAt =
+      (await storage.fetchLastModified(docId).catch(() => null)) ??
+      payload.created_at;
     const currentPath = get().peerActiveFilePath;
     const paths = Object.keys(payload.tree);
     const activePath =
@@ -52,12 +58,28 @@ export async function loadPeerSharedContent<StoreState extends PeerReviewState>(
       peerFileName: activePath,
       peerActiveFilePath: activePath,
       peerActiveDocId: docId,
+      peerLoadedUpdatedAt: loadedUpdatedAt,
+      peerDraftCommentOpen: false,
+      myPeerComments: options?.discardUnsubmitted
+        ? state.myPeerComments.filter((comment) =>
+            state.submittedPeerCommentIds.includes(comment.id),
+          )
+        : state.myPeerComments,
     }));
 
     startRelayForDoc(docId);
   } catch (error) {
-    set({ isPeerMode: true, sharedContent: null });
+    if (!hadLoadedContent) {
+      set({
+        isPeerMode: true,
+        sharedContent: null,
+        peerLoadedUpdatedAt: null,
+      });
+    } else {
+      set({ isPeerMode: true });
+    }
     console.error("[share] Failed to load shared content:", error);
+    throw error;
   }
 }
 
@@ -65,8 +87,14 @@ export async function syncUnsubmittedPeerComments<
   StoreState extends Pick<
     PeerReviewState,
     "myPeerComments" | "submittedPeerCommentIds"
-  >,
->(get: () => StoreState): Promise<void> {
+  > &
+    Pick<RelayState, "documentUpdateAvailable">,
+>(
+  get: () => StoreState,
+): Promise<void> {
+  if (get().documentUpdateAvailable) {
+    return;
+  }
   const parsed = parseShareHash();
   if (!parsed) {
     return;

--- a/src/modules/peer-review/selectors.ts
+++ b/src/modules/peer-review/selectors.ts
@@ -49,6 +49,12 @@ export function selectMyPeerComments<StoreState extends PeerReviewState>(
   return state.myPeerComments;
 }
 
+export function selectPeerDraftCommentOpen<StoreState extends PeerReviewState>(
+  state: StoreState,
+) {
+  return state.peerDraftCommentOpen;
+}
+
 export function selectUnsubmittedPeerComments<
   StoreState extends Pick<
     PeerReviewState,
@@ -57,5 +63,16 @@ export function selectUnsubmittedPeerComments<
 >(state: StoreState): PeerComment[] {
   return state.myPeerComments.filter(
     (comment) => !state.submittedPeerCommentIds.includes(comment.id),
+  );
+}
+
+export function selectHasPeerLocalCommentWork<
+  StoreState extends Pick<
+    PeerReviewState,
+    "peerDraftCommentOpen" | "myPeerComments" | "submittedPeerCommentIds"
+  >,
+>(state: StoreState): boolean {
+  return (
+    state.peerDraftCommentOpen || selectUnsubmittedPeerComments(state).length > 0
   );
 }

--- a/src/modules/peer-review/state.ts
+++ b/src/modules/peer-review/state.ts
@@ -1,6 +1,7 @@
 import type { StoreApi } from "zustand";
 import type { CommentType } from "../../types/criticmarkup";
 import type { PeerComment } from "../../types/share";
+import type { RelayState } from "../relay";
 import {
   loadPeerSharedContent,
   syncUnsubmittedPeerComments,
@@ -33,10 +34,12 @@ export function createPeerReviewState(): PeerReviewState {
     isPeerMode: false,
     peerName: null,
     sharedContent: null,
+    peerDraftCommentOpen: false,
     myPeerComments: [],
     submittedPeerCommentIds: [],
     peerShareKeys: {},
     peerActiveDocId: null,
+    peerLoadedUpdatedAt: null,
     peerRawContent: "",
     peerFileName: null,
     peerActiveFilePath: null,
@@ -46,13 +49,19 @@ export function createPeerReviewState(): PeerReviewState {
   };
 }
 
-export function createPeerReviewActions<StoreState extends PeerReviewState>(
+export function createPeerReviewActions<
+  StoreState extends PeerReviewState & Pick<RelayState, "documentUpdateAvailable">,
+>(
   set: SetState<StoreState>,
   get: GetState<StoreState>,
 ): PeerReviewActions {
   return {
     setPeerName: (name) => {
       set({ peerName: name });
+    },
+
+    setPeerDraftCommentOpen: (open) => {
+      set({ peerDraftCommentOpen: open });
     },
 
     selectPeerFile: (path) => {
@@ -74,14 +83,24 @@ export function createPeerReviewActions<StoreState extends PeerReviewState>(
       });
     },
 
-    loadSharedContent: async () => {
-      await loadPeerSharedContent(get, set);
+    loadSharedContent: async (options) => {
+      await loadPeerSharedContent(get, set, options);
     },
 
     postPeerComment: (blockIndex, type, text, path) => {
-      const comment = createPeerComment(get().peerName, blockIndex, type, text, path);
+      if (get().documentUpdateAvailable) {
+        return;
+      }
+      const comment = createPeerComment(
+        get().peerName,
+        blockIndex,
+        type,
+        text,
+        path,
+      );
       set((state) => ({
         myPeerComments: [comment, ...state.myPeerComments],
+        peerDraftCommentOpen: false,
       }));
     },
 
@@ -103,6 +122,15 @@ export function createPeerReviewActions<StoreState extends PeerReviewState>(
             ? { ...comment, commentType: type, text }
             : comment,
         ),
+      }));
+    },
+
+    discardUnsubmittedPeerComments: () => {
+      set((state) => ({
+        myPeerComments: state.myPeerComments.filter((comment) =>
+          state.submittedPeerCommentIds.includes(comment.id),
+        ),
+        peerDraftCommentOpen: false,
       }));
     },
 

--- a/src/modules/peer-review/state.ts
+++ b/src/modules/peer-review/state.ts
@@ -1,6 +1,7 @@
 import type { StoreApi } from "zustand";
 import type { CommentType } from "../../types/criticmarkup";
 import type { PeerComment } from "../../types/share";
+import type { RelayState } from "../relay";
 import type { PeerReviewActions, PeerReviewState } from "./types";
 
 type SetState<StoreState> = StoreApi<StoreState>["setState"];
@@ -29,10 +30,12 @@ export function createPeerReviewState(): PeerReviewState {
     isPeerMode: false,
     peerName: null,
     sharedContent: null,
+    peerDraftCommentOpen: false,
     myPeerComments: [],
     submittedPeerCommentIds: [],
     peerShareKeys: {},
     peerActiveDocId: null,
+    peerLoadedUpdatedAt: null,
     peerRawContent: "",
     peerFileName: null,
     peerActiveFilePath: null,
@@ -42,7 +45,9 @@ export function createPeerReviewState(): PeerReviewState {
   };
 }
 
-export function createPeerReviewActions<StoreState extends PeerReviewState>(
+export function createPeerReviewActions<
+  StoreState extends PeerReviewState & Pick<RelayState, "documentUpdateAvailable">,
+>(
   set: SetState<StoreState>,
   get: GetState<StoreState>,
 ): Pick<
@@ -52,11 +57,17 @@ export function createPeerReviewActions<StoreState extends PeerReviewState>(
   | "postPeerComment"
   | "deletePeerComment"
   | "editPeerComment"
+  | "setPeerDraftCommentOpen"
+  | "discardUnsubmittedPeerComments"
   | "confirmPeerCommentSubmitted"
 > {
   return {
     setPeerName: (name) => {
       set({ peerName: name });
+    },
+
+    setPeerDraftCommentOpen: (open) => {
+      set({ peerDraftCommentOpen: open });
     },
 
     selectPeerFile: (path) => {
@@ -79,9 +90,19 @@ export function createPeerReviewActions<StoreState extends PeerReviewState>(
     },
 
     postPeerComment: (blockIndex, type, text, path) => {
-      const comment = createPeerComment(get().peerName, blockIndex, type, text, path);
+      if (get().documentUpdateAvailable) {
+        return;
+      }
+      const comment = createPeerComment(
+        get().peerName,
+        blockIndex,
+        type,
+        text,
+        path,
+      );
       set((state) => ({
         myPeerComments: [comment, ...state.myPeerComments],
+        peerDraftCommentOpen: false,
       }));
     },
 
@@ -103,6 +124,15 @@ export function createPeerReviewActions<StoreState extends PeerReviewState>(
             ? { ...comment, commentType: type, text }
             : comment,
         ),
+      }));
+    },
+
+    discardUnsubmittedPeerComments: () => {
+      set((state) => ({
+        myPeerComments: state.myPeerComments.filter((comment) =>
+          state.submittedPeerCommentIds.includes(comment.id),
+        ),
+        peerDraftCommentOpen: false,
       }));
     },
 

--- a/src/modules/peer-review/test/loadSharedContent.test.ts
+++ b/src/modules/peer-review/test/loadSharedContent.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetchContent = vi.fn();
+const mockFetchLastModified = vi.fn();
 
 vi.mock("../../../modules/sharing", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../modules/sharing")>();
@@ -8,6 +9,7 @@ vi.mock("../../../modules/sharing", async (importOriginal) => {
     ...actual,
     ShareStorage: vi.fn().mockImplementation(() => ({
       fetchContent: mockFetchContent,
+      fetchLastModified: mockFetchLastModified,
     })),
   };
 });
@@ -57,7 +59,9 @@ describe("peer-review.loadSharedContent", () => {
   beforeEach(() => {
     resetTestStore();
     mockFetchContent.mockClear();
+    mockFetchLastModified.mockClear();
     window.location.hash = "#s=test-key-b64&n=test";
+    mockFetchLastModified.mockResolvedValue("2026-04-22T10:00:00.000Z");
   });
 
   afterEach(() => {
@@ -90,6 +94,7 @@ describe("peer-review.loadSharedContent", () => {
     expect(state.peerActiveFilePath).toBe("notes.md");
     expect(state.peerFileName).toBe("notes.md");
     expect(state.peerRawContent).toBe("# Updated Notes");
+    expect(state.peerLoadedUpdatedAt).toBe("2026-04-22T10:00:00.000Z");
   });
 
   it("falls back to first file when current file was removed from payload", async () => {
@@ -143,5 +148,45 @@ describe("peer-review.loadSharedContent", () => {
     const state = useAppStore.getState();
     expect(state.peerActiveFilePath).toBe("readme.md");
     expect(state.peerRawContent).toBe("# Hello");
+  });
+
+  it("discards unsubmitted comments when requested during refresh", async () => {
+    const submittedComment = {
+      id: "submitted-1",
+      peerName: "Alice",
+      path: "notes.md",
+      blockRef: { blockIndex: 0, contentPreview: "" },
+      commentType: "note" as const,
+      text: "submitted",
+      createdAt: new Date().toISOString(),
+    };
+    const localComment = {
+      ...submittedComment,
+      id: "local-1",
+      text: "unsent",
+    };
+    setTestState(
+      {},
+      {
+        isPeerMode: true,
+        peerDraftCommentOpen: true,
+        myPeerComments: [submittedComment, localComment],
+        submittedPeerCommentIds: ["submitted-1"],
+      },
+    );
+
+    mockFetchContent.mockResolvedValue({
+      version: "2.0",
+      created_at: new Date().toISOString(),
+      tree: {
+        "notes.md": "# Updated Notes",
+      },
+    });
+
+    await useAppStore.getState().loadSharedContent({ discardUnsubmitted: true });
+
+    const state = useAppStore.getState();
+    expect(state.myPeerComments).toEqual([submittedComment]);
+    expect(state.peerDraftCommentOpen).toBe(false);
   });
 });

--- a/src/modules/peer-review/test/syncPeerComments.test.ts
+++ b/src/modules/peer-review/test/syncPeerComments.test.ts
@@ -122,4 +122,20 @@ describe("peer-review.syncPeerComments", () => {
 
     expect(useAppStore.getState().submittedPeerCommentIds).toEqual(["c-1"]);
   });
+
+  it("does not submit comments while the peer view is stale", async () => {
+    const firstComment = makePeerComment({ id: "c-1" });
+    setTestState(
+      {},
+      {
+        documentUpdateAvailable: true,
+        myPeerComments: [firstComment],
+        submittedPeerCommentIds: [],
+      },
+    );
+
+    await useAppStore.getState().syncPeerComments();
+
+    expect(mockRelayCommentAdd).not.toHaveBeenCalled();
+  });
 });

--- a/src/modules/peer-review/types.ts
+++ b/src/modules/peer-review/types.ts
@@ -5,10 +5,12 @@ export interface PeerReviewState {
   isPeerMode: boolean;
   peerName: string | null;
   sharedContent: SharePayload | null;
+  peerDraftCommentOpen: boolean;
   myPeerComments: PeerComment[];
   submittedPeerCommentIds: string[];
   peerShareKeys: Record<string, CryptoKey>;
   peerActiveDocId: string | null;
+  peerLoadedUpdatedAt: string | null;
   peerRawContent: string;
   peerFileName: string | null;
   peerActiveFilePath: string | null;
@@ -19,7 +21,7 @@ export interface PeerReviewState {
 
 export interface PeerReviewActions {
   setPeerName: (name: string) => void;
-  loadSharedContent: () => Promise<void>;
+  loadSharedContent: (options?: { discardUnsubmitted?: boolean }) => Promise<void>;
   selectPeerFile: (path: string) => void;
   postPeerComment: (
     blockIndex: number,
@@ -29,6 +31,8 @@ export interface PeerReviewActions {
   ) => void;
   deletePeerComment: (commentId: string) => void;
   editPeerComment: (commentId: string, type: CommentType, text: string) => void;
+  setPeerDraftCommentOpen: (open: boolean) => void;
+  discardUnsubmittedPeerComments: () => void;
   syncPeerComments: () => Promise<void>;
   confirmPeerCommentSubmitted: (cmtId: string) => void;
 }

--- a/src/modules/relay/controller.ts
+++ b/src/modules/relay/controller.ts
@@ -7,6 +7,8 @@ import type {
 import type { PeerComment } from "../../types/share";
 import { useAppStore } from "../../store";
 import { WORKER_URL } from "../../config";
+import { ShareStorage } from "../sharing";
+import { selectHasPeerLocalCommentWork } from "../peer-review/selectors";
 
 export interface RelayConnection {
   subscribe(
@@ -590,6 +592,31 @@ function findHostSecret(docId: string): string | undefined {
   return undefined;
 }
 
+function createShareStorage(): ShareStorage | null {
+  if (!WORKER_URL) {
+    return null;
+  }
+  return new ShareStorage(WORKER_URL);
+}
+
+function isRemoteContentNewer(
+  loadedAt: string | null,
+  remoteUpdatedAt: string | null,
+): boolean {
+  if (!remoteUpdatedAt) {
+    return false;
+  }
+  if (!loadedAt) {
+    return true;
+  }
+  const loadedTime = Date.parse(loadedAt);
+  const remoteTime = Date.parse(remoteUpdatedAt);
+  if (Number.isNaN(loadedTime) || Number.isNaN(remoteTime)) {
+    return true;
+  }
+  return remoteTime > loadedTime;
+}
+
 async function decryptAndAddPendingComment(
   docId: string,
   cmtId: string,
@@ -625,6 +652,34 @@ async function decryptAndReplaceSnapshot(
     }
   }
   useAppStore.getState().replaceCommentsSnapshot(docId, comments);
+}
+
+async function refreshPeerContent(input?: { discardUnsubmitted?: boolean }) {
+  const state = useAppStore.getState();
+  try {
+    await state.loadSharedContent(input);
+    useAppStore.getState().dismissDocumentUpdate();
+  } catch (error) {
+    useAppStore.getState().setDocumentUpdateAvailable(true);
+    console.warn("[relay] peer content refresh failed:", error);
+  }
+}
+
+export async function applyPeerDocumentUpdate(
+  updatedAt: string | null,
+): Promise<void> {
+  const state = useAppStore.getState();
+  if (!state.isPeerMode || state.documentUpdateAvailable) {
+    return;
+  }
+  if (!isRemoteContentNewer(state.peerLoadedUpdatedAt, updatedAt)) {
+    return;
+  }
+  if (selectHasPeerLocalCommentWork(state)) {
+    state.setDocumentUpdateAvailable(true);
+    return;
+  }
+  await refreshPeerContent();
 }
 
 function handleIncomingMessage(docId: string, event: RelayEvent): void {
@@ -663,17 +718,29 @@ function handleIncomingMessage(docId: string, event: RelayEvent): void {
 
   if (event.type === "document:updated") {
     if (state.isPeerMode) {
-      state.setDocumentUpdateAvailable(true);
+      void applyPeerDocumentUpdate(event.updatedAt);
     }
   }
 }
 
-function performReconnectCatchUp(): void {
+export async function performReconnectCatchUp(): Promise<void> {
   const state = useAppStore.getState();
-  if (state.isPeerMode) {
-    state.loadSharedContent().catch((error: unknown) => {
-      console.warn("[relay] peer content catch-up failed:", error);
-    });
+  if (!state.isPeerMode || state.documentUpdateAvailable) {
+    return;
+  }
+  const docId = state.peerActiveDocId;
+  if (!docId) {
+    return;
+  }
+  const storage = createShareStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    const updatedAt = await storage.fetchLastModified(docId);
+    await applyPeerDocumentUpdate(updatedAt);
+  } catch (error) {
+    console.warn("[relay] peer content catch-up failed:", error);
   }
 }
 
@@ -682,7 +749,7 @@ function handleStatusChange(
 ): void {
   useAppStore.getState().setRelayStatus(status);
   if (status === "connected") {
-    performReconnectCatchUp();
+    void performReconnectCatchUp();
   }
 }
 

--- a/src/modules/relay/test/controller.test.ts
+++ b/src/modules/relay/test/controller.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchLastModified = vi.fn();
+
+vi.mock("../../../config", () => ({
+  WORKER_URL: "https://mock-worker.test",
+}));
+
+vi.mock("../../sharing", () => ({
+  ShareStorage: vi.fn().mockImplementation(() => ({
+    fetchLastModified: mockFetchLastModified,
+  })),
+}));
+
+import { applyPeerDocumentUpdate, performReconnectCatchUp } from "../controller";
+import { useAppStore } from "../../../store";
+import { makePeerComment, resetTestStore, setTestState } from "../../../testing/testHelpers";
+
+beforeEach(() => {
+  resetTestStore();
+  mockFetchLastModified.mockReset();
+});
+
+describe("relay controller peer content updates", () => {
+  it("auto-refreshes peer content when a newer update arrives and there is no local comment work", async () => {
+    const loadSharedContent = vi.fn().mockResolvedValue(undefined);
+    setTestState(
+      {},
+      {
+        isPeerMode: true,
+        peerLoadedUpdatedAt: "2026-04-22T10:00:00.000Z",
+        loadSharedContent,
+      },
+    );
+
+    await applyPeerDocumentUpdate("2026-04-22T11:00:00.000Z");
+
+    expect(loadSharedContent).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().documentUpdateAvailable).toBe(false);
+  });
+
+  it("marks the peer view stale instead of auto-refreshing when unsent comments exist", async () => {
+    const loadSharedContent = vi.fn().mockResolvedValue(undefined);
+    setTestState(
+      {},
+      {
+        isPeerMode: true,
+        peerLoadedUpdatedAt: "2026-04-22T10:00:00.000Z",
+        loadSharedContent,
+        myPeerComments: [makePeerComment({ id: "local-1" })],
+        submittedPeerCommentIds: [],
+      },
+    );
+
+    await applyPeerDocumentUpdate("2026-04-22T11:00:00.000Z");
+
+    expect(loadSharedContent).not.toHaveBeenCalled();
+    expect(useAppStore.getState().documentUpdateAvailable).toBe(true);
+  });
+
+  it("checks share freshness on reconnect without reloading when content is unchanged", async () => {
+    const loadSharedContent = vi.fn().mockResolvedValue(undefined);
+    setTestState(
+      {},
+      {
+        isPeerMode: true,
+        peerActiveDocId: "doc-1",
+        peerLoadedUpdatedAt: "2026-04-22T11:00:00.000Z",
+        loadSharedContent,
+      },
+    );
+    mockFetchLastModified.mockResolvedValue("2026-04-22T11:00:00.000Z");
+
+    await performReconnectCatchUp();
+
+    expect(mockFetchLastModified).toHaveBeenCalledWith("doc-1");
+    expect(loadSharedContent).not.toHaveBeenCalled();
+    expect(useAppStore.getState().documentUpdateAvailable).toBe(false);
+  });
+});

--- a/src/modules/sharing/storage.ts
+++ b/src/modules/sharing/storage.ts
@@ -58,6 +58,20 @@ export class ShareStorage {
     return deserializePayload(decrypted);
   }
 
+  async fetchLastModified(docId: string): Promise<string | null> {
+    const response = await fetch(`${this.workerUrl}/share/${docId}`, {
+      method: "HEAD",
+    });
+    if (!response.ok) {
+      throw new Error(
+        response.status === 404
+          ? "Share not found or expired"
+          : `Fetch failed: ${response.status}`,
+      );
+    }
+    return response.headers.get("Last-Modified");
+  }
+
   async updateContent(
     docId: string,
     hostSecret: string,

--- a/src/modules/sharing/test/shareStorage.test.ts
+++ b/src/modules/sharing/test/shareStorage.test.ts
@@ -11,6 +11,7 @@ interface MockResponseShape {
   status?: number;
   json?: unknown;
   arrayBuffer?: ArrayBuffer;
+  headers?: Record<string, string>;
 }
 
 function makeFetchMock(responses: MockResponseShape[]) {
@@ -23,6 +24,9 @@ function makeFetchMock(responses: MockResponseShape[]) {
       status: response.status ?? (response.ok ? 200 : 500),
       json: async () => response.json,
       arrayBuffer: async () => response.arrayBuffer ?? new ArrayBuffer(0),
+      headers: {
+        get: (name: string) => response.headers?.[name] ?? null,
+      },
     };
   });
 }
@@ -104,6 +108,28 @@ describe("ShareStorage.fetchContent", () => {
     await expect(storage.fetchContent("missing", key)).rejects.toThrow(
       "Share not found or expired",
     );
+  });
+});
+
+describe("ShareStorage.fetchLastModified", () => {
+  it("HEADs /share/:docId and returns Last-Modified", async () => {
+    const fetchMock = makeFetchMock([
+      {
+        ok: true,
+        headers: {
+          "Last-Modified": "2026-04-22T10:00:00.000Z",
+        },
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const storage = new ShareStorage(WORKER_URL);
+    const lastModified = await storage.fetchLastModified("doc1");
+
+    expect(lastModified).toBe("2026-04-22T10:00:00.000Z");
+    expect(fetchMock).toHaveBeenCalledWith(`${WORKER_URL}/share/doc1`, {
+      method: "HEAD",
+    });
   });
 });
 

--- a/src/ui/components/CommentMargin/CommentMargin.test.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { CommentMargin } from "./index";
+import { useAppStore } from "../../../store";
 import { setTestState, resetTestStore } from "../../../testing/testHelpers";
 
 beforeEach(() => {
@@ -64,6 +65,20 @@ describe('CommentMargin — add button', () => {
     await user.click(screen.getByRole('button', { name: 'Add comment' }))
     expect(screen.queryByRole('button', { name: 'Add comment' })).not.toBeInTheDocument()
   })
+
+  it('hides the add button in peer mode when content refresh is required', () => {
+    useAppStore.setState({ documentUpdateAvailable: true })
+    render(
+      <CommentMargin
+        containerRef={fakeContainerRef}
+        hoveredBlock={{ index: 0, top: 0 }}
+        onAddComment={vi.fn()}
+        peerMode
+        onPostPeerComment={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: 'Add comment' })).not.toBeInTheDocument()
+  })
 })
 
 describe('CommentMargin — AddCommentForm', () => {
@@ -120,5 +135,34 @@ describe('CommentMargin — AddCommentForm', () => {
     await user.type(screen.getByPlaceholderText('Add a comment…'), 'done')
     await user.click(screen.getByRole('button', { name: 'Save' }))
     expect(screen.queryByPlaceholderText('Add a comment…')).not.toBeInTheDocument()
+  })
+
+  it('disables saving a peer draft after the document becomes stale', async () => {
+    const user = userEvent.setup()
+    useAppStore.setState({ isPeerMode: true })
+    const { rerender } = render(
+      <CommentMargin
+        containerRef={fakeContainerRef}
+        hoveredBlock={{ index: 2, top: 0 }}
+        onAddComment={vi.fn()}
+        peerMode
+        onPostPeerComment={vi.fn()}
+      />,
+    )
+    await user.click(screen.getByRole('button', { name: 'Add comment' }))
+    await user.type(screen.getByPlaceholderText('Add a comment…'), 'draft')
+
+    useAppStore.setState({ documentUpdateAvailable: true })
+    rerender(
+      <CommentMargin
+        containerRef={fakeContainerRef}
+        hoveredBlock={{ index: 2, top: 0 }}
+        onAddComment={vi.fn()}
+        peerMode
+        onPostPeerComment={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 })

--- a/src/ui/components/CommentMargin/CommentMargin.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.tsx
@@ -2,6 +2,8 @@ import "./CommentMargin.css";
 import { useEffect, useRef, useMemo, useState } from "react";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
+import { selectDocumentUpdateAvailable } from "../../../modules/relay";
+import { selectPeerDraftCommentOpen } from "../../../modules/peer-review";
 import { CommentCard } from "../CommentCard";
 import { peerColor, initials } from "../../../utils/peerDisplay";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
@@ -22,9 +24,15 @@ interface AddCommentFormProps {
   top: number;
   onSubmit: (type: CommentType, text: string) => void;
   onCancel: () => void;
+  disabled?: boolean;
 }
 
-function AddCommentForm({ top, onSubmit, onCancel }: AddCommentFormProps) {
+function AddCommentForm({
+  top,
+  onSubmit,
+  onCancel,
+  disabled = false,
+}: AddCommentFormProps) {
   const [type, setType] = useState<CommentType>("note");
   const [text, setText] = useState("");
 
@@ -51,6 +59,7 @@ function AddCommentForm({ top, onSubmit, onCancel }: AddCommentFormProps) {
             type="button"
             className={`comment-add-form__type${type === t ? " comment-add-form__type--active" : ""}`}
             onClick={() => setType(t)}
+            disabled={disabled}
           >
             {t}
           </button>
@@ -63,12 +72,13 @@ function AddCommentForm({ top, onSubmit, onCancel }: AddCommentFormProps) {
         onChange={(e) => setText(e.target.value)}
         rows={3}
         autoFocus
+        disabled={disabled}
       />
       <div className="comment-add-form__actions">
         <button
           type="submit"
           className="comment-add-form__save"
-          disabled={!text.trim()}
+          disabled={disabled || !text.trim()}
         >
           Save
         </button>
@@ -123,6 +133,11 @@ export function CommentMargin({
   const activeDocId = tab?.activeDocId ?? null;
   const activeFilePath = tab?.activeFilePath ?? null;
   const fileName = tab?.fileName ?? null;
+  const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
+  const peerDraftCommentOpen = useAppStore(selectPeerDraftCommentOpen);
+  const setPeerDraftCommentOpen = useAppStore(
+    (state) => state.setPeerDraftCommentOpen,
+  );
   const [blockTops, setBlockTops] = useState<Map<number, number>>(new Map());
   // 'resolved' means the comments are gone from the file — no dots to show.
   // 'pending' is the same as 'all' for current (still-in-file) comments.
@@ -192,6 +207,20 @@ export function CommentMargin({
   }, [setActiveId]);
 
   useEffect(() => {
+    return () => {
+      if (peerMode) {
+        setPeerDraftCommentOpen(false);
+      }
+    };
+  }, [peerMode, setPeerDraftCommentOpen]);
+
+  useEffect(() => {
+    if (peerMode && addingBlock && !peerDraftCommentOpen) {
+      setAddingBlock(null);
+    }
+  }, [addingBlock, peerDraftCommentOpen, peerMode]);
+
+  useEffect(() => {
     measureRef.current = () => {
       const container = containerRef.current;
       if (!container) {
@@ -238,7 +267,7 @@ export function CommentMargin({
 
   return (
     <div className="comment-margin">
-      {hoveredBlock && !addingBlock && (
+      {hoveredBlock && !addingBlock && !(peerMode && documentUpdateAvailable) && (
         <div
           className="comment-margin__add-wrapper"
           style={{ top: hoveredBlock.top }}
@@ -249,6 +278,9 @@ export function CommentMargin({
             onClick={(e) => {
               e.stopPropagation();
               setAddingBlock(hoveredBlock);
+              if (peerMode) {
+                setPeerDraftCommentOpen(true);
+              }
             }}
           >
             <svg
@@ -268,19 +300,26 @@ export function CommentMargin({
         </div>
       )}
       {addingBlock && (
-        <AddCommentForm
-          top={addingBlock.top}
-          onSubmit={(type, text) => {
-            if (peerMode && onPostPeerComment) {
-              onPostPeerComment(addingBlock.index, type, text);
-            } else {
-              onAddComment(addingBlock.index, type, text);
-            }
-            setAddingBlock(null);
-          }}
-          onCancel={() => setAddingBlock(null)}
-        />
-      )}
+          <AddCommentForm
+            top={addingBlock.top}
+            onSubmit={(type, text) => {
+              if (peerMode && onPostPeerComment) {
+                onPostPeerComment(addingBlock.index, type, text);
+                setPeerDraftCommentOpen(false);
+              } else {
+                onAddComment(addingBlock.index, type, text);
+              }
+              setAddingBlock(null);
+            }}
+            onCancel={() => {
+              if (peerMode) {
+                setPeerDraftCommentOpen(false);
+              }
+              setAddingBlock(null);
+            }}
+            disabled={peerMode && documentUpdateAvailable}
+          />
+        )}
       {groups.map(({ top, comments: groupComments }, i) => {
         const activeComment =
           groupComments.find((c) => c.id === activeId) ?? null;

--- a/src/ui/components/CommentMargin/CommentMargin.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.tsx
@@ -6,6 +6,8 @@ import {
 } from "../../../markup";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
+import { selectDocumentUpdateAvailable } from "../../../modules/relay";
+import { selectPeerDraftCommentOpen } from "../../../modules/peer-review";
 import { CommentThreadCard } from "../CommentThreadCard";
 import { peerColor, initials } from "../../../utils/peerDisplay";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
@@ -26,12 +28,14 @@ interface AddCommentFormProps {
   top: number;
   onSubmit: (type: CommentType, text: string) => void;
   onCancel: () => void;
+  disabled?: boolean;
 }
 
 function AddCommentForm({
   top,
   onSubmit,
   onCancel,
+  disabled = false,
 }: AddCommentFormProps) {
   const [type, setType] = useState<CommentType>("note");
   const [text, setText] = useState("");
@@ -59,6 +63,7 @@ function AddCommentForm({
             type="button"
             className={`comment-add-form__type${type === t ? " comment-add-form__type--active" : ""}`}
             onClick={() => setType(t)}
+            disabled={disabled}
           >
             {t}
           </button>
@@ -71,12 +76,13 @@ function AddCommentForm({
         onChange={(e) => setText(e.target.value)}
         rows={3}
         autoFocus
+        disabled={disabled}
       />
       <div className="comment-add-form__actions">
         <button
           type="submit"
           className="comment-add-form__save"
-          disabled={!text.trim()}
+          disabled={disabled || !text.trim()}
         >
           Save
         </button>
@@ -131,6 +137,11 @@ export function CommentMargin({
   const activeDocId = tab?.activeDocId ?? null;
   const activeFilePath = tab?.activeFilePath ?? null;
   const fileName = tab?.fileName ?? null;
+  const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
+  const peerDraftCommentOpen = useAppStore(selectPeerDraftCommentOpen);
+  const setPeerDraftCommentOpen = useAppStore(
+    (state) => state.setPeerDraftCommentOpen,
+  );
   const [blockTops, setBlockTops] = useState<Map<number, number>>(new Map());
   // 'resolved' means the comments are gone from the file — no dots to show.
   // 'pending' is the same as 'all' for current (still-in-file) comments.
@@ -207,6 +218,20 @@ export function CommentMargin({
     document.addEventListener("click", onDocClick);
     return () => document.removeEventListener("click", onDocClick);
   }, [setActiveId]);
+
+  useEffect(() => {
+    return () => {
+      if (peerMode) {
+        setPeerDraftCommentOpen(false);
+      }
+    };
+  }, [peerMode, setPeerDraftCommentOpen]);
+
+  useEffect(() => {
+    if (peerMode && addingBlock && !peerDraftCommentOpen) {
+      setAddingBlock(null);
+    }
+  }, [addingBlock, peerDraftCommentOpen, peerMode]);
 
   useEffect(() => {
     measureRef.current = () => {
@@ -323,7 +348,7 @@ export function CommentMargin({
 
   return (
     <div className="comment-margin">
-      {hoveredBlock && !addingBlock && (
+      {hoveredBlock && !addingBlock && !(peerMode && documentUpdateAvailable) && (
         <div
           className="comment-margin__add-wrapper"
           style={{ top: hoveredBlock.top }}
@@ -334,6 +359,9 @@ export function CommentMargin({
             onClick={(e) => {
               e.stopPropagation();
               setAddingBlock(hoveredBlock);
+              if (peerMode) {
+                setPeerDraftCommentOpen(true);
+              }
             }}
           >
             <svg
@@ -353,19 +381,26 @@ export function CommentMargin({
         </div>
       )}
       {addingBlock && (
-          <AddCommentForm
-            top={addingBlock.top}
-            onSubmit={(type, text) => {
-              if (peerMode && onPostPeerComment) {
-                onPostPeerComment(addingBlock.index, type, text);
-              } else {
-                onAddComment(addingBlock.index, type, text);
-              }
-              setAddingBlock(null);
-            }}
-            onCancel={() => setAddingBlock(null)}
-          />
-        )}
+        <AddCommentForm
+          top={addingBlock.top}
+          onSubmit={(type, text) => {
+            if (peerMode && onPostPeerComment) {
+              onPostPeerComment(addingBlock.index, type, text);
+              setPeerDraftCommentOpen(false);
+            } else {
+              onAddComment(addingBlock.index, type, text);
+            }
+            setAddingBlock(null);
+          }}
+          onCancel={() => {
+            if (peerMode) {
+              setPeerDraftCommentOpen(false);
+            }
+            setAddingBlock(null);
+          }}
+          disabled={peerMode && documentUpdateAvailable}
+        />
+      )}
       {groups.map(({ top, threads }, i) => {
         const activeThread =
           threads.find(
@@ -438,7 +473,11 @@ export function CommentMargin({
       {/* Peer-only blocks (no host comments at this block) */}
       {Array.from(peerDotGroups.entries()).map(([blockIdx, peerComments]) => {
         // Skip blocks already rendered with host groups
-        if (groups.some((group) => group.threads[0]?.root.blockIndex === blockIdx)) {
+        if (
+          groups.some(
+            (group) => group.threads[0]?.root.blockIndex === blockIdx,
+          )
+        ) {
           return null;
         }
         const top = blockTops.get(blockIdx);

--- a/src/ui/components/ContentUpdateBanner/ContentUpdateBanner.test.tsx
+++ b/src/ui/components/ContentUpdateBanner/ContentUpdateBanner.test.tsx
@@ -15,7 +15,22 @@ describe("ContentUpdateBanner - visibility", () => {
     useAppStore.setState({ documentUpdateAvailable: true });
     render(<ContentUpdateBanner />);
     expect(
-      screen.getByText("The shared document has been updated."),
+      screen.getByText(
+        "The shared document has been updated. Refresh to continue reviewing.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("warns about unsent comments when local peer comment work exists", () => {
+    useAppStore.setState({
+      documentUpdateAvailable: true,
+      peerDraftCommentOpen: true,
+    });
+    render(<ContentUpdateBanner />);
+    expect(
+      screen.getByText(
+        "The shared document changed. Refresh to continue reviewing. Unsent comments will be discarded.",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -32,7 +47,9 @@ describe("ContentUpdateBanner - Refresh button", () => {
     useAppStore.setState({ documentUpdateAvailable: true, loadSharedContent });
     render(<ContentUpdateBanner />);
     await userEvent.click(screen.getByRole("button", { name: "Refresh" }));
-    expect(loadSharedContent).toHaveBeenCalledTimes(1);
+    expect(loadSharedContent).toHaveBeenCalledWith({
+      discardUnsubmitted: true,
+    });
   });
 
   it("calls dismissDocumentUpdate after loadSharedContent resolves", async () => {
@@ -67,17 +84,11 @@ describe("ContentUpdateBanner - Refresh button", () => {
     });
     expect(dismissDocumentUpdate).not.toHaveBeenCalled();
   });
-});
-
-describe("ContentUpdateBanner - Dismiss button", () => {
-  it("calls dismissDocumentUpdate when Dismiss is clicked", async () => {
-    const dismissDocumentUpdate = vi.fn();
-    useAppStore.setState({
-      documentUpdateAvailable: true,
-      dismissDocumentUpdate,
-    });
+  it("does not render a dismiss button", () => {
+    useAppStore.setState({ documentUpdateAvailable: true });
     render(<ContentUpdateBanner />);
-    await userEvent.click(screen.getByRole("button", { name: "Dismiss" }));
-    expect(dismissDocumentUpdate).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Dismiss" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/ui/components/ContentUpdateBanner/ContentUpdateBanner.tsx
+++ b/src/ui/components/ContentUpdateBanner/ContentUpdateBanner.tsx
@@ -1,48 +1,11 @@
 import { selectDocumentUpdateAvailable } from "../../../modules/relay";
+import { selectHasPeerLocalCommentWork } from "../../../modules/peer-review";
 import { useAppStore } from "../../../store";
 import "./ContentUpdateBanner.css";
 
-const closeIcon = (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 14 14"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-  >
-    <path d="M1 1l12 12M13 1L1 13" />
-  </svg>
-);
-
-function BannerActions(props: {
-  onRefresh: () => void;
-  onDismiss: () => void;
-}) {
-  return (
-    <>
-      <button
-        className="content-update-banner__refresh"
-        type="button"
-        onClick={props.onRefresh}
-      >
-        Refresh
-      </button>
-      <button
-        className="content-update-banner__dismiss"
-        type="button"
-        onClick={props.onDismiss}
-        aria-label="Dismiss"
-      >
-        {closeIcon}
-      </button>
-    </>
-  );
-}
-
 export function ContentUpdateBanner() {
   const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
+  const hasPeerLocalCommentWork = useAppStore(selectHasPeerLocalCommentWork);
   const loadSharedContent = useAppStore((state) => state.loadSharedContent);
   const dismissDocumentUpdate = useAppStore(
     (state) => state.dismissDocumentUpdate,
@@ -53,7 +16,7 @@ export function ContentUpdateBanner() {
   }
 
   function handleRefresh(): void {
-    loadSharedContent()
+    loadSharedContent({ discardUnsubmitted: true })
       .then(() => {
         dismissDocumentUpdate();
       })
@@ -64,11 +27,18 @@ export function ContentUpdateBanner() {
 
   return (
     <div className="content-update-banner">
-      <span>The shared document has been updated.</span>
-      <BannerActions
-        onRefresh={handleRefresh}
-        onDismiss={dismissDocumentUpdate}
-      />
+      <span>
+        {hasPeerLocalCommentWork
+          ? "The shared document changed. Refresh to continue reviewing. Unsent comments will be discarded."
+          : "The shared document has been updated. Refresh to continue reviewing."}
+      </span>
+      <button
+        className="content-update-banner__refresh"
+        type="button"
+        onClick={handleRefresh}
+      >
+        Refresh
+      </button>
     </div>
   );
 }

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -2,6 +2,7 @@ import "./Header.css";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { selectUnsubmittedPeerComments } from "../../../modules/peer-review";
+import { selectDocumentUpdateAvailable } from "../../../modules/relay";
 import { SunIcon, MoonIcon } from "../Icons";
 import { HistoryDropdown } from "../HistoryDropdown";
 import { TableOfContents } from "../TableOfContents";
@@ -158,8 +159,8 @@ export function Header({
   const toggleCommentPanel = useAppStore((s) => s.toggleCommentPanel);
   const toggleSharedPanel = useAppStore((s) => s.toggleSharedPanel);
   const refreshFile = useAppStore((s) => s.refreshFile);
-  const loadSharedContent = useAppStore((s) => s.loadSharedContent);
   const syncPeerComments = useAppStore((s) => s.syncPeerComments);
+  const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
 
   const myPeerComments = useAppStore((s) => s.myPeerComments);
   const peerActiveFilePath = useAppStore((s) => s.peerActiveFilePath);
@@ -317,20 +318,17 @@ export function Header({
           {peerMode && (
             <>
               <ConnectionStatus />
-              <button
-                onClick={loadSharedContent}
-                aria-label="Get latest content"
-                title="Fetch latest content from the host"
-                className="app-header__btn app-header__btn--text"
-              >
-                Get latest
-              </button>
               {unsubmittedPeerCount > 0 && (
                 <button
                   onClick={syncPeerComments}
                   aria-label="Submit comments"
-                  title="Send your comments to the host"
+                  title={
+                    documentUpdateAvailable
+                      ? "Refresh to the latest content before submitting comments"
+                      : "Send your comments to the host"
+                  }
                   className="app-header__btn app-header__btn--text"
+                  disabled={documentUpdateAvailable}
                 >
                   Submit comments ({unsubmittedPeerCount})
                 </button>

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import { buildCommentThreadGroups } from "../../../markup";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { selectUnsubmittedPeerComments } from "../../../modules/peer-review";
+import { selectDocumentUpdateAvailable } from "../../../modules/relay";
 import { SunIcon, MoonIcon } from "../Icons";
 import { HistoryDropdown } from "../HistoryDropdown";
 import { TableOfContents } from "../TableOfContents";
@@ -159,8 +160,8 @@ export function Header({
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const toggleCommentPanel = useAppStore((s) => s.toggleCommentPanel);
   const toggleSharedPanel = useAppStore((s) => s.toggleSharedPanel);
-  const loadSharedContent = useAppStore((s) => s.loadSharedContent);
   const syncPeerComments = useAppStore((s) => s.syncPeerComments);
+  const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
 
   const myPeerComments = useAppStore((s) => s.myPeerComments);
   const peerActiveFilePath = useAppStore((s) => s.peerActiveFilePath);
@@ -325,20 +326,17 @@ export function Header({
 
           {peerMode && (
             <>
-              <button
-                onClick={loadSharedContent}
-                aria-label="Get latest content"
-                title="Fetch latest content from the host"
-                className="app-header__btn app-header__btn--text"
-              >
-                Get latest
-              </button>
               {unsubmittedPeerCount > 0 && (
                 <button
                   onClick={syncPeerComments}
                   aria-label="Submit comments"
-                  title="Send your comments to the host"
+                  title={
+                    documentUpdateAvailable
+                      ? "Refresh to the latest content before submitting comments"
+                      : "Send your comments to the host"
+                  }
                   className="app-header__btn app-header__btn--text"
+                  disabled={documentUpdateAvailable}
                 >
                   Submit comments ({unsubmittedPeerCount})
                 </button>

--- a/src/ui/components/Header/downloadActiveFile.test.tsx
+++ b/src/ui/components/Header/downloadActiveFile.test.tsx
@@ -51,4 +51,41 @@ describe("Header — Save file button", () => {
     await user.click(screen.getByRole("button", { name: /Save file/ }));
     expect(mockDownloadFile).toHaveBeenCalledOnce();
   });
+
+  it("does not render a standalone Get latest button in peer mode", () => {
+    setTestState(
+      {},
+      { isPeerMode: true, peerFileName: "readme.md", peerRawContent: "# Hi" },
+    );
+    render(<Header peerMode />);
+    expect(
+      screen.queryByRole("button", { name: /Get latest/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables Submit comments while the peer view is stale", () => {
+    setTestState(
+      {},
+      {
+        isPeerMode: true,
+        peerFileName: "readme.md",
+        peerRawContent: "# Hi",
+        myPeerComments: [
+          {
+            id: "c-1",
+            peerName: "Alice",
+            path: "readme.md",
+            blockRef: { blockIndex: 0, contentPreview: "Hi" },
+            commentType: "note",
+            text: "Comment",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        submittedPeerCommentIds: [],
+        documentUpdateAvailable: true,
+      },
+    );
+    render(<Header peerMode />);
+    expect(screen.getByRole("button", { name: /Submit comments/i })).toBeDisabled();
+  });
 });

--- a/src/ui/hooks/useHashRouter.ts
+++ b/src/ui/hooks/useHashRouter.ts
@@ -11,7 +11,11 @@ export function useHashRouter(): boolean {
   useEffect(() => {
     function checkHash() {
       if (isShareHash() && WORKER_URL) {
-        loadSharedContent().finally(() => setPeerModeChecked(true));
+        loadSharedContent()
+          .catch((error: unknown) => {
+            console.warn("[useHashRouter] failed to load shared content:", error);
+          })
+          .finally(() => setPeerModeChecked(true));
       } else {
         setPeerModeChecked(true);
         restoreTabs();


### PR DESCRIPTION
## Summary
- auto-refresh peer shares on `document:updated` when there is no local peer comment work
- mark peer views stale and require refresh when unsent comments or an open draft would make auto-refresh unsafe
- route reconnect catch-up through the same freshness gate and document the old manual-refresh flow as obsolete

Closes #36.

## Testing
- `git diff --check`
- `yarn test src/modules/relay/test/controller.test.ts src/modules/peer-review/test/loadSharedContent.test.ts` *(fails locally: `/opt/homebrew/bin/yarn` points at a missing Node interpreter and the workspace is missing the Yarn node_modules state file)*