### PR TITLE
Add threaded question answers

### DIFF
--- a/docs/design/v2-technical-design.md
+++ b/docs/design/v2-technical-design.md
@@ -13,7 +13,7 @@ v2 adds encrypted async peer sharing on top of the v1 local editing experience. 
 
 - Real-time sync (planned for v3 via WebRTC + Yjs)
 - Peer identity / authentication (peers self-declare a display name)
-- Comment threads or reactions
+- Peer-shared comment threads or reactions
 - Diff view between share revisions
 
 ---

--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -46,7 +46,7 @@ Developers and technical professionals who use LLM CLIs to generate structured r
 
 **Step 3:** Developer selects any block and leaves a comment. The editor writes CriticMarkup directly into the markdown file with a Conventional Comments-style type prefix.
 
-**Step 4:** Developer tells the LLM CLI: "Read this file and address all CriticMarkup comments." The LLM sees the comments inline, makes the fixes, and removes the markup.
+**Step 4:** Developer tells the LLM CLI: "Read this file and address all CriticMarkup comments." For standard comments, the LLM sees the comments inline, makes the fixes, and removes the markup. For threaded `question:` comments, the developer can use MarkReview's `Copy agent prompt` helper so the agent answers inline with a linked `answer:` reply instead of rewriting the original question.
 
 **Step 5:** Developer refreshes (Phase 1) or sees live updates (Phase 2) with the LLM's changes applied.
 
@@ -90,15 +90,38 @@ Supported types:
 - **expand** — add more detail or coverage
 - **clarify** — this is confusing, make it clearer
 - **question** — I need to understand this before approving
+- **answer** — a reply linked to an existing `question:` thread root
 - **remove** — this should be deleted
 
-### 6.3 Why This Works
+### 6.3 Threaded Question / Answer Extension
 
-The LLM reads the file and sees comments as part of the content — no separate protocol to learn. CriticMarkup is well-represented in LLM training data, so models already understand it. Comments and content stay in sync because they live in the same file. Any text editor can view and edit the annotations. No sidecar files, no sync issues, no export/import steps.
+MarkReview extends the plain comment protocol for threaded review questions.
 
-### 6.4 Editor Responsibilities
+- A `question:` comment can be a thread root.
+- MarkReview writes hidden `[markreview ...]` metadata into app-created `question:` comments so a raw markdown file still carries stable thread identifiers.
+- Agents reply with a separate inline `answer:` CriticMarkup comment near the same text block.
+- The reply reuses the root `thread` value and sets `replyTo` to the root question `id`.
+- The reply can also include `author` so the UI can show `Codex`, `Cursor`, or a generic `Agent` label.
 
-The editor parses CriticMarkup and hides it from the rendered view. Comments are displayed as UI elements — colored indicators in the margin that expand into comment cards. Highlights are shown as subtle background colors on the referenced text. When the user adds a comment through the UI, the editor inserts CriticMarkup at the correct position in the raw markdown. When the user deletes a comment, the editor removes the CriticMarkup from the file.
+Example root:
+
+```text
+{>>question: Why is this section needed? [markreview id="mr-question-1" thread="mr-question-1"]<<}
+```
+
+Example reply:
+
+```text
+{>>answer: This section explains the reconnect fallback path after a missed live event. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}
+```
+
+### 6.4 Why This Works
+
+For standard comments, the LLM reads the file and sees comments as part of the content — no separate protocol to learn. CriticMarkup is well-represented in LLM training data, so models already understand it. For threaded `question:` comments, MarkReview adds a small metadata extension plus a `Copy agent prompt` helper so replies stay linked without introducing sidecar files. Comments and content still stay in sync because everything lives in the same file. Any text editor can view and edit the annotations. No sidecar files, no sync issues, no export/import steps.
+
+### 6.5 Editor Responsibilities
+
+The editor parses CriticMarkup and hides it from the rendered view. Comments are displayed as UI elements — colored indicators in the margin that expand into comment cards. Highlights are shown as subtle background colors on the referenced text. When the user adds a comment through the UI, the editor inserts CriticMarkup at the correct position in the raw markdown. App-created `question:` comments receive hidden thread metadata so later `answer:` replies can link back to them. When the user deletes a comment, the editor removes the CriticMarkup from the file.
 
 ---
 
@@ -174,7 +197,8 @@ Typeform-inspired: the content is the interface. Light mode default with dark mo
 ## 10. Success Metrics
 
 - Time from opening a folder to leaving the first comment: under 10 seconds
-- The LLM addresses CriticMarkup comments correctly without additional prompting beyond "read and address the comments in this file"
+- The LLM addresses standard CriticMarkup comments correctly without additional prompting beyond "read and address the comments in this file"
+- Threaded `question:` comments can be handed off with `Copy agent prompt`, and the resulting `answer:` replies render as linked inline threads
 - A full review-comment-revise cycle completes in under 5 minutes
 - The reading experience is rated as comfortable and clean for documents over 3,000 words
 - Zero data leaves the user's machine

--- a/docs/features/realtime-comments/spec.md
+++ b/docs/features/realtime-comments/spec.md
@@ -46,6 +46,7 @@ Host-authored local comments remain local-only. They are merged directly into th
 - `/comments/*` REST API
 - KV-based comment polling or comment catch-up
 - peer-to-peer WebRTC transport
+- syncing host-local `question:` / `answer:` threads through the relay
 - remote rendering of other peers' comments in peer mode
 - real-time edit/delete of already-submitted peer comments
 - presence, cursors, typing indicators

--- a/docs/features/realtime-comments/technical-design.md
+++ b/docs/features/realtime-comments/technical-design.md
@@ -221,6 +221,7 @@ The WebSocket instance and timers stay in `src/services/relay.ts`, not in the Zu
 
 ## 10. Non-Goals
 
+- syncing host-local `question:` / `answer:` threads through the relay
 - collaborative peer-to-peer comment thread rendering
 - peer self-delete after submit
 - submitted comment edit flow

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -1,0 +1,19 @@
+export function buildAgentReplyPrompt(): string {
+  return `Review this markdown file and answer MarkReview threaded questions inline.
+
+Rules:
+- Leave each original question comment unchanged.
+- Reply with a separate inline CriticMarkup comment near the same text block.
+- Use the \`answer:\` prefix in every reply.
+- Keep the question's existing \`thread\` value.
+- Set \`replyTo\` to the question's \`id\`.
+- Give your reply its own unique \`id\`.
+- Add your agent name in \`author\` (for example \`Codex\` or \`Cursor\`).
+- Keep answers concise, specific, and grounded in the referenced text.
+
+Example question:
+{>>question: Why is this section needed? [markreview id="mr-question-1" thread="mr-question-1"]<<}
+
+Example answer:
+{>>answer: This section explains the reconnect fallback path after a missed live event. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}`;
+}

