### PR TITLE
feat: polish review metadata UI

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -172,9 +172,17 @@ File tree sidebar showing the project structure with nested folders. Filters to 
 
 Standard markdown (CommonMark + GFM). Tables with proper alignment and clean styling. Fenced code blocks with syntax highlighting. Mermaid diagrams (flowcharts, sequence, ER, Gantt, mindmaps). KaTeX/LaTeX math — inline and block. Task lists, footnotes, admonitions/callouts. Article-quality typography: 16–18px body, 1.6–1.8 line height, clear heading hierarchy, comfortable paragraph spacing.
 
+Markdown files may start with YAML-style frontmatter metadata. The rendered
+review surface hides the raw frontmatter from the document body and displays it
+as a quiet metadata panel before the first rendered heading. Scalar values render
+as label/value rows, while list-style fields such as participants, tags, extends,
+amends, and relates render as compact chips. Comment anchors and inserted
+CriticMarkup comments still target the rendered document body, not the hidden
+metadata block.
+
 ### 8.3 Block-Level Commenting UI
 
-Every rendered block (paragraph, heading, table, code block, diagram, list item) is commentable. On hover, a subtle comment icon appears in the left margin. Clicking opens an inline comment form with type selector and text input. Existing comments show as colored dots in the margin — color-coded by type. Clicking a dot expands the comment card. The right sidebar shows all comments in document order. Filters: all, by type, pending only (CriticMarkup still present), resolved (CriticMarkup removed by the LLM).
+Every rendered block (paragraph, heading, table, code block, diagram, list item) is commentable. On hover, a visible comment icon appears in the left margin. Clicking opens an inline comment form with type selector and text input. Existing comments show as colored markers in the margin — color-coded by type, with a stronger selected state so their document anchor is clear. Clicking a marker expands the comment card. The right sidebar shows all comments in document order. Filters: all, by type, pending only (CriticMarkup still present), resolved (CriticMarkup removed by the LLM). Bulk deletion requires a confirmation step instead of deleting directly from the panel header.
 
 ### 8.4 Design
 

--- a/src/markup/frontmatter.ts
+++ b/src/markup/frontmatter.ts
@@ -1,0 +1,165 @@
+import type { Comment } from "../types/criticmarkup";
+
+export interface MarkdownMetadataField {
+  key: string;
+  values: string[];
+  multiline: boolean;
+}
+
+export interface ParsedMarkdownFrontmatter {
+  metadata: MarkdownMetadataField[];
+  body: string;
+  bodyStart: number;
+}
+
+function findFrontmatterEnd(source: string): {
+  metadataText: string;
+  bodyStart: number;
+} | null {
+  if (!source.startsWith("---\n") && !source.startsWith("---\r\n")) {
+    return null;
+  }
+
+  const lineBreak = source.startsWith("---\r\n") ? "\r\n" : "\n";
+  let cursor = 3 + lineBreak.length;
+
+  while (cursor <= source.length) {
+    const nextBreak = source.indexOf(lineBreak, cursor);
+    const lineEnd = nextBreak === -1 ? source.length : nextBreak;
+    const line = source.slice(cursor, lineEnd);
+
+    if (line.trim() === "---") {
+      const metadataText = source.slice(3 + lineBreak.length, cursor);
+      const bodyStart =
+        nextBreak === -1 ? source.length : nextBreak + lineBreak.length;
+      return { metadataText, bodyStart };
+    }
+
+    if (nextBreak === -1) {
+      return null;
+    }
+    cursor = nextBreak + lineBreak.length;
+  }
+
+  return null;
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) {
+    return trimmed;
+  }
+  const first = trimmed[0];
+  const last = trimmed[trimmed.length - 1];
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseInlineList(value: string): string[] | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) {
+    return null;
+  }
+
+  return trimmed
+    .slice(1, -1)
+    .split(",")
+    .map((item) => unquote(item))
+    .filter((item) => item.length > 0);
+}
+
+function parseMetadataLine(
+  line: string,
+): { key: string; value: string } | null {
+  const separatorIndex = line.indexOf(":");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const key = line.slice(0, separatorIndex).trim();
+  if (!/^[A-Za-z0-9_-]+$/.test(key)) {
+    return null;
+  }
+
+  return {
+    key,
+    value: line.slice(separatorIndex + 1).trim(),
+  };
+}
+
+export function parseMarkdownFrontmatter(
+  source: string,
+): ParsedMarkdownFrontmatter {
+  const frontmatter = findFrontmatterEnd(source);
+  if (!frontmatter) {
+    return { metadata: [], body: source, bodyStart: 0 };
+  }
+
+  const fields: MarkdownMetadataField[] = [];
+  let activeField: MarkdownMetadataField | null = null;
+  let activeBlockScalar = false;
+
+  for (const line of frontmatter.metadataText.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const listMatch = /^\s*-\s+(.+)$/.exec(line);
+    if (listMatch && activeField) {
+      activeField.values.push(unquote(listMatch[1]));
+      activeField.multiline = true;
+      activeBlockScalar = false;
+      continue;
+    }
+
+    const continuationMatch = /^\s+(.+)$/.exec(line);
+    if (continuationMatch && activeField && activeBlockScalar) {
+      const separator = activeField.values[0] ? " " : "";
+      activeField.values[0] =
+        activeField.values[0] + separator + continuationMatch[1].trim();
+      continue;
+    }
+
+    const parsed = parseMetadataLine(line);
+    if (!parsed) {
+      activeField = null;
+      activeBlockScalar = false;
+      continue;
+    }
+
+    const inlineValues = parseInlineList(parsed.value);
+    activeBlockScalar = parsed.value === ">" || parsed.value === "|";
+    const values =
+      inlineValues ??
+      (activeBlockScalar ? [""] : parsed.value ? [unquote(parsed.value)] : []);
+    activeField = {
+      key: parsed.key,
+      values,
+      multiline: inlineValues !== null || values.length !== 1,
+    };
+    fields.push(activeField);
+  }
+
+  return {
+    metadata: fields,
+    body: source.slice(frontmatter.bodyStart),
+    bodyStart: frontmatter.bodyStart,
+  };
+}
+
+export function shiftCommentRawOffsets(
+  comments: Comment[],
+  bodyStart: number,
+): Comment[] {
+  if (bodyStart === 0) {
+    return comments;
+  }
+
+  return comments.map((comment) => ({
+    ...comment,
+    rawStart: comment.rawStart + bodyStart,
+    rawEnd: comment.rawEnd + bodyStart,
+  }));
+}

