### PR TITLE
Remove host refresh button

### DIFF
--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -157,7 +157,6 @@ export function Header({
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const toggleCommentPanel = useAppStore((s) => s.toggleCommentPanel);
   const toggleSharedPanel = useAppStore((s) => s.toggleSharedPanel);
-  const refreshFile = useAppStore((s) => s.refreshFile);
   const loadSharedContent = useAppStore((s) => s.loadSharedContent);
   const syncPeerComments = useAppStore((s) => s.syncPeerComments);
 
@@ -177,7 +176,6 @@ export function Header({
   const commentPanelOpen = peerMode
     ? peerCommentPanelOpen
     : (tab?.commentPanelOpen ?? false);
-  const fileHandle = tab?.fileHandle ?? null;
   const shares = tab?.shares ?? [];
   const sharedPanelOpen = tab?.sharedPanelOpen ?? false;
   const hasActiveShares = shares.some(
@@ -345,17 +343,6 @@ export function Header({
                 Save file
               </button>
             </>
-          )}
-
-          {!peerMode && fileHandle && (
-            <button
-              onClick={refreshFile}
-              aria-label="Refresh file"
-              title="Refresh file from disk"
-              className="app-header__btn app-header__btn--text"
-            >
-              Refresh
-            </button>
           )}
 
           <button


### PR DESCRIPTION
## Summary

- Remove the host toolbar `Refresh` button.
- Keep the underlying `refreshFile` action untouched for auto-refresh/watchers.

## Testing

- `git diff --check`
- Not run: `yarn test src/ui/components/Header/downloadActiveFile.test.tsx` because this environment has a broken Yarn/Node setup and no installed node_modules state.