--- a/src/markup/commentProtocol.ts
+++ b/src/markup/commentProtocol.ts
@@ -1,0 +1,208 @@
+import type {
+  Comment,
+  CommentThreadMetadata,
+  CommentType,
+} from "../types/criticmarkup";
+
+const PREFIX_RE = /^(fix|rewrite|expand|clarify|question|answer|remove):\s*/i;
+const METADATA_RE = /\s*\[markreview\s+([^\]]+)\]\s*$/i;
+const THREAD_COMMENT_PREFIX = "mr-";
+
+const COMMENT_TYPES: ReadonlySet<string> = new Set<CommentType>([
+  "note",
+  "fix",
+  "rewrite",
+  "expand",
+  "clarify",
+  "question",
+  "answer",
+  "remove",
+]);
+
+export function isCommentType(value: string): value is CommentType {
+  return COMMENT_TYPES.has(value);
+}
+
+export function parseCommentType(text: string): {
+  type: CommentType;
+  text: string;
+} {
+  const match = PREFIX_RE.exec(text);
+  if (!match) {
+    return { type: "note", text };
+  }
+  const lower = match[1].toLowerCase();
+  return {
+    type: isCommentType(lower) ? lower : "note",
+    text: text.slice(match[0].length),
+  };
+}
+
+function parseMetadataAttributes(
+  attributesText: string,
+): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const attributeRe =
+    /([a-zA-Z][a-zA-Z0-9]*)=(?:"([^"]*)"|'([^']*)'|([^\s]+))/g;
+
+  let match: RegExpExecArray | null = attributeRe.exec(attributesText);
+  while (match) {
+    const [, key, doubleQuoted, singleQuoted, unquoted] = match;
+    const value = doubleQuoted ?? singleQuoted ?? unquoted ?? "";
+    attributes[key] = value;
+    match = attributeRe.exec(attributesText);
+  }
+
+  return attributes;
+}
+
+export function parseThreadMetadata(
+  text: string,
+): { text: string; thread?: CommentThreadMetadata } {
+  const metadataMatch = METADATA_RE.exec(text);
+  if (!metadataMatch) {
+    return { text };
+  }
+
+  const attributes = parseMetadataAttributes(metadataMatch[1]);
+  const commentId = attributes.id;
+  const threadId = attributes.thread;
+  if (!commentId || !threadId) {
+    return { text };
+  }
+
+  const visibleText = text.slice(0, metadataMatch.index).trimEnd();
+
+  const thread: CommentThreadMetadata = {
+    commentId,
+    threadId,
+  };
+  if (attributes.replyTo) {
+    thread.replyTo = attributes.replyTo;
+  }
+  if (attributes.author) {
+    thread.authorLabel = attributes.author;
+  }
+
+  return {
+    text: visibleText,
+    thread,
+  };
+}
+
+export function parseStructuredCommentBody(text: string): {
+  type: CommentType;
+  text: string;
+  thread?: CommentThreadMetadata;
+} {
+  const parsedType = parseCommentType(text);
+  const parsedThread = parseThreadMetadata(parsedType.text);
+  return {
+    type: parsedType.type,
+    text: parsedThread.text,
+    thread: parsedThread.thread,
+  };
+}
+
+function serializeThreadMetadata(thread: CommentThreadMetadata): string {
+  const attributes = [
+    `id="${thread.commentId}"`,
+    `thread="${thread.threadId}"`,
+  ];
+
+  if (thread.replyTo) {
+    attributes.push(`replyTo="${thread.replyTo}"`);
+  }
+  if (thread.authorLabel) {
+    attributes.push(`author="${thread.authorLabel}"`);
+  }
+
+  return `[markreview ${attributes.join(" ")}]`;
+}
+
+export function serializeCommentBody(input: {
+  type: CommentType;
+  text: string;
+  thread?: CommentThreadMetadata;
+}): string {
+  const prefix = input.type === "note" ? "" : `${input.type}: `;
+  const metadata = input.thread ? ` ${serializeThreadMetadata(input.thread)}` : "";
+  return `${prefix}${input.text}${metadata}`;
+}
+
+function createRandomCommentId(): string {
+  const cryptoValue = globalThis.crypto;
+  if (cryptoValue && typeof cryptoValue.randomUUID === "function") {
+    return `${THREAD_COMMENT_PREFIX}${cryptoValue.randomUUID()}`;
+  }
+
+  const randomSuffix = Math.random().toString(36).slice(2, 10);
+  const timeSuffix = Date.now().toString(36);
+  return `${THREAD_COMMENT_PREFIX}${timeSuffix}-${randomSuffix}`;
+}
+
+export function createQuestionThreadMetadata(): CommentThreadMetadata {
+  const commentId = createRandomCommentId();
+  return {
+    commentId,
+    threadId: commentId,
+  };
+}
+
+export function isThreadReply(comment: Comment): boolean {
+  return !!comment.thread?.replyTo;
+}
+
+export function isThreadRoot(comment: Comment): boolean {
+  return !!comment.thread && !comment.thread.replyTo;
+}
+
+export interface CommentThreadGroup {
+  root: Comment;
+  replies: Comment[];
+}
+
+export function buildCommentThreadGroups(
+  comments: Comment[],
+): CommentThreadGroup[] {
+  const commentsByThreadCommentId = new Map<string, Comment>();
+  const repliesByRootCommentId = new Map<string, Comment[]>();
+
+  for (const comment of comments) {
+    if (comment.thread?.commentId) {
+      commentsByThreadCommentId.set(comment.thread.commentId, comment);
+    }
+    if (comment.thread?.replyTo) {
+      const replies = repliesByRootCommentId.get(comment.thread.replyTo) ?? [];
+      replies.push(comment);
+      repliesByRootCommentId.set(comment.thread.replyTo, replies);
+    }
+  }
+
+  const groups: CommentThreadGroup[] = [];
+  for (const comment of comments) {
+    if (isThreadReply(comment)) {
+      const rootComment = commentsByThreadCommentId.get(
+        comment.thread?.replyTo ?? "",
+      );
+      if (rootComment && rootComment.thread?.threadId === comment.thread?.threadId) {
+        continue;
+      }
+      groups.push({ root: comment, replies: [] });
+      continue;
+    }
+
+    const replies =
+      repliesByRootCommentId
+        .get(comment.thread?.commentId ?? "")
+        ?.filter((reply) => reply.thread?.threadId === comment.thread?.threadId) ??
+      [];
+    groups.push({ root: comment, replies });
+  }
+
+  return groups;
+}
+
+export function getThreadRootCommentId(comment: Comment): string {
+  return comment.thread?.replyTo ?? comment.id;
+}