--- a/src/markup/index.ts
+++ b/src/markup/index.ts
@@ -4,5 +4,6 @@ export * from "./commentProtocol";
 export * from "./criticmarkup";
 export * from "./deleteComment";
 export * from "./editComment";
+export * from "./frontmatter";
 export * from "./insertComment";
 export * from "./useShikiRehypePlugin";

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -4,7 +4,9 @@ import {
   applyEdit,
   assignBlockIndices,
   insertComment as insertCommentService,
+  parseMarkdownFrontmatter,
   parseCriticMarkup,
+  shiftCommentRawOffsets,
 } from "../../markup";
 import { findLiveFileInTree } from "../../types/fileTree";
 import type { Comment } from "../../types/criticmarkup";
@@ -126,15 +128,20 @@ export async function scanAllTabFileComments(
       if (node.kind === "file") {
         try {
           const content = await readFile(node.handle);
-          const parsed = parseCriticMarkup(content);
+          const document = parseMarkdownFrontmatter(content);
+          const parsed = parseCriticMarkup(document.body);
           const comments = assignBlockIndices(
             parsed.comments,
             parsed.cleanMarkdown,
           );
+          const commentsWithRawOffsets = shiftCommentRawOffsets(
+            comments,
+            document.bodyStart,
+          );
           result[node.path] = {
             filePath: node.path,
             fileName: node.name,
-            comments: comments.map((comment) => ({
+            comments: commentsWithRawOffsets.map((comment) => ({
               ...comment,
               filePath: node.path,
             })),
@@ -340,15 +347,18 @@ export function createHostReviewControllerActions<
         return;
       }
 
-      const { cleanMarkdown } = parseCriticMarkup(tab.rawContent);
-      const nextRawContent = insertCommentService({
-        rawContent: tab.rawContent,
-        existingComments: tab.comments,
-        cleanMarkdown,
+      const document = parseMarkdownFrontmatter(tab.rawContent);
+      const parsed = parseCriticMarkup(document.body);
+      const nextBody = insertCommentService({
+        rawContent: document.body,
+        existingComments: parsed.comments,
+        cleanMarkdown: parsed.cleanMarkdown,
         blockIndex,
         type,
         text,
       });
+      const nextRawContent =
+        tab.rawContent.slice(0, document.bodyStart) + nextBody;
 
       await writeAndUpdate({
         set,

--- a/src/modules/host-review/test/addComment.test.ts
+++ b/src/modules/host-review/test/addComment.test.ts
@@ -80,6 +80,35 @@ describe("store.addComment", () => {
     expect(tab?.rawContent).toBe("Para.{>>fix: fix it<<}");
   });
 
+  it("inserts comments into the body when markdown starts with metadata", async () => {
+    const mockWritable = createWritableStub();
+    const rawContent = [
+      "---",
+      "id: DEC-example",
+      "participants:",
+      "  - Ivan",
+      "  - Codex",
+      "---",
+      "# Decision",
+      "",
+      "Body paragraph.",
+    ].join("\n");
+    setTestState({
+      fileHandle: createFileHandleStub(mockWritable),
+      rawContent,
+    });
+
+    await useAppStore.getState().addComment(0, "note", "body note");
+
+    const expectedContent = rawContent.replace(
+      "# Decision",
+      "# Decision{>>body note<<}",
+    );
+    expect(mockWritable.write).toHaveBeenCalledWith(expectedContent);
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.rawContent).toBe(expectedContent);
+  });
+
   it("sets writeAllowed to false on NotAllowedError", async () => {
     const error = Object.assign(new Error("no permission"), {
       name: "NotAllowedError",

--- a/src/modules/sharing/controller.ts
+++ b/src/modules/sharing/controller.ts
@@ -1,5 +1,9 @@
 import type { StoreApi } from "zustand";
-import { insertComment as insertCommentService, parseCriticMarkup } from "../../markup";
+import {
+  insertComment as insertCommentService,
+  parseMarkdownFrontmatter,
+  parseCriticMarkup,
+} from "../../markup";
 import { WORKER_URL } from "../../config";
 import {
   base64urlToKey,
@@ -502,16 +506,18 @@ export function createSharingControllerActions<
         blockIndex: comment.blockRef.blockIndex,
       });
 
-      const { cleanMarkdown } = parseCriticMarkup(tab.rawContent);
+      const document = parseMarkdownFrontmatter(tab.rawContent);
+      const parsed = parseCriticMarkup(document.body);
       const attribution = ` — ${comment.peerName}`;
-      const newRaw = insertCommentService({
-        rawContent: tab.rawContent,
-        existingComments: tab.comments,
-        cleanMarkdown,
+      const newBody = insertCommentService({
+        rawContent: document.body,
+        existingComments: parsed.comments,
+        cleanMarkdown: parsed.cleanMarkdown,
         blockIndex: comment.blockRef.blockIndex,
         type: comment.commentType,
         text: comment.text + attribution,
       });
+      const newRaw = tab.rawContent.slice(0, document.bodyStart) + newBody;
       if (newRaw === tab.rawContent) {
         console.error("[mergeComment] insert had no effect", {
           blockIndex: comment.blockRef.blockIndex,

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -148,10 +148,10 @@ describe("App — single file open", () => {
     });
   });
 
-  it("shows the header with the file name", () => {
+  it("shows the header workflow context", () => {
     const { container } = render(<App />);
     const headerFilename = container.querySelector(".app-header__filename");
-    expect(headerFilename?.textContent).toBe("research.md");
+    expect(headerFilename?.textContent).toBe("File review");
   });
 
   it("renders the MarkdownRenderer", () => {
@@ -230,8 +230,9 @@ describe("App — folder open", () => {
   it("shows an empty state when no file is selected", () => {
     render(<App />);
     expect(
-      screen.getByText(/Select a file from the sidebar/),
+      screen.getByText(/Choose a Markdown file from the sidebar/),
     ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "my-docs" })).toBeInTheDocument();
     expect(screen.queryByTestId("markdown-renderer")).not.toBeInTheDocument();
   });
 
@@ -265,14 +266,14 @@ describe("App — folder open", () => {
     render(<App />);
     expect(screen.getByTestId("markdown-renderer")).toBeInTheDocument();
     expect(
-      screen.queryByText(/Select a file from the sidebar/),
+      screen.queryByText(/Choose a Markdown file from the sidebar/),
     ).not.toBeInTheDocument();
   });
 
-  it('shows "my-docs / readme.md" in the header when a file is selected', () => {
+  it('shows "Folder review" in the header when a folder file is selected', () => {
     setTestState({ fileName: "readme.md", activeFilePath: "readme.md" });
     render(<App />);
-    expect(screen.getByText("my-docs / readme.md")).toBeInTheDocument();
+    expect(screen.getByText("Folder review")).toBeInTheDocument();
   });
 
   it('shows "Open file" and "Open folder" buttons in folder mode', () => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -53,12 +53,44 @@ const folderIcon = (
   </svg>
 );
 
-function NoFileSelected() {
+function countFiles(nodes: SidebarTreeNode[]): number {
+  return nodes.reduce((total, node) => {
+    if (node.kind === "file") {
+      return total + 1;
+    }
+    return total + countFiles(node.children);
+  }, 0);
+}
+
+function NoFileSelected({
+  directoryName,
+  fileCount,
+  onOpenFolder,
+}: {
+  directoryName: string | null;
+  fileCount: number;
+  onOpenFolder: () => void;
+}) {
   return (
     <div className="content-empty">
-      <p className="content-empty__text">
-        Select a file from the sidebar to start reading
-      </p>
+      <div className="content-empty__panel">
+        <p className="content-empty__eyebrow">Folder open</p>
+        <h1 className="content-empty__title">
+          {directoryName ?? "Select a file"}
+        </h1>
+        <p className="content-empty__text">
+          Choose a Markdown file from the sidebar to start reviewing.
+        </p>
+        {fileCount > 0 && (
+          <p className="content-empty__meta">
+            {fileCount} readable file{fileCount === 1 ? "" : "s"} in this
+            workspace
+          </p>
+        )}
+        <button className="content-empty__action" onClick={onOpenFolder}>
+          Open another folder
+        </button>
+      </div>
     </div>
   );
 }
@@ -359,7 +391,11 @@ function App() {
           ) : tab?.fileName ? (
             <MarkdownRenderer />
           ) : (
-            <NoFileSelected />
+            <NoFileSelected
+              directoryName={tab?.directoryName ?? null}
+              fileCount={countFiles(hostTree)}
+              onOpenFolder={openDirectoryInNewTab}
+            />
           )}
         </main>
         {tab?.commentPanelOpen && !focusMode && !disableReviewPanels && (

--- a/src/ui/components/CommentMargin/CommentMargin.css
+++ b/src/ui/components/CommentMargin/CommentMargin.css
@@ -1,40 +1,44 @@
 /* ── Comment margin column ───────────────────────────────────── */
 .comment-margin {
-  width: 2.5rem;
+  width: 3rem;
   flex-shrink: 0;
   position: relative;
 }
 
 .comment-margin__dots {
   position: absolute;
-  right: 0.5rem;
+  right: 0.7rem;
   display: flex;
   flex-direction: column;
   gap: 3px;
 }
 
 .comment-margin__dot {
-  width: 8px;
-  height: 8px;
+  width: 11px;
+  height: 11px;
   border-radius: 50%;
-  border: none;
+  border: 2px solid var(--surface);
   padding: 0;
   cursor: pointer;
   flex-shrink: 0;
+  box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 30%, transparent);
   transition:
     transform 0.15s,
     box-shadow 0.15s;
 }
 
 .comment-margin__dot:hover {
-  transform: scale(1.4);
+  transform: scale(1.25);
+  box-shadow:
+    0 0 0 2px var(--surface),
+    0 0 0 4px currentColor;
 }
 
 .comment-margin__dot--active {
-  transform: scale(1.4);
+  transform: scale(1.25);
   box-shadow:
     0 0 0 2px var(--surface),
-    0 0 0 3px currentColor;
+    0 0 0 4px currentColor;
 }
 
 .comment-margin__add-wrapper {
@@ -44,12 +48,12 @@
 }
 
 .comment-margin__add {
-  width: 20px;
-  height: 20px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-secondary);
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--accent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -61,8 +65,9 @@
 }
 
 .comment-margin__add:hover {
-  background: var(--accent-bg);
-  color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
 .comment-margin__peer-dot {

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -1,6 +1,6 @@
 /* ── Comment panel ───────────────────────────────────────────── */
 .comment-panel {
-  width: 280px;
+  width: 320px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -57,6 +57,76 @@
 }
 .comment-panel__delete-all:hover {
   background-color: color-mix(in srgb, var(--c-red) 10%, transparent);
+}
+
+.comment-panel__secondary-action {
+  margin-left: auto;
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.18rem 0.55rem;
+}
+
+.comment-panel__secondary-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.comment-panel__danger-trigger {
+  background: var(--surface);
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.18rem 0.55rem;
+}
+
+.comment-panel__danger-trigger:hover {
+  border-color: var(--c-red);
+  color: var(--c-red);
+}
+
+.comment-panel__danger-confirm {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--c-red) 35%, var(--border));
+  background: color-mix(in srgb, var(--surface) 88%, var(--c-red) 12%);
+  color: var(--text);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.comment-panel__danger-confirm span {
+  flex: 1;
+}
+
+.comment-panel__danger-confirm-delete,
+.comment-panel__danger-confirm-cancel {
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 650;
+  padding: 0.18rem 0.45rem;
+}
+
+.comment-panel__danger-confirm-delete {
+  border: 1px solid var(--c-red);
+  background: var(--c-red);
+  color: #fff;
+}
+
+.comment-panel__danger-confirm-cancel {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
 }
 
 .comment-panel__close {
@@ -165,7 +235,7 @@
   width: 100%;
   align-items: center;
   gap: 0.25rem 0.4rem;
-  padding: 0.45rem 0.75rem;
+  padding: 0.55rem 0.75rem;
   background: none;
   border: none;
   cursor: pointer;
@@ -179,6 +249,7 @@
 
 .comment-panel__entry--active {
   background-color: var(--accent-bg);
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .comment-panel__badge {

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -137,6 +137,7 @@ export function CommentPanel({ peerMode = false }: Props) {
   const deletePeerComment = useAppStore((state) => state.deletePeerComment);
   const selectPeerFile = useAppStore((state) => state.selectPeerFile);
   const sharedContent = useAppStore((state) => state.sharedContent);
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
 
   const isFolderMode = fileTree.length > 0 && !peerMode;
   const isPeerMultiFile =
@@ -346,7 +347,7 @@ export function CommentPanel({ peerMode = false }: Props) {
           <>
             {hasQuestionThreads && (
               <button
-                className="comment-panel__delete-all"
+                className="comment-panel__secondary-action"
                 onClick={() => {
                   void handleCopyAgentPrompt();
                 }}
@@ -356,11 +357,11 @@ export function CommentPanel({ peerMode = false }: Props) {
               </button>
             )}
             <button
-              className="comment-panel__delete-all"
-              onClick={deleteAllComments}
-              title="Delete all comments from the file"
+              className="comment-panel__danger-trigger"
+              onClick={() => setConfirmDeleteAll(true)}
+              title="Review before deleting all comments from the file"
             >
-              Delete all
+              Clear
             </button>
           </>
         )}
@@ -372,6 +373,27 @@ export function CommentPanel({ peerMode = false }: Props) {
           ×
         </button>
       </div>
+
+      {confirmDeleteAll && (
+        <div className="comment-panel__danger-confirm" role="alert">
+          <span>Delete all comments from this file?</span>
+          <button
+            className="comment-panel__danger-confirm-delete"
+            onClick={() => {
+              deleteAllComments();
+              setConfirmDeleteAll(false);
+            }}
+          >
+            Delete all
+          </button>
+          <button
+            className="comment-panel__danger-confirm-cancel"
+            onClick={() => setConfirmDeleteAll(false)}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
 
       {(showStatusFilters || showTypeFilters) && (
         <div className="comment-panel__filters">

--- a/src/ui/components/FileTreeSidebar/FileTreeSidebar.css
+++ b/src/ui/components/FileTreeSidebar/FileTreeSidebar.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   background-color: var(--surface);
-  border-right: 1px solid var(--border-light);
+  border-right: 1px solid var(--border);
   overflow: hidden;
   position: relative;
 }
@@ -31,14 +31,14 @@
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
 .file-tree-header__name {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--text-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   overflow: hidden;
@@ -77,12 +77,12 @@
   width: 100%;
   align-items: center;
   gap: 0.375rem;
-  padding: 0.3rem 0.75rem;
+  padding: 0.36rem 0.75rem;
   background: none;
   border: none;
   cursor: pointer;
   font-size: 0.8125rem;
-  color: var(--text-secondary);
+  color: var(--text);
   text-align: left;
   transition:
     background-color 0.1s,
@@ -99,7 +99,8 @@
 .tree-item--active {
   background-color: var(--accent-bg);
   color: var(--accent);
-  font-weight: 500;
+  font-weight: 650;
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .tree-item--active:hover {
@@ -109,7 +110,7 @@
 
 .tree-item--dir {
   color: var(--text);
-  font-weight: 500;
+  font-weight: 650;
 }
 
 .tree-item__name {
@@ -144,7 +145,7 @@
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  opacity: 0;
+  opacity: 0.38;
   transition:
     opacity 0.15s,
     color 0.15s;

--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -87,6 +87,19 @@
   font-weight: 500;
 }
 
+.app-header__btn--share {
+  background-color: color-mix(in srgb, var(--c-green) 10%, var(--surface-alt));
+  border-color: color-mix(in srgb, var(--c-green) 28%, var(--border-light));
+  color: color-mix(in srgb, var(--c-green) 78%, var(--text));
+  font-weight: 650;
+}
+
+.app-header__btn--share:hover {
+  background-color: var(--c-green);
+  border-color: var(--c-green);
+  color: #fff;
+}
+
 .app-header__btn--review {
   background-color: var(--accent-bg);
   border-color: color-mix(in srgb, var(--accent) 35%, var(--border-light));

--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -32,7 +32,19 @@
 .app-header__actions {
   display: flex;
   align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.app-header__group {
+  display: inline-flex;
+  align-items: center;
   gap: 0.25rem;
+}
+
+.app-header__group + .app-header__group {
+  border-left: 1px solid var(--border-light);
+  padding-left: 0.45rem;
 }
 
 .app-header__divider {
@@ -73,6 +85,19 @@
   padding: 0.35rem 0.5rem;
   font-size: 0.8rem;
   font-weight: 500;
+}
+
+.app-header__btn--review {
+  background-color: var(--accent-bg);
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border-light));
+  color: var(--accent);
+  font-weight: 650;
+}
+
+.app-header__btn--review:hover {
+  background-color: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
 }
 
 .focus-exit-btn {

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -266,33 +266,35 @@ export function Header({
             <div className="app-header__group app-header__group--share">
               {fileName && onShareFile && (
                 <button
-                  className="app-header__btn app-header__btn--icon"
+                  className="app-header__btn app-header__btn--text app-header__btn--share"
                   onClick={onShareFile}
                   aria-label="Share file"
-                  title="Share file"
+                  title="Create a review link for the current file"
                   disabled={disableHostReviewActions}
                 >
                   <ShareFileIcon />
+                  Share file
                 </button>
               )}
               {hasFolderOpen && onShareFolder && (
                 <button
-                  className="app-header__btn app-header__btn--icon"
+                  className="app-header__btn app-header__btn--text app-header__btn--share"
                   onClick={onShareFolder}
                   aria-label="Share folder"
-                  title="Share folder"
+                  title="Create a review link for the current folder"
                   disabled={disableHostReviewActions}
                 >
                   <ShareFolderIcon />
+                  Share folder
                 </button>
               )}
               <button
                 className={`app-header__btn app-header__btn--text${sharedPanelOpen ? " app-header__btn--active" : ""}`}
                 onClick={toggleSharedPanel}
-                title="Manage shared documents"
+                title="Manage shared review links"
                 disabled={disableHostReviewActions}
               >
-                Shared
+                Shared links
                 {totalPending > 0 && (
                   <span className="app-header__badge app-header__badge--pending">
                     {totalPending}

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -213,11 +213,13 @@ export function Header({
     0,
   );
 
-  const displayName = peerMode
+  const contextLabel = peerMode
     ? (useAppStore.getState().peerFileName ?? "Shared document")
-    : hasFolderOpen && fileName
-      ? `${directoryName} / ${fileName}`
-      : (fileName ?? directoryName ?? "");
+    : hasFolderOpen
+      ? "Folder review"
+      : hasContent
+        ? "File review"
+        : "";
 
   return (
     <>
@@ -233,7 +235,7 @@ export function Header({
               <SidebarIcon />
             </button>
           )}
-          <span className="app-header__filename">{displayName}</span>
+          <span className="app-header__filename">{contextLabel}</span>
           {peerMode && (
             <span className="app-header__peer-badge">Reviewing</span>
           )}
@@ -242,7 +244,7 @@ export function Header({
 
         <div className="app-header__actions">
           {!peerMode && (
-            <>
+            <div className="app-header__group app-header__group--source">
               <button
                 onClick={openFileInNewTab}
                 className="app-header__btn app-header__btn--text"
@@ -257,75 +259,76 @@ export function Header({
               </button>
 
               <HistoryDropdown />
-
-              {WORKER_URL && hasContent && (
-                <>
-                  <div className="app-header__divider" aria-hidden="true" />
-                  {fileName && onShareFile && (
-                    <button
-                      className="app-header__btn app-header__btn--icon"
-                      onClick={onShareFile}
-                      aria-label="Share file"
-                      title="Share file"
-                      disabled={disableHostReviewActions}
-                    >
-                      <ShareFileIcon />
-                    </button>
-                  )}
-                  {hasFolderOpen && onShareFolder && (
-                    <button
-                      className="app-header__btn app-header__btn--icon"
-                      onClick={onShareFolder}
-                      aria-label="Share folder"
-                      title="Share folder"
-                      disabled={disableHostReviewActions}
-                    >
-                      <ShareFolderIcon />
-                    </button>
-                  )}
-                  <button
-                    className={`app-header__btn app-header__btn--text${sharedPanelOpen ? " app-header__btn--active" : ""}`}
-                    onClick={toggleSharedPanel}
-                    title="Manage shared documents"
-                    disabled={disableHostReviewActions}
-                  >
-                    Shared
-                    {totalPending > 0 && (
-                      <span className="app-header__badge app-header__badge--pending">
-                        {totalPending}
-                      </span>
-                    )}
-                  </button>
-                  {hasActiveShares && (
-                    <button
-                      onClick={syncActiveShares}
-                      title="Push latest content to all active shares"
-                      className="app-header__btn app-header__btn--text"
-                      disabled={disableHostReviewActions}
-                    >
-                      Push update
-                    </button>
-                  )}
-                </>
-              )}
-
-              <div className="app-header__divider" aria-hidden="true" />
-            </>
+            </div>
           )}
 
-          <TableOfContents peerMode={peerMode} />
+          {!peerMode && WORKER_URL && hasContent && (
+            <div className="app-header__group app-header__group--share">
+              {fileName && onShareFile && (
+                <button
+                  className="app-header__btn app-header__btn--icon"
+                  onClick={onShareFile}
+                  aria-label="Share file"
+                  title="Share file"
+                  disabled={disableHostReviewActions}
+                >
+                  <ShareFileIcon />
+                </button>
+              )}
+              {hasFolderOpen && onShareFolder && (
+                <button
+                  className="app-header__btn app-header__btn--icon"
+                  onClick={onShareFolder}
+                  aria-label="Share folder"
+                  title="Share folder"
+                  disabled={disableHostReviewActions}
+                >
+                  <ShareFolderIcon />
+                </button>
+              )}
+              <button
+                className={`app-header__btn app-header__btn--text${sharedPanelOpen ? " app-header__btn--active" : ""}`}
+                onClick={toggleSharedPanel}
+                title="Manage shared documents"
+                disabled={disableHostReviewActions}
+              >
+                Shared
+                {totalPending > 0 && (
+                  <span className="app-header__badge app-header__badge--pending">
+                    {totalPending}
+                  </span>
+                )}
+              </button>
+              {hasActiveShares && (
+                <button
+                  onClick={syncActiveShares}
+                  title="Push latest content to all active shares"
+                  className="app-header__btn app-header__btn--text"
+                  disabled={disableHostReviewActions}
+                >
+                  Push update
+                </button>
+              )}
+            </div>
+          )}
 
-          <button
-            onClick={() => setTheme(isDark ? "light" : "dark")}
-            aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-            title={isDark ? "Switch to light mode" : "Switch to dark mode"}
-            className="app-header__btn app-header__btn--icon"
-          >
-            {isDark ? <SunIcon /> : <MoonIcon />}
-          </button>
+          <div className="app-header__group app-header__group--view">
+            <TableOfContents peerMode={peerMode} />
+
+            <button
+              onClick={() => setTheme(isDark ? "light" : "dark")}
+              aria-label={
+                isDark ? "Switch to light mode" : "Switch to dark mode"
+              }
+              title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+              className="app-header__btn app-header__btn--icon"
+            >
+              {isDark ? <SunIcon /> : <MoonIcon />}
+            </button>
+          </div>
 
           {peerMode && (
-            <>
+            <div className="app-header__group app-header__group--peer">
               {unsubmittedPeerCount > 0 && (
                 <button
                   onClick={syncPeerComments}
@@ -350,47 +353,53 @@ export function Header({
                 <FloppyDiskIcon />
                 Save file
               </button>
-            </>
+            </div>
           )}
 
-          <button
-            onClick={toggleCommentPanel}
-            aria-label={
-              commentPanelOpen ? "Close comments panel" : "Open comments panel"
-            }
-            title={
-              commentPanelOpen ? "Close comments panel" : "Open comments panel"
-            }
-            className={`app-header__btn app-header__btn--text${commentPanelOpen ? " app-header__btn--active" : ""}`}
-            disabled={disableHostReviewActions}
-          >
-            Comments
-            {commentCount > 0 && (
-              <span className="app-header__badge">{commentCount}</span>
+          <div className="app-header__group app-header__group--review">
+            <button
+              onClick={toggleCommentPanel}
+              aria-label={
+                commentPanelOpen
+                  ? "Close comments panel"
+                  : "Open comments panel"
+              }
+              title={
+                commentPanelOpen
+                  ? "Close comments panel"
+                  : "Open comments panel"
+              }
+              className={`app-header__btn app-header__btn--text app-header__btn--review${commentPanelOpen ? " app-header__btn--active" : ""}`}
+              disabled={disableHostReviewActions}
+            >
+              Comments
+              {commentCount > 0 && (
+                <span className="app-header__badge">{commentCount}</span>
+              )}
+            </button>
+
+            {!peerMode && hasContent && onPresent && (
+              <button
+                onClick={onPresent}
+                aria-label="Enter presentation mode"
+                title="Enter presentation mode"
+                className="app-header__btn app-header__btn--icon"
+              >
+                <PresentIcon />
+              </button>
             )}
-          </button>
 
-          {!peerMode && hasContent && onPresent && (
-            <button
-              onClick={onPresent}
-              aria-label="Enter presentation mode"
-              title="Enter presentation mode"
-              className="app-header__btn app-header__btn--icon"
-            >
-              <PresentIcon />
-            </button>
-          )}
-
-          {!peerMode && (
-            <button
-              onClick={toggleFocusMode}
-              aria-label="Enter focus mode"
-              title="Enter focus mode"
-              className="app-header__btn app-header__btn--icon"
-            >
-              <FocusIcon />
-            </button>
-          )}
+            {!peerMode && (
+              <button
+                onClick={toggleFocusMode}
+                aria-label="Enter focus mode"
+                title="Enter focus mode"
+                className="app-header__btn app-header__btn--icon"
+              >
+                <FocusIcon />
+              </button>
+            )}
+          </div>
         </div>
       </header>
     </>

--- a/src/ui/components/Header/HeaderShare.test.tsx
+++ b/src/ui/components/Header/HeaderShare.test.tsx
@@ -94,7 +94,9 @@ describe("Header share buttons", () => {
       render(<Header onShareFile={vi.fn()} onShareFolder={vi.fn()} />);
 
       expect(screen.getByRole("button", { name: "Share file" })).toBeDisabled();
-      expect(screen.getByRole("button", { name: "Shared" })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Shared links" }),
+      ).toBeDisabled();
       expect(
         screen.getByRole("button", { name: "Open comments panel" }),
       ).toBeDisabled();

--- a/src/ui/components/MarkdownRenderer/MarkdownRenderer.css
+++ b/src/ui/components/MarkdownRenderer/MarkdownRenderer.css
@@ -70,6 +70,68 @@
   line-height: var(--leading);
 }
 
+.markdown-metadata {
+  margin: 0 0 2rem;
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-alt) 72%, var(--surface));
+  color: var(--text);
+}
+
+.markdown-metadata__title {
+  margin: 0 0 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.markdown-metadata__list {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+}
+
+.markdown-metadata__row {
+  display: grid;
+  grid-template-columns: minmax(7rem, 10rem) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.markdown-metadata__key {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.markdown-metadata__value {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  line-height: 1.5;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.markdown-metadata__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.markdown-metadata__chip {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 0.08rem 0.48rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 62%, transparent);
+  color: var(--text);
+  line-height: 1.45;
+}
+
 .markdown-body h1,
 .markdown-body h2,
 .markdown-body h3,
@@ -370,6 +432,10 @@
   }
   .markdown-body h3 {
     font-size: 1.125rem;
+  }
+  .markdown-metadata__row {
+    grid-template-columns: 1fr;
+    gap: 0.1rem;
   }
   .markdown-body pre {
     font-size: 0.8125rem;

--- a/src/ui/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/src/ui/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -161,6 +161,45 @@ describe("MarkdownRenderer — GFM extras", () => {
   });
 });
 
+describe("MarkdownRenderer — metadata", () => {
+  it("renders frontmatter as a metadata panel and removes it from the body", () => {
+    setContent(
+      [
+        "---",
+        "id: DEC-retrieval-fast-paths-use-generated-metadata",
+        "date: 11/06/2026",
+        "status: Proposed",
+        "summary: Fast-path retrieval should not require broad document reads.",
+        "participants:",
+        "  - Ivan Tytarenko",
+        "  - Codex",
+        "extends: [decision-records-carry-summary, agent-quality-gates]",
+        "---",
+        "# Decision: Retrieval Fast Paths",
+      ].join("\n"),
+    );
+
+    const { container } = render(<MarkdownRenderer />);
+
+    expect(screen.getByRole("region", { name: "Metadata" })).toBeInTheDocument();
+    expect(screen.getByText("id")).toBeInTheDocument();
+    expect(
+      screen.getByText("DEC-retrieval-fast-paths-use-generated-metadata"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ivan Tytarenko")).toBeInTheDocument();
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Decision: Retrieval Fast Paths",
+      }),
+    ).toBeInTheDocument();
+    expect(container.querySelector(".markdown-body")?.textContent).not.toContain(
+      "participants:",
+    );
+  });
+});
+
 describe("MarkdownRenderer — read-only banner", () => {
   it("does not show the banner when writeAllowed is true", () => {
     setTestState({ writeAllowed: true });

--- a/src/ui/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/ui/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -16,9 +16,12 @@ import { useActiveTab } from "../../../store/selectors";
 import {
   assignBlockIndices,
   isCommentType,
+  parseMarkdownFrontmatter,
   parseCriticMarkup,
+  shiftCommentRawOffsets,
   useShikiRehypePlugin,
 } from "../../../markup";
+import type { MarkdownMetadataField } from "../../../markup";
 import {
   getRestoreAccessActionLabel,
   shouldRenderRestoreBanner,
@@ -67,6 +70,58 @@ export function PreBlock({ children }: ComponentPropsWithoutRef<"pre">) {
 }
 
 const markdownComponents = { code: CodeBlock, pre: PreBlock };
+
+const CHIP_FIELDS = new Set([
+  "participants",
+  "extends",
+  "amends",
+  "relates",
+  "tags",
+  "owners",
+  "reviewers",
+]);
+
+function formatMetadataLabel(key: string): string {
+  return key.replace(/[-_]/g, " ");
+}
+
+function shouldRenderChips(field: MarkdownMetadataField): boolean {
+  return field.values.length > 1 || CHIP_FIELDS.has(field.key.toLowerCase());
+}
+
+function MetadataPanel({ fields }: { fields: MarkdownMetadataField[] }) {
+  if (fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="markdown-metadata" aria-label="Metadata">
+      <h2 className="markdown-metadata__title">Metadata</h2>
+      <dl className="markdown-metadata__list">
+        {fields.map((field) => (
+          <div key={field.key} className="markdown-metadata__row">
+            <dt className="markdown-metadata__key">
+              {formatMetadataLabel(field.key)}
+            </dt>
+            <dd className="markdown-metadata__value">
+              {shouldRenderChips(field) ? (
+                <span className="markdown-metadata__chips">
+                  {field.values.map((value) => (
+                    <span key={value} className="markdown-metadata__chip">
+                      {value}
+                    </span>
+                  ))}
+                </span>
+              ) : (
+                <span>{field.values[0] ?? ""}</span>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
 
 export function MarkdownRenderer() {
   const tab = useActiveTab();
@@ -154,10 +209,15 @@ export function MarkdownRenderer() {
   );
 
   // Strip CriticMarkup and collect comments with block indices
-  const { cleanMarkdown, comments } = useMemo(() => {
-    const parsed = parseCriticMarkup(rawContent);
+  const { cleanMarkdown, comments, metadata } = useMemo(() => {
+    const document = parseMarkdownFrontmatter(rawContent);
+    const parsed = parseCriticMarkup(document.body);
     const comments = assignBlockIndices(parsed.comments, parsed.cleanMarkdown);
-    return { cleanMarkdown: parsed.cleanMarkdown, comments };
+    return {
+      cleanMarkdown: parsed.cleanMarkdown,
+      comments: shiftCommentRawOffsets(comments, document.bodyStart),
+      metadata: document.metadata,
+    };
   }, [rawContent]);
 
   // Sync parsed comments into the store during render to avoid an extra
@@ -264,6 +324,7 @@ export function MarkdownRenderer() {
           onPostPeerComment={handlePostPeerComment}
         />
         <div className="markdown-body" onMouseOver={handleBodyMouseOver}>
+          <MetadataPanel fields={metadata} />
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             rehypePlugins={rehypePlugins}

--- a/src/ui/components/PresentationMode/PresentationMode.tsx
+++ b/src/ui/components/PresentationMode/PresentationMode.tsx
@@ -6,7 +6,11 @@ import { CodeBlock, PreBlock } from "../MarkdownRenderer";
 import { SunIcon, MoonIcon } from "../Icons";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
-import { parseCriticMarkup, useShikiRehypePlugin } from "../../../markup";
+import {
+  parseCriticMarkup,
+  parseMarkdownFrontmatter,
+  useShikiRehypePlugin,
+} from "../../../markup";
 
 function splitIntoSlides(markdown: string): string[] {
   const lines = markdown.split("\n");
@@ -69,7 +73,8 @@ export function PresentationMode() {
   const viewportRef = useRef<HTMLDivElement>(null);
 
   const cleanMarkdown = useMemo(() => {
-    return parseCriticMarkup(rawContent).cleanMarkdown;
+    const document = parseMarkdownFrontmatter(rawContent);
+    return parseCriticMarkup(document.body).cleanMarkdown;
   }, [rawContent]);
 
   const slides = useMemo(() => splitIntoSlides(cleanMarkdown), [cleanMarkdown]);

--- a/src/ui/components/SharedPanel/SharedPanel.css
+++ b/src/ui/components/SharedPanel/SharedPanel.css
@@ -1,6 +1,6 @@
 /* ── Shared panel (unified with comment-panel) ───────────────── */
 .shared-panel {
-  width: 280px;
+  width: 320px;
   flex-shrink: 0;
   display: flex;
   flex-direction: column;

--- a/src/ui/components/SharedPanel/SharedPanel.tsx
+++ b/src/ui/components/SharedPanel/SharedPanel.tsx
@@ -50,7 +50,7 @@ export function SharedPanel() {
           onClick={toggleSharedPanel}
           aria-label="Close shared panel"
         >
-          ?
+          ×
         </button>
       </div>
 

--- a/src/ui/components/TableOfContents/TableOfContents.tsx
+++ b/src/ui/components/TableOfContents/TableOfContents.tsx
@@ -2,7 +2,7 @@ import "./TableOfContents.css";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
-import { parseCriticMarkup } from "../../../markup";
+import { parseCriticMarkup, parseMarkdownFrontmatter } from "../../../markup";
 import { extractHeadings } from "../../../utils/extractHeadings";
 
 function OutlineIcon() {
@@ -53,7 +53,8 @@ export function TableOfContents({ peerMode = false }: Props) {
     if (!rawContent) {
       return [];
     }
-    const { cleanMarkdown } = parseCriticMarkup(rawContent);
+    const document = parseMarkdownFrontmatter(rawContent);
+    const { cleanMarkdown } = parseCriticMarkup(document.body);
     return extractHeadings(cleanMarkdown);
   }, [rawContent]);
 

--- a/src/ui/styles/app-layout.css
+++ b/src/ui/styles/app-layout.css
@@ -52,11 +52,59 @@
   height: 100%;
   align-items: center;
   justify-content: center;
+  padding: 2rem;
+}
+
+.content-empty__panel {
+  width: min(28rem, 100%);
+  text-align: center;
+  color: var(--text);
+}
+
+.content-empty__eyebrow {
+  margin: 0 0 0.6rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.content-empty__title {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.6rem;
+  font-weight: 650;
 }
 
 .content-empty__text {
+  margin: 0.7rem 0 0;
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.content-empty__meta {
+  margin: 0.7rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.content-empty__action {
+  margin-top: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.45rem 0.8rem;
+}
+
+.content-empty__action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 /* ── Share status screen (revoked / expired) ─────────────────── */


### PR DESCRIPTION
## Summary
- render YAML-style Markdown frontmatter as a Codex-style metadata panel instead of raw document content
- keep TOC, presentation mode, comment insertion, and pending-comment merge aligned with body-only rendered blocks
- polish review UI hierarchy: grouped header controls, stronger comment anchors, clearer empty folder state, safer bulk delete confirmation, sidebar contrast, and Shared panel close affordance

## Validation
- git diff --check
- targeted tests not run: this checkout has no Yarn install state, and yarn install fails with registry/network errors (ENOTCONN / EBADF)