### PR TITLE
Hide healthy connection status

### DIFF
--- a/src/ui/components/ConnectionStatus/ConnectionStatus.css
+++ b/src/ui/components/ConnectionStatus/ConnectionStatus.css
@@ -2,6 +2,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  flex-shrink: 0;
 }
 
 .connection-status__dot {
@@ -10,10 +11,6 @@
   border-radius: 50%;
   flex-shrink: 0;
   background-color: var(--text-muted, #868e96);
-}
-
-.connection-status[data-status="connected"] .connection-status__dot {
-  background-color: #22c55e;
 }
 
 .connection-status[data-status="connecting"] .connection-status__dot {

--- a/src/ui/components/ConnectionStatus/ConnectionStatus.test.tsx
+++ b/src/ui/components/ConnectionStatus/ConnectionStatus.test.tsx
@@ -8,10 +8,10 @@ beforeEach(() => {
 });
 
 describe("ConnectionStatus - peer mode", () => {
-  it('renders "Connected" when relayStatus is connected in peer mode', () => {
+  it("hides the healthy connected state in peer mode", () => {
     setTestState({}, { isPeerMode: true, relayStatus: "connected" });
-    render(<ConnectionStatus />);
-    expect(screen.getByText("Connected")).toBeInTheDocument();
+    const { container } = render(<ConnectionStatus />);
+    expect(container.firstChild).toBeNull();
   });
 
   it('renders "Connecting..." when relayStatus is connecting in peer mode', () => {
@@ -27,17 +27,17 @@ describe("ConnectionStatus - peer mode", () => {
   });
 
   it("sets data-status attribute from relayStatus", () => {
-    setTestState({}, { isPeerMode: true, relayStatus: "connected" });
+    setTestState({}, { isPeerMode: true, relayStatus: "connecting" });
     render(<ConnectionStatus />);
     const statusElement = screen
-      .getByText("Connected")
+      .getByText("Connecting...")
       .closest(".connection-status");
-    expect(statusElement).toHaveAttribute("data-status", "connected");
+    expect(statusElement).toHaveAttribute("data-status", "connecting");
   });
 });
 
 describe("ConnectionStatus - host mode with active shares", () => {
-  it("renders when active tab has a non-expired share", () => {
+  it("hides the healthy connected state when active tab has a non-expired share", () => {
     const activeShare = makeShare({
       expiresAt: new Date(Date.now() + 86400000).toISOString(),
     });
@@ -45,8 +45,20 @@ describe("ConnectionStatus - host mode with active shares", () => {
       { shares: [activeShare] },
       { isPeerMode: false, relayStatus: "connected" },
     );
+    const { container } = render(<ConnectionStatus />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders non-healthy status when active tab has a non-expired share", () => {
+    const activeShare = makeShare({
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+    });
+    setTestState(
+      { shares: [activeShare] },
+      { isPeerMode: false, relayStatus: "connecting" },
+    );
     render(<ConnectionStatus />);
-    expect(screen.getByText("Connected")).toBeInTheDocument();
+    expect(screen.getByText("Connecting...")).toBeInTheDocument();
   });
 
   it("does not render when active tab only has expired shares", () => {

--- a/src/ui/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/src/ui/components/ConnectionStatus/ConnectionStatus.tsx
@@ -20,7 +20,6 @@ function selectActiveTabHasShares(state: {
 }
 
 const statusLabels: Record<string, string> = {
-  connected: "Connected",
   connecting: "Connecting...",
   disconnected: "Offline",
 };
@@ -31,6 +30,10 @@ export function ConnectionStatus() {
   const activeTabHasShares = useAppStore(selectActiveTabHasShares);
 
   if (!isPeerMode && !activeTabHasShares) {
+    return null;
+  }
+
+  if (relayStatus === "connected") {
     return null;
   }
 

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -231,6 +231,7 @@ export function Header({
           {peerMode && (
             <span className="app-header__peer-badge">Reviewing</span>
           )}
+          <ConnectionStatus />
         </div>
 
         <div className="app-header__actions">
@@ -299,7 +300,6 @@ export function Header({
               )}
 
               <div className="app-header__divider" aria-hidden="true" />
-              <ConnectionStatus />
             </>
           )}
 
@@ -316,7 +316,6 @@ export function Header({
 
           {peerMode && (
             <>
-              <ConnectionStatus />
               <button
                 onClick={loadSharedContent}
                 aria-label="Get latest content"


### PR DESCRIPTION
## Summary

- Hide the healthy `connected` relay status so the toolbar no longer shows a green-dot `Connected` label.
- Move remaining non-healthy connection states beside the filename / review badge instead of between toolbar actions.
- Update `ConnectionStatus` tests to expect healthy status to stay hidden while `connecting` and `offline` remain visible.

## Testing

- `git diff --check`
- Not run: `yarn test src/ui/components/ConnectionStatus/ConnectionStatus.test.tsx` because this environment has a broken Yarn/Node setup and no installed node_modules state.