--- a/src/markup/criticmarkup.test.ts
+++ b/src/markup/criticmarkup.test.ts
@@ -298,7 +298,7 @@ describe('parseCriticMarkup — cleanStart / cleanEnd', () => {
 // ─── Step 2.3 — type prefix parsing ──────────────────────────────────────────
 
 describe('parseCommentType — prefix recognition', () => {
-  it.each(['fix', 'rewrite', 'expand', 'clarify', 'question', 'remove'])(
+  it.each(['fix', 'rewrite', 'expand', 'clarify', 'question', 'answer', 'remove'])(
     'recognizes "%s:" prefix',
     (prefix) => {
       const { type, text } = parseCommentType(`${prefix}: some text`)
@@ -384,5 +384,33 @@ describe('parseCriticMarkup — type field via prefix', () => {
   it('raw field is preserved unchanged (includes the prefix)', () => {
     const [c] = extractComments('{>>fix: something<<}')
     expect(c.raw).toBe('{>>fix: something<<}')
+  })
+
+  it('parses hidden markreview metadata from a question comment', () => {
+    const [comment] = extractComments(
+      '{>>question: Why is this here? [markreview id="mr-question-1" thread="mr-question-1"]<<}',
+    )
+
+    expect(comment.type).toBe('question')
+    expect(comment.text).toBe('Why is this here?')
+    expect(comment.thread).toEqual({
+      commentId: 'mr-question-1',
+      threadId: 'mr-question-1',
+    })
+  })
+
+  it('parses answer metadata and author label', () => {
+    const [comment] = extractComments(
+      '{>>answer: Because it documents reconnect fallback. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}',
+    )
+
+    expect(comment.type).toBe('answer')
+    expect(comment.text).toBe('Because it documents reconnect fallback.')
+    expect(comment.thread).toEqual({
+      commentId: 'mr-answer-1',
+      threadId: 'mr-question-1',
+      replyTo: 'mr-question-1',
+      authorLabel: 'Codex',
+    })
   })
 })

--- a/src/markup/criticmarkup.ts
+++ b/src/markup/criticmarkup.ts
@@ -1,29 +1,7 @@
-import type { Comment, CommentType, CriticType } from '../types/criticmarkup'
+import type { Comment, CommentType, CriticType } from "../types/criticmarkup";
+import { parseStructuredCommentBody } from "./commentProtocol";
 
-// Recognized Conventional Comments prefixes
-const PREFIX_RE = /^(fix|rewrite|expand|clarify|question|remove):\s*/i
-
-const COMMENT_TYPES: ReadonlySet<string> = new Set<CommentType>([
-  'note', 'fix', 'rewrite', 'expand', 'clarify', 'question', 'remove',
-])
-
-export function isCommentType(value: string): value is CommentType {
-  return COMMENT_TYPES.has(value)
-}
-
-// Parse a semantic type from the start of a comment body.
-// Returns the matched type and the text with the prefix stripped.
-export function parseCommentType(text: string): { type: CommentType; text: string } {
-  const m = PREFIX_RE.exec(text)
-  if (!m) {
-    return { type: 'note', text }
-  }
-  const lower = m[1].toLowerCase()
-  return {
-    type: isCommentType(lower) ? lower : 'note',
-    text: text.slice(m[0].length),
-  }
-}
+export { isCommentType, parseCommentType } from "./commentProtocol";
 
 // Combined regex matching all 5 CriticMarkup syntax types.
 // Capture groups:
@@ -110,30 +88,31 @@ export function parseCriticMarkup(source: string): {
     let from: string | undefined
     let to: string | undefined
     let cleanReplacement: string
+    let thread: Comment["thread"] = undefined
 
     if (match[1] !== undefined) {
       criticType = 'highlight'
       highlightedText = match[1]
-      ;({ type, text } = parseCommentType(match[2]))
-      cleanReplacement = match[1]      // keep the highlighted span
+      ({ type, text, thread } = parseStructuredCommentBody(match[2]));
+      cleanReplacement = match[1];
     } else if (match[3] !== undefined) {
-      criticType = 'comment'
-      ;({ type, text } = parseCommentType(match[3]))
-      cleanReplacement = ''            // pure annotation, nothing visible
+      criticType = "comment";
+      ({ type, text, thread } = parseStructuredCommentBody(match[3]));
+      cleanReplacement = "";
     } else if (match[4] !== undefined) {
-      criticType = 'addition'
-      text = match[4]
-      cleanReplacement = match[4]      // keep the added text
+      criticType = "addition";
+      text = match[4];
+      cleanReplacement = match[4];
     } else if (match[5] !== undefined) {
-      criticType = 'deletion'
-      text = match[5]
-      cleanReplacement = ''            // removed text disappears
+      criticType = "deletion";
+      text = match[5];
+      cleanReplacement = "";
     } else {
-      criticType = 'substitution'
-      from = match[6]
-      to = match[7]
-      text = match[7]
-      cleanReplacement = match[7]      // keep the replacement text
+      criticType = "substitution";
+      from = match[6];
+      to = match[7];
+      text = match[7];
+      cleanReplacement = match[7];
     }
 
     const cleanStart = cleanOffset
@@ -156,6 +135,7 @@ export function parseCriticMarkup(source: string): {
       rawEnd,
       cleanStart,
       cleanEnd,
+      thread,
     })
   }
 

--- a/src/markup/editComment.ts
+++ b/src/markup/editComment.ts
@@ -1,13 +1,22 @@
-import type { Comment, CommentType } from '../types/criticmarkup'
+import type { Comment, CommentType } from "../types/criticmarkup";
+import { serializeCommentBody } from "./commentProtocol";
 
 // Rebuild the raw CriticMarkup string for a comment/highlight after an edit.
 // Addition, deletion, and substitution are not editable through the comment UI.
-export function replaceCommentMarkup(comment: Comment, type: CommentType, text: string): string {
-  const prefix = type === 'note' ? '' : `${type}: `
-  if (comment.criticType === 'highlight') {
-    return `{==${comment.highlightedText ?? ''}==}{>>${prefix}${text}<<}`
+export function replaceCommentMarkup(
+  comment: Comment,
+  type: CommentType,
+  text: string,
+): string {
+  const body = serializeCommentBody({
+    type,
+    text,
+    thread: comment.thread,
+  });
+  if (comment.criticType === "highlight") {
+    return `{==${comment.highlightedText ?? ""}==}{>>${body}<<}`;
   }
-  return `{>>${prefix}${text}<<}`
+  return `{>>${body}<<}`;
 }
 
 // Return rawContent with the comment's markup replaced by the updated version.
@@ -17,6 +26,10 @@ export function applyEdit(
   type: CommentType,
   text: string,
 ): string {
-  const newMarkup = replaceCommentMarkup(comment, type, text)
-  return rawContent.slice(0, comment.rawStart) + newMarkup + rawContent.slice(comment.rawEnd)
+  const newMarkup = replaceCommentMarkup(comment, type, text);
+  return (
+    rawContent.slice(0, comment.rawStart) +
+    newMarkup +
+    rawContent.slice(comment.rawEnd)
+  );
 }

--- a/src/markup/editDelete.test.ts
+++ b/src/markup/editDelete.test.ts
@@ -21,6 +21,36 @@ describe('replaceCommentMarkup', () => {
     const c = makeComment({ criticType: 'highlight', highlightedText: 'text' })
     expect(replaceCommentMarkup(c, 'rewrite', 'rewrite it')).toBe('{==text==}{>>rewrite: rewrite it<<}')
   })
+
+  it('preserves hidden thread metadata when editing a threaded question', () => {
+    const c = makeComment({
+      type: 'question',
+      text: 'Why?',
+      thread: {
+        commentId: 'mr-question-1',
+        threadId: 'mr-question-1',
+      },
+    })
+    expect(replaceCommentMarkup(c, 'question', 'Updated why?')).toBe(
+      '{>>question: Updated why? [markreview id="mr-question-1" thread="mr-question-1"]<<}',
+    )
+  })
+
+  it('preserves reply metadata and author label when editing an answer', () => {
+    const c = makeComment({
+      type: 'answer',
+      text: 'Because.',
+      thread: {
+        commentId: 'mr-answer-1',
+        threadId: 'mr-question-1',
+        replyTo: 'mr-question-1',
+        authorLabel: 'Codex',
+      },
+    })
+    expect(replaceCommentMarkup(c, 'answer', 'Updated answer')).toBe(
+      '{>>answer: Updated answer [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}',
+    )
+  })
 })
 
 describe('applyEdit', () => {

--- a/src/markup/index.ts
+++ b/src/markup/index.ts
@@ -1,4 +1,6 @@
+export * from "./agentPrompt";
 export * from "./blockIndex";
+export * from "./commentProtocol";
 export * from "./criticmarkup";
 export * from "./deleteComment";
 export * from "./editComment";

--- a/src/markup/insertComment.test.ts
+++ b/src/markup/insertComment.test.ts
@@ -5,26 +5,77 @@ import { makeComment } from '../testing/testHelpers'
 describe('insertComment — plain content (no existing markup)', () => {
   it('appends a note comment (no prefix) after the first paragraph', () => {
     const raw = 'Hello world.\n\nSecond paragraph.'
-    const result = insertComment(raw, [], raw, 0, 'note', 'my note')
+    const result = insertComment({
+      rawContent: raw,
+      existingComments: [],
+      cleanMarkdown: raw,
+      blockIndex: 0,
+      type: 'note',
+      text: 'my note',
+    })
     expect(result).toBe('Hello world.{>>my note<<}\n\nSecond paragraph.')
   })
 
   it('appends a typed comment with its prefix after a later paragraph', () => {
     const raw = 'First.\n\nSecond.'
-    const result = insertComment(raw, [], raw, 1, 'fix', 'fix this')
+    const result = insertComment({
+      rawContent: raw,
+      existingComments: [],
+      cleanMarkdown: raw,
+      blockIndex: 1,
+      type: 'fix',
+      text: 'fix this',
+    })
     expect(result).toBe('First.\n\nSecond.{>>fix: fix this<<}')
   })
 
   it('returns rawContent unchanged when blockIndex is out of range', () => {
     const raw = 'Single paragraph.'
-    expect(insertComment(raw, [], raw, 5, 'note', 'hi')).toBe(raw)
-    expect(insertComment(raw, [], raw, -1, 'note', 'hi')).toBe(raw)
+    expect(insertComment({
+      rawContent: raw,
+      existingComments: [],
+      cleanMarkdown: raw,
+      blockIndex: 5,
+      type: 'note',
+      text: 'hi',
+    })).toBe(raw)
+    expect(insertComment({
+      rawContent: raw,
+      existingComments: [],
+      cleanMarkdown: raw,
+      blockIndex: -1,
+      type: 'note',
+      text: 'hi',
+    })).toBe(raw)
   })
 
   it('handles a single-paragraph document', () => {
     const raw = 'Only paragraph.'
-    const result = insertComment(raw, [], raw, 0, 'rewrite', 'rewrite it')
+    const result = insertComment({
+      rawContent: raw,
+      existingComments: [],
+      cleanMarkdown: raw,
+      blockIndex: 0,
+      type: 'rewrite',
+      text: 'rewrite it',
+    })
     expect(result).toBe('Only paragraph.{>>rewrite: rewrite it<<}')
+  })
+
+  it('adds hidden thread metadata when inserting a question', () => {
+    const raw = 'Only paragraph.'
+    const result = insertComment({
+      rawContent: raw,
+      existingComments: [],
+      cleanMarkdown: raw,
+      blockIndex: 0,
+      type: 'question',
+      text: 'Why is this here?',
+    })
+
+    expect(result).toMatch(
+      /Only paragraph\.\{>>question: Why is this here\? \[markreview id="mr-[^"]+" thread="mr-[^"]+"\]<<}/,
+    )
   })
 })
 
@@ -38,7 +89,14 @@ describe('insertComment — content with existing CriticMarkup', () => {
       makeComment({ rawStart: 6, rawEnd: 20, cleanStart: 6, cleanEnd: 6 }),
       // {>>existing<<} = 14 chars (6..20)
     ]
-    const result = insertComment(raw, existing, clean, 0, 'note', 'new')
+    const result = insertComment({
+      rawContent: raw,
+      existingComments: existing,
+      cleanMarkdown: clean,
+      blockIndex: 0,
+      type: 'note',
+      text: 'new',
+    })
     // Block 0 ends at clean offset 6, which maps to raw offset 20 (after the markup)
     expect(result).toBe('Hello.{>>existing<<}{>>new<<}\n\nSecond.')
   })
@@ -55,7 +113,14 @@ describe('insertComment — content with existing CriticMarkup', () => {
         cleanStart: 6, cleanEnd: 11, // "world" = 5 chars
       }),
     ]
-    const result = insertComment(raw, existing, clean, 0, 'note', 'note')
+    const result = insertComment({
+      rawContent: raw,
+      existingComments: existing,
+      cleanMarkdown: clean,
+      blockIndex: 0,
+      type: 'note',
+      text: 'note',
+    })
     // Block 0 ends at clean offset 12 ("Hello world."), which is in the plain
     // segment after the addition span. Raw offset = 17 + (12 - 11) = 18 (the '.')
     expect(result).toBe('Hello {++world++}.{>>note<<}\n\nSecond.')
@@ -67,7 +132,14 @@ describe('insertComment — content with existing CriticMarkup', () => {
     const existing = [
       makeComment({ rawStart: 20, rawEnd: 34, cleanStart: 20, cleanEnd: 20 }),
     ]
-    const result = insertComment(raw, existing, clean, 1, 'fix', 'fix it')
+    const result = insertComment({
+      rawContent: raw,
+      existingComments: existing,
+      cleanMarkdown: clean,
+      blockIndex: 1,
+      type: 'fix',
+      text: 'fix it',
+    })
     expect(result).toBe('Para one.\n\nPara two.{>>existing<<}{>>fix: fix it<<}')
   })
 })

--- a/src/markup/insertComment.ts
+++ b/src/markup/insertComment.ts
@@ -1,5 +1,9 @@
 import { getBlockPositions } from "./blockIndex";
 import type { Comment, CommentType } from "../types/criticmarkup";
+import {
+  createQuestionThreadMetadata,
+  serializeCommentBody,
+} from "./commentProtocol";
 
 // A segment maps a range of cleanMarkdown offsets to a range of raw offsets.
 // Plain segments are 1:1; replaced segments (CriticMarkup spans) map any
@@ -75,28 +79,37 @@ function cleanToRaw(cleanOffset: number, segments: Segment[]): number {
 
 // Insert a new CriticMarkup comment after the block at blockIndex.
 // Returns the updated raw content string.
-export function insertComment(
-  rawContent: string,
-  existingComments: Comment[],
-  cleanMarkdown: string,
-  blockIndex: number,
-  type: CommentType,
-  text: string,
-): string {
-  const blocks = getBlockPositions(cleanMarkdown);
-  if (blockIndex < 0 || blockIndex >= blocks.length) {
+export function insertComment(input: {
+  rawContent: string;
+  existingComments: Comment[];
+  cleanMarkdown: string;
+  blockIndex: number;
+  type: CommentType;
+  text: string;
+}): string {
+  const blocks = getBlockPositions(input.cleanMarkdown);
+  if (input.blockIndex < 0 || input.blockIndex >= blocks.length) {
     console.error("[insertComment] blockIndex out of range", {
-      blockIndex,
+      blockIndex: input.blockIndex,
       totalBlocks: blocks.length,
     });
-    return rawContent;
+    return input.rawContent;
   }
 
-  const blockEnd = blocks[blockIndex].end;
-  const segments = buildSegments(rawContent, existingComments);
+  const blockEnd = blocks[input.blockIndex].end;
+  const segments = buildSegments(input.rawContent, input.existingComments);
   const rawPos = cleanToRaw(blockEnd, segments);
 
-  const prefix = type === "note" ? "" : `${type}: `;
-  const markup = `{>>${prefix}${text}<<}`;
-  return rawContent.slice(0, rawPos) + markup + rawContent.slice(rawPos);
+  const thread =
+    input.type === "question" ? createQuestionThreadMetadata() : undefined;
+  const markup = `{>>${serializeCommentBody({
+    type: input.type,
+    text: input.text,
+    thread,
+  })}<<}`;
+  return (
+    input.rawContent.slice(0, rawPos) +
+    markup +
+    input.rawContent.slice(rawPos)
+  );
 }

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -341,14 +341,14 @@ export function createHostReviewControllerActions<
       }
 
       const { cleanMarkdown } = parseCriticMarkup(tab.rawContent);
-      const nextRawContent = insertCommentService(
-        tab.rawContent,
-        tab.comments,
+      const nextRawContent = insertCommentService({
+        rawContent: tab.rawContent,
+        existingComments: tab.comments,
         cleanMarkdown,
         blockIndex,
         type,
         text,
-      );
+      });
 
       await writeAndUpdate({
         set,

--- a/src/modules/sharing/controller.ts
+++ b/src/modules/sharing/controller.ts
@@ -504,14 +504,14 @@ export function createSharingControllerActions<
 
       const { cleanMarkdown } = parseCriticMarkup(tab.rawContent);
       const attribution = ` — ${comment.peerName}`;
-      const newRaw = insertCommentService(
-        tab.rawContent,
-        tab.comments,
+      const newRaw = insertCommentService({
+        rawContent: tab.rawContent,
+        existingComments: tab.comments,
         cleanMarkdown,
-        comment.blockRef.blockIndex,
-        comment.commentType,
-        comment.text + attribution,
-      );
+        blockIndex: comment.blockRef.blockIndex,
+        type: comment.commentType,
+        text: comment.text + attribution,
+      });
       if (newRaw === tab.rawContent) {
         console.error("[mergeComment] insert had no effect", {
           blockIndex: comment.blockRef.blockIndex,

--- a/src/types/criticmarkup.ts
+++ b/src/types/criticmarkup.ts
@@ -14,6 +14,7 @@ export type CommentType =
   | "expand"
   | "clarify"
   | "question"
+  | "answer"
   | "remove";
 
 /** CSS color variable for each comment type. */
@@ -23,9 +24,17 @@ export const COMMENT_TYPE_COLOR: Record<CommentType, string> = {
   expand: "var(--accent)",
   clarify: "var(--c-purple)",
   question: "var(--c-cyan)",
+  answer: "var(--accent)",
   remove: "var(--text-muted)",
   note: "var(--c-green)",
 };
+
+export interface CommentThreadMetadata {
+  commentId: string;
+  threadId: string;
+  replyTo?: string;
+  authorLabel?: string;
+}
 
 export interface Comment {
   id: string;
@@ -44,4 +53,5 @@ export interface Comment {
   cleanEnd: number; // char offset (exclusive) in cleanMarkdown
   blockIndex?: number; // nearest top-level block index (step 2.4)
   filePath?: string; // set when aggregating comments across files
+  thread?: CommentThreadMetadata;
 }

--- a/src/ui/components/CommentMargin/CommentMargin.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.tsx
@@ -1,11 +1,15 @@
 import "./CommentMargin.css";
 import { useEffect, useRef, useMemo, useState } from "react";
+import {
+  buildCommentThreadGroups,
+  type CommentThreadGroup,
+} from "../../../markup";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
-import { CommentCard } from "../CommentCard";
+import { CommentThreadCard } from "../CommentThreadCard";
 import { peerColor, initials } from "../../../utils/peerDisplay";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
-import type { Comment, CommentType } from "../../../types/criticmarkup";
+import type { CommentType } from "../../../types/criticmarkup";
 import type { PeerComment } from "../../../types/share";
 
 const COMMENT_TYPES: CommentType[] = [
@@ -24,7 +28,11 @@ interface AddCommentFormProps {
   onCancel: () => void;
 }
 
-function AddCommentForm({ top, onSubmit, onCancel }: AddCommentFormProps) {
+function AddCommentForm({
+  top,
+  onSubmit,
+  onCancel,
+}: AddCommentFormProps) {
   const [type, setType] = useState<CommentType>("note");
   const [text, setText] = useState("");
 
@@ -86,7 +94,7 @@ function AddCommentForm({ top, onSubmit, onCancel }: AddCommentFormProps) {
 
 interface DotGroup {
   top: number;
-  comments: Comment[];
+  threads: CommentThreadGroup[];
 }
 
 interface Props {
@@ -126,16 +134,25 @@ export function CommentMargin({
   const [blockTops, setBlockTops] = useState<Map<number, number>>(new Map());
   // 'resolved' means the comments are gone from the file — no dots to show.
   // 'pending' is the same as 'all' for current (still-in-file) comments.
-  const comments =
-    commentFilter === "all" ||
-    commentFilter === "pending" ||
-    commentFilter === "resolved"
-      ? commentFilter === "resolved"
-        ? []
-        : allComments
-      : allComments.filter((c) => c.type === commentFilter);
+  const allThreadGroups = useMemo(
+    () => buildCommentThreadGroups(allComments),
+    [allComments],
+  );
+  const threadGroups = useMemo(
+    () =>
+      commentFilter === "all" ||
+      commentFilter === "pending" ||
+      commentFilter === "resolved"
+        ? commentFilter === "resolved"
+          ? []
+          : allThreadGroups
+        : allThreadGroups.filter((thread) => thread.root.type === commentFilter),
+    [allThreadGroups, commentFilter],
+  );
   const [groups, setGroups] = useState<DotGroup[]>([]);
+  const [floatingTop, setFloatingTop] = useState<number | null>(null);
   const measureRef = useRef<() => void>(() => {});
+  const activeCardRef = useRef<HTMLDivElement | null>(null);
 
   // In peer mode, show the peer's own comments as dots
   const myPeerComments = useAppStore((s) => s.myPeerComments);
@@ -198,14 +215,14 @@ export function CommentMargin({
         return;
       }
 
-      const byBlock = new Map<number, Comment[]>();
-      for (const c of comments) {
-        if (c.blockIndex === undefined) {
+      const byBlock = new Map<number, CommentThreadGroup[]>();
+      for (const thread of threadGroups) {
+        if (thread.root.blockIndex === undefined) {
           continue;
         }
-        const arr = byBlock.get(c.blockIndex) ?? [];
-        arr.push(c);
-        byBlock.set(c.blockIndex, arr);
+        const threadsForBlock = byBlock.get(thread.root.blockIndex) ?? [];
+        threadsForBlock.push(thread);
+        byBlock.set(thread.root.blockIndex, threadsForBlock);
       }
 
       const next: DotGroup[] = [];
@@ -219,7 +236,7 @@ export function CommentMargin({
         if (!group) {
           continue;
         }
-        next.push({ top: el.offsetTop, comments: group });
+        next.push({ top: el.offsetTop, threads: group });
       }
       setGroups(next);
       setBlockTops(tops);
@@ -234,7 +251,75 @@ export function CommentMargin({
     const ro = new ResizeObserver(() => measureRef.current());
     ro.observe(container);
     return () => ro.disconnect();
-  }, [comments, containerRef]);
+  }, [containerRef, threadGroups]);
+
+  const activeThreadData = useMemo(() => {
+    for (const group of groups) {
+      const activeThread =
+        group.threads.find(
+          (thread) =>
+            thread.root.id === activeId ||
+            thread.replies.some((reply) => reply.id === activeId),
+        ) ?? null;
+      if (activeThread) {
+        return { top: group.top, thread: activeThread };
+      }
+    }
+    return null;
+  }, [activeId, groups]);
+
+  useEffect(() => {
+    if (!activeThreadData) {
+      setFloatingTop(null);
+      return;
+    }
+
+    function updateFloatingTop() {
+      const viewer = containerRef.current;
+      const card = activeCardRef.current;
+      const scrollArea = viewer?.parentElement;
+      if (!viewer || !card || !(scrollArea instanceof HTMLElement)) {
+        setFloatingTop(activeThreadData.top);
+        return;
+      }
+
+      const padding = 8;
+      const preferredTop = activeThreadData.top;
+      const visibleTop = scrollArea.scrollTop + padding;
+      const visibleBottom = scrollArea.scrollTop + scrollArea.clientHeight;
+      const maxTop = Math.max(
+        visibleTop,
+        visibleBottom - card.offsetHeight - padding,
+      );
+
+      setFloatingTop(Math.min(Math.max(preferredTop, visibleTop), maxTop));
+    }
+
+    updateFloatingTop();
+
+    const viewer = containerRef.current;
+    const scrollArea = viewer?.parentElement;
+    if (!(scrollArea instanceof HTMLElement)) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => updateFloatingTop());
+    resizeObserver.observe(scrollArea);
+    if (activeCardRef.current) {
+      resizeObserver.observe(activeCardRef.current);
+    }
+
+    scrollArea.addEventListener("scroll", updateFloatingTop, {
+      passive: true,
+    });
+    window.addEventListener("resize", updateFloatingTop);
+
+    return () => {
+      resizeObserver.disconnect();
+      scrollArea.removeEventListener("scroll", updateFloatingTop);
+      window.removeEventListener("resize", updateFloatingTop);
+    };
+  }, [activeThreadData, containerRef]);
 
   return (
     <div className="comment-margin">
@@ -268,42 +353,53 @@ export function CommentMargin({
         </div>
       )}
       {addingBlock && (
-        <AddCommentForm
-          top={addingBlock.top}
-          onSubmit={(type, text) => {
-            if (peerMode && onPostPeerComment) {
-              onPostPeerComment(addingBlock.index, type, text);
-            } else {
-              onAddComment(addingBlock.index, type, text);
-            }
-            setAddingBlock(null);
-          }}
-          onCancel={() => setAddingBlock(null)}
-        />
-      )}
-      {groups.map(({ top, comments: groupComments }, i) => {
-        const activeComment =
-          groupComments.find((c) => c.id === activeId) ?? null;
+          <AddCommentForm
+            top={addingBlock.top}
+            onSubmit={(type, text) => {
+              if (peerMode && onPostPeerComment) {
+                onPostPeerComment(addingBlock.index, type, text);
+              } else {
+                onAddComment(addingBlock.index, type, text);
+              }
+              setAddingBlock(null);
+            }}
+            onCancel={() => setAddingBlock(null)}
+          />
+        )}
+      {groups.map(({ top, threads }, i) => {
+        const activeThread =
+          threads.find(
+            (thread) =>
+              thread.root.id === activeId ||
+              thread.replies.some((reply) => reply.id === activeId),
+          ) ?? null;
         // Find peer comments for the same block
-        const blockIdx = groupComments[0]?.blockIndex;
+        const blockIdx = threads[0]?.root.blockIndex;
         const peerForBlock =
           blockIdx !== undefined ? (peerDotGroups.get(blockIdx) ?? []) : [];
         return (
           <div key={i}>
             <div className="comment-margin__dots" style={{ top }}>
-              {groupComments.map((c) => (
-                <button
-                  key={c.id}
-                  className={`comment-margin__dot${activeId === c.id ? " comment-margin__dot--active" : ""}`}
-                  style={{ backgroundColor: COMMENT_TYPE_COLOR[c.type] }}
-                  aria-label={`${c.type}: ${c.text}`}
-                  title={`${c.type}: ${c.text}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setActiveId(activeId === c.id ? null : c.id);
-                  }}
-                />
-              ))}
+              {threads.map((thread) => {
+                const isActive =
+                  thread.root.id === activeId ||
+                  thread.replies.some((reply) => reply.id === activeId);
+                return (
+                  <button
+                    key={thread.root.id}
+                    className={`comment-margin__dot${isActive ? " comment-margin__dot--active" : ""}`}
+                    style={{
+                      backgroundColor: COMMENT_TYPE_COLOR[thread.root.type],
+                    }}
+                    aria-label={`${thread.root.type}: ${thread.root.text}`}
+                    title={`${thread.root.type}: ${thread.root.text}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setActiveId(isActive ? null : thread.root.id);
+                    }}
+                  />
+                );
+              })}
               {peerForBlock.map((pc) => (
                 <button
                   key={pc.id}
@@ -323,16 +419,15 @@ export function CommentMargin({
                 </button>
               ))}
             </div>
-            {activeComment && (
-              <CommentCard
-                comment={activeComment}
-                top={top}
+            {activeThread && (
+              <CommentThreadCard
+                thread={activeThread}
+                top={floatingTop ?? top}
+                cardRef={activeCardRef}
                 onClose={() => setActiveId(null)}
-                onEdit={(type, text) =>
-                  editCommentAction(activeComment.id, type, text)
-                }
-                onDelete={() => {
-                  deleteCommentAction(activeComment.id);
+                onEdit={(id, type, text) => editCommentAction(id, type, text)}
+                onDelete={(id) => {
+                  deleteCommentAction(id);
                   setActiveId(null);
                 }}
               />
@@ -343,7 +438,7 @@ export function CommentMargin({
       {/* Peer-only blocks (no host comments at this block) */}
       {Array.from(peerDotGroups.entries()).map(([blockIdx, peerComments]) => {
         // Skip blocks already rendered with host groups
-        if (groups.some((g) => g.comments[0]?.blockIndex === blockIdx)) {
+        if (groups.some((group) => group.threads[0]?.root.blockIndex === blockIdx)) {
           return null;
         }
         const top = blockTops.get(blockIdx);

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -135,6 +135,46 @@ describe('CommentPanel — active entry', () => {
     const tab = getActiveTab(useAppStore.getState())
     expect(tab?.activeCommentId).toBeNull()
   })
+
+  it('keeps threaded replies out of the panel list and highlights the root entry', () => {
+    setTestState({
+      comments: [
+        makeCommentBase({
+          id: 'question-root',
+          type: 'question',
+          text: 'Why is this here?',
+          blockIndex: 0,
+          thread: {
+            commentId: 'mr-question-1',
+            threadId: 'mr-question-1',
+          },
+        }),
+        makeCommentBase({
+          id: 'answer-reply',
+          type: 'answer',
+          text: 'Because it explains reconnect fallback.',
+          blockIndex: 0,
+          thread: {
+            commentId: 'mr-answer-1',
+            threadId: 'mr-question-1',
+            replyTo: 'mr-question-1',
+            authorLabel: 'Codex',
+          },
+        }),
+      ],
+      activeCommentId: 'answer-reply',
+    })
+
+    const { container } = render(<CommentPanel />)
+
+    expect(screen.getByText('Why is this here?')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Because it explains reconnect fallback.'),
+    ).not.toBeInTheDocument()
+
+    const active = container.querySelector('.comment-panel__entry--active')
+    expect(active?.textContent).toContain('Why is this here?')
+  })
 })
 
 describe('CommentPanel — close', () => {
@@ -145,6 +185,56 @@ describe('CommentPanel — close', () => {
     render(<CommentPanel />)
     await user.click(screen.getByRole('button', { name: 'Close comments panel' }))
     expect(mockToggle).toHaveBeenCalledOnce()
+  })
+})
+
+describe('CommentPanel — agent prompt', () => {
+  it('shows a copy prompt button when question threads exist', () => {
+    setTestState({
+      comments: [
+        makeCommentBase({
+          id: 'question-root',
+          type: 'question',
+          text: 'Why is this here?',
+          thread: {
+            commentId: 'mr-question-1',
+            threadId: 'mr-question-1',
+          },
+        }),
+      ],
+    })
+
+    render(<CommentPanel />)
+    expect(
+      screen.getByRole('button', { name: 'Copy agent prompt' }),
+    ).toBeInTheDocument()
+  })
+
+  it('copies the agent prompt to the clipboard', async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue(undefined)
+
+    setTestState({
+      comments: [
+        makeCommentBase({
+          id: 'question-root',
+          type: 'question',
+          text: 'Why is this here?',
+          thread: {
+            commentId: 'mr-question-1',
+            threadId: 'mr-question-1',
+          },
+        }),
+      ],
+    })
+
+    render(<CommentPanel />)
+    await user.click(screen.getByRole('button', { name: 'Copy agent prompt' }))
+
+    expect(writeText).toHaveBeenCalledOnce()
+    expect(useAppStore.getState().toast).toBe('Agent prompt copied')
   })
 })
 

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -1,5 +1,9 @@
 import "./CommentPanel.css";
 import { useEffect, useMemo, useState } from "react";
+import {
+  buildAgentReplyPrompt,
+  buildCommentThreadGroups,
+} from "../../../markup";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
@@ -12,6 +16,7 @@ const ALL_TYPES: CommentType[] = [
   "expand",
   "clarify",
   "question",
+  "answer",
   "remove",
   "note",
 ];
@@ -74,6 +79,30 @@ function filterCrossFileByType<C extends { type: CommentType }>(
     .filter((entry) => entry.comments.length > 0);
 }
 
+function getRootOnlyComments(comments: Comment[]): Comment[] {
+  return buildCommentThreadGroups(comments).map((group) => group.root);
+}
+
+function getActiveRootCommentId(
+  comments: Comment[],
+  activeCommentId: string | null,
+): string | null {
+  if (!activeCommentId) {
+    return null;
+  }
+
+  for (const group of buildCommentThreadGroups(comments)) {
+    if (
+      group.root.id === activeCommentId ||
+      group.replies.some((reply) => reply.id === activeCommentId)
+    ) {
+      return group.root.id;
+    }
+  }
+
+  return activeCommentId;
+}
+
 interface Props {
   peerMode?: boolean;
 }
@@ -81,12 +110,18 @@ interface Props {
 export function CommentPanel({ peerMode = false }: Props) {
   const tab = useActiveTab();
   const comments = tab?.comments ?? [];
+  const hostRootComments = useMemo(() => getRootOnlyComments(comments), [comments]);
   const resolvedComments = tab?.resolvedComments ?? [];
   const activeCommentId = tab?.activeCommentId ?? null;
+  const activeRootCommentId = useMemo(
+    () => getActiveRootCommentId(comments, activeCommentId),
+    [activeCommentId, comments],
+  );
   const commentFilter = tab?.commentFilter ?? "all";
   const setActiveCommentId = useAppStore((state) => state.setActiveCommentId);
   const setCommentFilter = useAppStore((state) => state.setCommentFilter);
   const toggleCommentPanel = useAppStore((state) => state.toggleCommentPanel);
+  const showToast = useAppStore((state) => state.showToast);
   const myPeerComments = useAppStore((state) => state.myPeerComments);
   const peerActiveFilePath = useAppStore((state) => state.peerActiveFilePath);
   const activeFilePath = peerMode
@@ -133,7 +168,7 @@ export function CommentPanel({ peerMode = false }: Props) {
     return activeFilePath ? (peerDisplayByPath[activeFilePath] ?? []) : [];
   }, [peerMode, isPeerMultiFile, peerDisplayByPath, activeFilePath]);
 
-  const sourceComments = peerMode ? peerDisplayComments : comments;
+  const sourceComments = peerMode ? peerDisplayComments : hostRootComments;
 
   // Build peer cross-file entries from the shared grouped map
   const peerCrossFileEntries = useMemo(() => {
@@ -154,9 +189,12 @@ export function CommentPanel({ peerMode = false }: Props) {
     if (!isFolderMode) {
       return [];
     }
-    const entries = Object.values(allFileComments).filter(
-      (entry) => entry.comments.length > 0,
-    );
+    const entries = Object.values(allFileComments)
+      .map((entry) => ({
+        ...entry,
+        comments: getRootOnlyComments(entry.comments),
+      }))
+      .filter((entry) => entry.comments.length > 0);
     entries.sort((entryA, entryB) =>
       entryA.filePath.localeCompare(entryB.filePath),
     );
@@ -176,6 +214,22 @@ export function CommentPanel({ peerMode = false }: Props) {
       0,
     );
   }, [isPeerMultiFile, myPeerComments.length, isFolderMode, crossFileComments]);
+
+  const hasQuestionThreads = useMemo(() => {
+    if (peerMode) {
+      return false;
+    }
+    if (isFolderMode) {
+      return crossFileComments.some((entry) =>
+        entry.comments.some(
+          (comment) => comment.type === "question" && !!comment.thread,
+        ),
+      );
+    }
+    return hostRootComments.some(
+      (comment) => comment.type === "question" && !!comment.thread,
+    );
+  }, [crossFileComments, hostRootComments, isFolderMode, peerMode]);
 
   const isResolved = !peerMode && commentFilter === "resolved";
 
@@ -249,17 +303,28 @@ export function CommentPanel({ peerMode = false }: Props) {
     return body.length > 72 ? body.slice(0, 72) + "…" : body;
   }
 
+  async function handleCopyAgentPrompt() {
+    try {
+      await navigator.clipboard.writeText(buildAgentReplyPrompt());
+      showToast("Agent prompt copied");
+    } catch (error) {
+      console.error("[CommentPanel] failed to copy agent prompt:", error);
+      showToast("Couldn't copy agent prompt");
+    }
+  }
+
   useEffect(() => {
-    if (!activeCommentId) {
+    const activePanelCommentId = peerMode ? activeCommentId : activeRootCommentId;
+    if (!activePanelCommentId) {
       return;
     }
     const el = document.querySelector(
-      `.comment-panel [data-comment-id="${activeCommentId}"]`,
+      `.comment-panel [data-comment-id="${activePanelCommentId}"]`,
     );
     if (el && typeof el.scrollIntoView === "function") {
       el.scrollIntoView({ behavior: "smooth", block: "nearest" });
     }
-  }, [activeCommentId]);
+  }, [activeCommentId, activeRootCommentId, peerMode]);
 
   const displayCount =
     isPeerMultiFile || isFolderMode
@@ -278,13 +343,26 @@ export function CommentPanel({ peerMode = false }: Props) {
           )}
         </span>
         {!peerMode && displayCount > 0 && (
-          <button
-            className="comment-panel__delete-all"
-            onClick={deleteAllComments}
-            title="Delete all comments from the file"
-          >
-            Delete all
-          </button>
+          <>
+            {hasQuestionThreads && (
+              <button
+                className="comment-panel__delete-all"
+                onClick={() => {
+                  void handleCopyAgentPrompt();
+                }}
+                title="Copy instructions for answering threaded questions"
+              >
+                Copy agent prompt
+              </button>
+            )}
+            <button
+              className="comment-panel__delete-all"
+              onClick={deleteAllComments}
+              title="Delete all comments from the file"
+            >
+              Delete all
+            </button>
+          </>
         )}
         <button
           className="comment-panel__close"
@@ -379,7 +457,7 @@ export function CommentPanel({ peerMode = false }: Props) {
           <CrossFileList
             entries={filteredCrossFile}
             activeFilePath={activeFilePath}
-            activeCommentId={activeCommentId}
+            activeCommentId={activeRootCommentId}
             onEntryClick={handleEntryClick}
             onCrossFileClick={handleCrossFileClick}
             onEdit={editComment}
@@ -390,7 +468,7 @@ export function CommentPanel({ peerMode = false }: Props) {
             visible={visible}
             isResolved={isResolved}
             peerMode={peerMode}
-            activeCommentId={activeCommentId}
+            activeCommentId={peerMode ? activeCommentId : activeRootCommentId}
             sourceComments={sourceComments}
             onEntryClick={handleEntryClick}
             entryLabel={entryLabel}

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.css
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.css
@@ -1,0 +1,196 @@
+.comment-thread-card {
+  position: absolute;
+  left: calc(100% + 0.75rem);
+  z-index: 50;
+  width: min(420px, calc(100vw - 7rem));
+  max-height: min(70vh, 520px);
+  overflow-y: auto;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  padding: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.comment-thread-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.comment-thread-card__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.comment-thread-card__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--text-muted);
+  padding: 0 0.25rem;
+}
+
+.comment-thread-card__close:hover {
+  color: var(--text);
+}
+
+.comment-thread-card__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.comment-thread-card__item {
+  padding: 0.75rem;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface) 92%, var(--bg));
+}
+
+.comment-thread-card__item--reply {
+  margin-left: 1rem;
+}
+
+.comment-thread-card__item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.comment-thread-card__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.comment-thread-card__badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 99px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #fff;
+}
+
+.comment-thread-card__author {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.comment-thread-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.comment-thread-card__action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  padding: 0 0.25rem;
+}
+
+.comment-thread-card__action:hover {
+  color: var(--accent);
+}
+
+.comment-thread-card__action--delete:hover {
+  color: var(--c-red, #ef4444);
+}
+
+.comment-thread-card__highlight {
+  margin: 0 0 0.4rem;
+  padding: 0.3rem 0.5rem;
+  border-left: 3px solid var(--border);
+  font-style: italic;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.comment-thread-card__content {
+  margin: 0;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+
+.comment-thread-card__content--add {
+  color: var(--c-green);
+}
+
+.comment-thread-card__content--del {
+  color: var(--c-red);
+  text-decoration: line-through;
+}
+
+.comment-thread-card__sub {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.comment-thread-card__sub-from {
+  color: var(--c-red);
+  text-decoration: line-through;
+}
+
+.comment-thread-card__sub-arrow {
+  color: var(--text-muted);
+}
+
+.comment-thread-card__sub-to {
+  color: var(--c-green);
+}
+
+.comment-thread-card__confirm {
+  padding-top: 0.25rem;
+  font-size: 0.8rem;
+}
+
+.comment-thread-card__confirm p {
+  margin: 0 0 0.4rem;
+}
+
+.comment-thread-card__confirm-yes {
+  background: var(--c-red, #ef4444);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.comment-thread-card__confirm-yes:hover {
+  opacity: 0.85;
+}
+
+.comment-thread-card__edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-top: 0.25rem;
+}
+
+.comment-thread-card__empty {
+  margin: 0;
+  color: var(--text-muted);
+}

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CommentThreadCard } from "./index";
+import { makeComment } from "../../../testing/testHelpers";
+
+function makeQuestionThread() {
+  const root = makeComment({
+    id: "root-comment",
+    type: "question",
+    text: "Why is this section needed?",
+    thread: {
+      commentId: "mr-question-1",
+      threadId: "mr-question-1",
+    },
+  });
+  const reply = makeComment({
+    id: "reply-comment",
+    type: "answer",
+    text: "It explains the reconnect fallback path.",
+    thread: {
+      commentId: "mr-answer-1",
+      threadId: "mr-question-1",
+      replyTo: "mr-question-1",
+      authorLabel: "Codex",
+    },
+  });
+
+  return {
+    root,
+    reply,
+    thread: { root, replies: [reply] },
+  };
+}
+
+describe("CommentThreadCard", () => {
+  it("renders a question with linked agent answers", () => {
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Thread")).toBeInTheDocument();
+    expect(screen.getByText("Why is this section needed?")).toBeInTheDocument();
+    expect(
+      screen.getByText("It explains the reconnect fallback path."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+  });
+
+  it("falls back to Agent when an answer has no author label", () => {
+    const { root, reply } = makeQuestionThread();
+
+    render(
+      <CommentThreadCard
+        thread={{
+          root,
+          replies: [
+            {
+              ...reply,
+              thread: {
+                commentId: "mr-answer-1",
+                threadId: "mr-question-1",
+                replyTo: "mr-question-1",
+              },
+            },
+          ],
+        }}
+        top={0}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("edits the selected thread message", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={onEdit}
+      />,
+    );
+
+    await user.click(screen.getAllByRole("button", { name: "Edit comment" })[1]);
+    const textarea = screen.getByDisplayValue(
+      "It explains the reconnect fallback path.",
+    );
+    await user.clear(textarea);
+    await user.type(textarea, "Updated answer.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onEdit).toHaveBeenCalledWith(
+      "reply-comment",
+      "answer",
+      "Updated answer.",
+    );
+  });
+
+  it("deletes the selected thread message", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    await user.click(
+      screen.getAllByRole("button", { name: "Delete comment" })[1],
+    );
+    await user.click(screen.getByRole("button", { name: "Confirm delete" }));
+
+    expect(onDelete).toHaveBeenCalledWith("reply-comment");
+  });
+});

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
@@ -1,0 +1,299 @@
+import "./CommentThreadCard.css";
+import { useState } from "react";
+import type { RefObject } from "react";
+import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
+import type { Comment, CommentType } from "../../../types/criticmarkup";
+import type { CommentThreadGroup } from "../../../markup";
+
+const EDITABLE_COMMENT_TYPES: CommentType[] = [
+  "note",
+  "fix",
+  "rewrite",
+  "expand",
+  "clarify",
+  "question",
+  "remove",
+];
+
+const EDITABLE_CRITIC_TYPES: Comment["criticType"][] = ["comment", "highlight"];
+
+function CommentBody({ comment }: { comment: Comment }) {
+  if (comment.criticType === "addition") {
+    return (
+      <p className="comment-thread-card__content comment-thread-card__content--add">
+        + {comment.text}
+      </p>
+    );
+  }
+  if (comment.criticType === "deletion") {
+    return (
+      <p className="comment-thread-card__content comment-thread-card__content--del">
+        − {comment.text}
+      </p>
+    );
+  }
+  if (comment.criticType === "substitution") {
+    return (
+      <div className="comment-thread-card__sub">
+        <span className="comment-thread-card__sub-from">{comment.from}</span>
+        <span className="comment-thread-card__sub-arrow">→</span>
+        <span className="comment-thread-card__sub-to">{comment.to}</span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {comment.highlightedText && (
+        <p className="comment-thread-card__highlight">
+          "{comment.highlightedText}"
+        </p>
+      )}
+      {comment.text && <p className="comment-thread-card__content">{comment.text}</p>}
+    </>
+  );
+}
+
+function CommentEditForm({
+  comment,
+  onSave,
+  onCancel,
+}: {
+  comment: Comment;
+  onSave: (type: CommentType, text: string) => void;
+  onCancel: () => void;
+}) {
+  const [editType, setEditType] = useState<CommentType>(comment.type);
+  const [editText, setEditText] = useState(comment.text);
+  const availableTypes =
+    comment.thread || comment.type === "answer"
+      ? [comment.type]
+      : EDITABLE_COMMENT_TYPES;
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!editText.trim()) {
+      return;
+    }
+    onSave(editType, editText.trim());
+  }
+
+  return (
+    <form className="comment-thread-card__edit-form" onSubmit={handleSubmit}>
+      <div className="comment-add-form__types">
+        {availableTypes.map((commentType) => (
+          <button
+            key={commentType}
+            type="button"
+            className={`comment-add-form__type${editType === commentType ? " comment-add-form__type--active" : ""}`}
+            onClick={() => setEditType(commentType)}
+          >
+            {commentType}
+          </button>
+        ))}
+      </div>
+      <textarea
+        className="comment-add-form__input"
+        value={editText}
+        onChange={(event) => setEditText(event.target.value)}
+        rows={3}
+        autoFocus
+      />
+      <div className="comment-add-form__actions">
+        <button
+          type="submit"
+          className="comment-add-form__save"
+          disabled={!editText.trim()}
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          className="comment-add-form__cancel"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+interface CommentRowProps {
+  comment: Comment;
+  reply: boolean;
+  editing: boolean;
+  confirmingDelete: boolean;
+  onStartEdit: () => void;
+  onCancelEdit: () => void;
+  onSave: (type: CommentType, text: string) => void;
+  onStartDelete: () => void;
+  onCancelDelete: () => void;
+  onConfirmDelete: () => void;
+}
+
+function CommentRow({
+  comment,
+  reply,
+  editing,
+  confirmingDelete,
+  onStartEdit,
+  onCancelEdit,
+  onSave,
+  onStartDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}: CommentRowProps) {
+  const editable = EDITABLE_CRITIC_TYPES.includes(comment.criticType);
+  const authorLabel =
+    comment.type === "answer"
+      ? (comment.thread?.authorLabel ?? "Agent")
+      : null;
+
+  return (
+    <div
+      className={`comment-thread-card__item${reply ? " comment-thread-card__item--reply" : ""}`}
+    >
+      <div className="comment-thread-card__item-header">
+        <div className="comment-thread-card__meta">
+          <span
+            className="comment-thread-card__badge"
+            style={{ backgroundColor: COMMENT_TYPE_COLOR[comment.type] }}
+          >
+            {comment.type}
+          </span>
+          {authorLabel && (
+            <span className="comment-thread-card__author">{authorLabel}</span>
+          )}
+        </div>
+        <div className="comment-thread-card__actions">
+          {editable && !editing && !confirmingDelete && (
+            <button
+              className="comment-thread-card__action"
+              onClick={onStartEdit}
+              aria-label="Edit comment"
+            >
+              Edit
+            </button>
+          )}
+          {!editing && !confirmingDelete && (
+            <button
+              className="comment-thread-card__action comment-thread-card__action--delete"
+              onClick={onStartDelete}
+              aria-label="Delete comment"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {editing ? (
+        <CommentEditForm
+          comment={comment}
+          onSave={onSave}
+          onCancel={onCancelEdit}
+        />
+      ) : confirmingDelete ? (
+        <div className="comment-thread-card__confirm">
+          <p>Delete this comment?</p>
+          <div className="comment-add-form__actions">
+            <button
+              className="comment-thread-card__confirm-yes"
+              onClick={onConfirmDelete}
+              aria-label="Confirm delete"
+            >
+              Delete
+            </button>
+            <button
+              className="comment-add-form__cancel"
+              onClick={onCancelDelete}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <CommentBody comment={comment} />
+      )}
+    </div>
+  );
+}
+
+interface Props {
+  thread: CommentThreadGroup;
+  top: number;
+  cardRef?: RefObject<HTMLDivElement | null>;
+  onClose: () => void;
+  onEdit?: (id: string, type: CommentType, text: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+export function CommentThreadCard({
+  thread,
+  top,
+  cardRef,
+  onClose,
+  onEdit,
+  onDelete,
+}: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const comments = [thread.root, ...thread.replies];
+
+  return (
+    <div
+      ref={cardRef}
+      className="comment-thread-card"
+      style={{ top }}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="comment-thread-card__header">
+        <span className="comment-thread-card__title">
+          {thread.replies.length > 0 ? "Thread" : "Comment"}
+        </span>
+        <button
+          className="comment-thread-card__close"
+          onClick={onClose}
+          aria-label="Close comment"
+        >
+          ×
+        </button>
+      </div>
+
+      <div className="comment-thread-card__list">
+        {comments.length === 0 && (
+          <p className="comment-thread-card__empty">No comments in this thread.</p>
+        )}
+        {comments.map((comment, index) => (
+          <CommentRow
+            key={comment.id}
+            comment={comment}
+            reply={index > 0}
+            editing={editingId === comment.id}
+            confirmingDelete={confirmingId === comment.id}
+            onStartEdit={() => {
+              setConfirmingId(null);
+              setEditingId(comment.id);
+            }}
+            onCancelEdit={() => setEditingId(null)}
+            onSave={(type, text) => {
+              onEdit?.(comment.id, type, text);
+              setEditingId(null);
+            }}
+            onStartDelete={() => {
+              setEditingId(null);
+              setConfirmingId(comment.id);
+            }}
+            onCancelDelete={() => setConfirmingId(null)}
+            onConfirmDelete={() => {
+              onDelete?.(comment.id);
+              setConfirmingId(null);
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/CommentThreadCard/index.ts
+++ b/src/ui/components/CommentThreadCard/index.ts
@@ -1,0 +1,1 @@
+export { CommentThreadCard } from "./CommentThreadCard";

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import "./Header.css";
+import { buildCommentThreadGroups } from "../../../markup";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { selectUnsubmittedPeerComments } from "../../../modules/peer-review";
@@ -186,7 +187,7 @@ export function Header({
   const hasFolderComments = !peerMode && fileTree.length > 0;
   const crossFileTotal = hasFolderComments
     ? Object.values(allFileComments).reduce(
-        (sum, entry) => sum + entry.comments.length,
+        (sum, entry) => sum + buildCommentThreadGroups(entry.comments).length,
         0,
       )
     : 0;
@@ -197,7 +198,7 @@ export function Header({
     ? peerCommentsForFile.length
     : hasFolderComments
       ? crossFileTotal
-      : comments.length;
+      : buildCommentThreadGroups(comments).length;
   const isDark = theme === "dark";
   const hasFolderOpen = fileTree.length > 0;
   const hasContent = !!(fileName || directoryName);


### PR DESCRIPTION
## Summary
- add MarkReview question/answer thread metadata parsing and serialization
- render linked inline thread cards from margin dots while keeping the right panel root-only
- add copyable agent instructions for answering threaded questions inline
- document the protocol extension and keep realtime relay threading out of scope

## Validation
- git diff --check
- git diff --cached --check before commit

Full build/tests were not run because the clean worktree has no node_modules and Yarn install failed with socket/network errors even when retried with escalation.