### PR TITLE
refactor: introduce workspace runtime boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,6 +66,7 @@ Shared module shape:
 
 Lower-level reusable code lives outside modules:
 
+- `src/runtime/`: runtime capability boundaries and active runtime adapters
 - `src/services/`: browser, network, crypto, and file-system adapters
 - `src/markup/`: CriticMarkup parsing and editing helpers
 - `src/types/`: shared application types

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -253,6 +253,12 @@ Suggested implementation phases:
 
 Each phase should keep the website runnable.
 
+Initial implementation note: the first foundation slice introduces
+`src/runtime/` and routes host file and folder operations through a web workspace
+runtime that delegates to the existing browser filesystem implementation. This
+does not add desktop execution yet; it creates the boundary the desktop runtime
+can implement later.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -11,7 +11,7 @@ import {
 import { findLiveFileInTree } from "../../types/fileTree";
 import type { Comment } from "../../types/criticmarkup";
 import type { FileNode, FileTreeNode } from "../../types/fileTree";
-import { readFile, writeFile } from "../../services/fileSystem";
+import { readFile, writeFile } from "../../runtime";
 import type { TabState } from "../../types/tab";
 import type { FileCommentEntry, HostReviewActions } from "./types";
 
@@ -23,7 +23,7 @@ interface ActiveTabStoreState {
   activeTabId: string | null;
 }
 
-interface HostReviewControllerStoreState extends ActiveTabStoreState {}
+type HostReviewControllerStoreState = ActiveTabStoreState;
 
 interface HostReviewControllerDeps<
   StoreState extends HostReviewControllerStoreState,
@@ -75,24 +75,19 @@ export function findResolvedComments(
   return comments.filter((comment) => !rawContent.includes(comment.raw));
 }
 
-export async function writeAndUpdate<StoreState extends ActiveTabStoreState>(
-  input: {
-    set: SetState<StoreState>;
-    buildUpdatedActiveTabs: (
-      tabs: TabState[],
-      activeTabId: string | null,
-      updater: (tab: TabState) => Partial<TabState>,
-    ) => TabState[];
-    fileHandle: FileSystemFileHandle;
-    newRawContent: string;
-  },
-): Promise<boolean> {
-  const {
-    set,
-    buildUpdatedActiveTabs,
-    fileHandle,
-    newRawContent,
-  } = input;
+export async function writeAndUpdate<
+  StoreState extends ActiveTabStoreState,
+>(input: {
+  set: SetState<StoreState>;
+  buildUpdatedActiveTabs: (
+    tabs: TabState[],
+    activeTabId: string | null,
+    updater: (tab: TabState) => Partial<TabState>,
+  ) => TabState[];
+  fileHandle: FileSystemFileHandle;
+  newRawContent: string;
+}): Promise<boolean> {
+  const { set, buildUpdatedActiveTabs, fileHandle, newRawContent } = input;
   try {
     await writeFile(fileHandle, newRawContent);
     set((state) => ({
@@ -195,7 +190,10 @@ export function createHostReviewControllerActions<
         return;
       }
 
-      const scannedComments = await scanAllTabFileComments(tab, getLiveFileTree);
+      const scannedComments = await scanAllTabFileComments(
+        tab,
+        getLiveFileTree,
+      );
       const currentTab = get().tabs.find(
         (currentTab) => currentTab.id === tab.id,
       );

--- a/src/modules/sharing/controller.ts
+++ b/src/modules/sharing/controller.ts
@@ -11,7 +11,7 @@ import {
   generateKey,
   keyToBase64url,
 } from "../../services/crypto";
-import { readFile } from "../../services/fileSystem";
+import { readFile } from "../../runtime";
 import type { FileTreeNode } from "../../types/fileTree";
 import type { ShareRecord } from "../../types/share";
 import type { TabState } from "../../types/tab";
@@ -22,12 +22,12 @@ import {
   relayCommentResolve,
   unsubscribeFromDoc,
 } from "../relay";
-import { removePendingCommentState, replacePendingCommentsState } from "./state";
+import {
+  removePendingCommentState,
+  replacePendingCommentsState,
+} from "./state";
 import { ShareStorage } from "./storage";
-import type {
-  ShareContentOptions,
-  SharingActions,
-} from "./types";
+import type { ShareContentOptions, SharingActions } from "./types";
 
 type SetState<StoreState> = StoreApi<StoreState>["setState"];
 type GetState<StoreState> = StoreApi<StoreState>["getState"];
@@ -39,7 +39,9 @@ interface SharingControllerStoreState {
   activeTabId: string | null;
 }
 
-interface SharingControllerDeps<StoreState extends SharingControllerStoreState> {
+interface SharingControllerDeps<
+  StoreState extends SharingControllerStoreState,
+> {
   set: SetState<StoreState>;
   get: GetState<StoreState>;
   queuePendingResolve: (docId: string, cmtId: string) => void;
@@ -100,11 +102,13 @@ export function saveShares(key: string, shares: ShareRecord[]) {
   saveAllShares(allShares);
 }
 
-export function loadAndCleanShares(tabs: {
-  id: string;
-  directoryName: string | null;
-  fileName: string | null;
-}[]): Record<string, ShareRecord[]> {
+export function loadAndCleanShares(
+  tabs: {
+    id: string;
+    directoryName: string | null;
+    fileName: string | null;
+  }[],
+): Record<string, ShareRecord[]> {
   const allShares = loadAllShares();
   let changed = false;
 
@@ -214,16 +218,14 @@ export function getSharingStorage(): ShareStorage | null {
   return new ShareStorage(WORKER_URL);
 }
 
-function buildShareRecord(
-  input: {
-    docId: string;
-    hostSecret: string;
-    keyB64: string;
-    label: string;
-    ttl: number;
-    tree: Record<string, string>;
-  },
-): ShareRecord {
+function buildShareRecord(input: {
+  docId: string;
+  hostSecret: string;
+  keyB64: string;
+  label: string;
+  ttl: number;
+  tree: Record<string, string>;
+}): ShareRecord {
   const now = new Date();
   return {
     docId: input.docId,
@@ -249,7 +251,8 @@ async function createShare(
   record: ShareRecord;
   shareUrl: string;
 }> {
-  const label = options.label ?? tab.directoryName ?? tab.fileName ?? "document";
+  const label =
+    options.label ?? tab.directoryName ?? tab.fileName ?? "document";
   const liveFileTree = getLiveFileTree(tab);
   const sourceNodes =
     options.nodes ??
@@ -292,7 +295,8 @@ function findSharingTabByDocId(
   docId: string,
 ): TabState | null {
   return (
-    tabs.find((tab) => tab.shares.some((share) => share.docId === docId)) ?? null
+    tabs.find((tab) => tab.shares.some((share) => share.docId === docId)) ??
+    null
   );
 }
 
@@ -370,9 +374,13 @@ export function createSharingControllerActions<
       }
 
       set((state) => ({
-        tabs: buildUpdatedActiveTabs(state.tabs, state.activeTabId, (tabState) => ({
-          shareKeys: { ...tabState.shareKeys, ...restoredKeys },
-        })),
+        tabs: buildUpdatedActiveTabs(
+          state.tabs,
+          state.activeTabId,
+          (tabState) => ({
+            shareKeys: { ...tabState.shareKeys, ...restoredKeys },
+          }),
+        ),
       }));
     },
 
@@ -394,7 +402,9 @@ export function createSharingControllerActions<
         getLiveFileTree,
       );
 
-      const currentTab = get().tabs.find((currentTab) => currentTab.id === tabId);
+      const currentTab = get().tabs.find(
+        (currentTab) => currentTab.id === tabId,
+      );
       if (!currentTab) {
         throw new Error("Tab disappeared");
       }
@@ -406,9 +416,9 @@ export function createSharingControllerActions<
         buildUpdatedTabs,
         tabId,
         updater: (tabState) => ({
-        shares,
-        shareKeys: { ...tabState.shareKeys, [docId]: key },
-        activeDocId: docId,
+          shares,
+          shareKeys: { ...tabState.shareKeys, [docId]: key },
+          activeDocId: docId,
         }),
       });
 
@@ -541,7 +551,11 @@ export function createSharingControllerActions<
         return;
       }
 
-      const nextTabState = removePendingCommentState(latestTab, docId, comment.id);
+      const nextTabState = removePendingCommentState(
+        latestTab,
+        docId,
+        comment.id,
+      );
       saveShares(stableShareKey(latestTab), nextTabState.shares);
       updateSharingTabState({
         set,

--- a/src/modules/workspace/README.md
+++ b/src/modules/workspace/README.md
@@ -50,6 +50,9 @@ Expected side effects:
 - file refresh
 - restore from persisted handles
 
+File and folder operations should go through the runtime workspace capability
+boundary rather than importing browser filesystem services directly.
+
 ## Related Docs
 
 - [Architecture](../../../ARCHITECTURE.md)

--- a/src/modules/workspace/storage.ts
+++ b/src/modules/workspace/storage.ts
@@ -1,11 +1,10 @@
 export {
   buildFileTree,
-  buildVirtualTree,
   openDirectory,
   openFile,
   readFile,
   writeFile,
-} from "../../services/fileSystem";
+} from "../../runtime";
 export {
   getHandle,
   removeHandle,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,32 @@
+import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
+
+export type {
+  OpenedWorkspaceDirectory,
+  OpenedWorkspaceFile,
+  WorkspaceRuntime,
+} from "./workspace";
+
+export const workspaceRuntime = webWorkspaceRuntime;
+
+export function openFile() {
+  return workspaceRuntime.openFile();
+}
+
+export function openDirectory() {
+  return workspaceRuntime.openDirectory();
+}
+
+export function readFile(handle: FileSystemFileHandle) {
+  return workspaceRuntime.readFile(handle);
+}
+
+export function writeFile(handle: FileSystemFileHandle, content: string) {
+  return workspaceRuntime.writeFile(handle, content);
+}
+
+export function buildFileTree(
+  handle: FileSystemDirectoryHandle,
+  basePath?: string,
+) {
+  return workspaceRuntime.buildFileTree(handle, basePath);
+}

--- a/src/runtime/webWorkspaceRuntime.test.ts
+++ b/src/runtime/webWorkspaceRuntime.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/fileSystem", () => ({
+  buildFileTree: vi.fn(),
+  openDirectory: vi.fn(),
+  openFile: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+import {
+  buildFileTree,
+  openDirectory,
+  openFile,
+  readFile,
+  writeFile,
+} from "../services/fileSystem";
+import { workspaceRuntime } from ".";
+
+function createFileHandle(name: string): FileSystemFileHandle {
+  return {
+    kind: "file",
+    name,
+    createWritable: vi.fn(),
+    getFile: vi.fn(),
+    isSameEntry: vi.fn(),
+    queryPermission: vi.fn(),
+    requestPermission: vi.fn(),
+  };
+}
+
+function createDirectoryHandle(name: string): FileSystemDirectoryHandle {
+  return {
+    kind: "directory",
+    name,
+    getDirectoryHandle: vi.fn(),
+    getFileHandle: vi.fn(),
+    removeEntry: vi.fn(),
+    resolve: vi.fn(),
+    entries: vi.fn(),
+    keys: vi.fn(),
+    values: vi.fn(),
+    isSameEntry: vi.fn(),
+    queryPermission: vi.fn(),
+    requestPermission: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("workspaceRuntime", () => {
+  it("delegates file operations to the web filesystem implementation", async () => {
+    const fileHandle = createFileHandle("notes.md");
+    vi.mocked(openFile).mockResolvedValue({
+      handle: fileHandle,
+      name: "notes.md",
+    });
+    vi.mocked(readFile).mockResolvedValue("# Notes");
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    await expect(workspaceRuntime.openFile()).resolves.toEqual({
+      handle: fileHandle,
+      name: "notes.md",
+    });
+    await expect(workspaceRuntime.readFile(fileHandle)).resolves.toBe(
+      "# Notes",
+    );
+    await workspaceRuntime.writeFile(fileHandle, "# Updated");
+
+    expect(openFile).toHaveBeenCalled();
+    expect(readFile).toHaveBeenCalledWith(fileHandle);
+    expect(writeFile).toHaveBeenCalledWith(fileHandle, "# Updated");
+  });
+
+  it("delegates directory operations to the web filesystem implementation", async () => {
+    const directoryHandle = createDirectoryHandle("docs");
+    const tree = [
+      {
+        kind: "file",
+        name: "README.md",
+        path: "README.md",
+        handle: createFileHandle("README.md"),
+      },
+    ];
+    vi.mocked(openDirectory).mockResolvedValue({
+      handle: directoryHandle,
+      name: "docs",
+    });
+    vi.mocked(buildFileTree).mockResolvedValue(tree);
+
+    await expect(workspaceRuntime.openDirectory()).resolves.toEqual({
+      handle: directoryHandle,
+      name: "docs",
+    });
+    await expect(workspaceRuntime.buildFileTree(directoryHandle)).resolves.toBe(
+      tree,
+    );
+
+    expect(openDirectory).toHaveBeenCalled();
+    expect(buildFileTree).toHaveBeenCalledWith(directoryHandle);
+  });
+});

--- a/src/runtime/webWorkspaceRuntime.ts
+++ b/src/runtime/webWorkspaceRuntime.ts
@@ -1,0 +1,16 @@
+import {
+  buildFileTree,
+  openDirectory,
+  openFile,
+  readFile,
+  writeFile,
+} from "../services/fileSystem";
+import type { WorkspaceRuntime } from "./workspace";
+
+export const webWorkspaceRuntime: WorkspaceRuntime = {
+  openFile,
+  openDirectory,
+  readFile,
+  writeFile,
+  buildFileTree,
+};

--- a/src/runtime/workspace.ts
+++ b/src/runtime/workspace.ts
@@ -1,0 +1,22 @@
+import type { FileTreeNode } from "../types/fileTree";
+
+export interface OpenedWorkspaceFile {
+  handle: FileSystemFileHandle;
+  name: string;
+}
+
+export interface OpenedWorkspaceDirectory {
+  handle: FileSystemDirectoryHandle;
+  name: string;
+}
+
+export interface WorkspaceRuntime {
+  openFile(): Promise<OpenedWorkspaceFile | null>;
+  openDirectory(): Promise<OpenedWorkspaceDirectory | null>;
+  readFile(handle: FileSystemFileHandle): Promise<string>;
+  writeFile(handle: FileSystemFileHandle, content: string): Promise<void>;
+  buildFileTree(
+    handle: FileSystemDirectoryHandle,
+    basePath?: string,
+  ): Promise<FileTreeNode[]>;
+}

--- a/src/services/fileSystem.ts
+++ b/src/services/fileSystem.ts
@@ -1,10 +1,4 @@
-import type {
-  FileTreeNode,
-  FileNode,
-  DirectoryNode,
-  SidebarTreeNode,
-  SidebarDirectoryNode,
-} from "../types/fileTree";
+import type { FileTreeNode, FileNode, DirectoryNode } from "../types/fileTree";
 
 function isDirectoryHandle(
   entry: FileSystemHandle,
@@ -111,57 +105,6 @@ export async function buildFileTree(
   files.sort((a, b) => a.name.localeCompare(b.name));
 
   return [...dirs, ...files];
-}
-
-/** Build a nested tree from flat path keys like "folder/sub/file.md" */
-export function buildVirtualTree(paths: string[]): SidebarTreeNode[] {
-  const root: SidebarDirectoryNode = {
-    kind: "directory",
-    name: "",
-    path: "",
-    children: [],
-  };
-
-  for (const path of paths) {
-    const parts = path.split("/");
-    let current = root;
-    for (let i = 0; i < parts.length; i++) {
-      const name = parts[i];
-      const subPath = parts.slice(0, i + 1).join("/");
-      if (i === parts.length - 1) {
-        current.children.push({ kind: "file", name, path });
-      } else {
-        const found = current.children.find(
-          (c) => c.kind === "directory" && c.name === name,
-        );
-        let dir: SidebarDirectoryNode | undefined =
-          found?.kind === "directory" ? found : undefined;
-        if (!dir) {
-          dir = { kind: "directory", name, path: subPath, children: [] };
-          current.children.push(dir);
-        }
-        current = dir;
-      }
-    }
-  }
-
-  function sortNodes(nodes: SidebarTreeNode[]): SidebarTreeNode[] {
-    return nodes
-      .sort((a, b) => {
-        if (a.kind !== b.kind) {
-          return a.kind === "directory" ? -1 : 1;
-        }
-        return a.name.localeCompare(b.name);
-      })
-      .map((n) => {
-        if (n.kind === "directory") {
-          return { ...n, children: sortNodes(n.children) };
-        }
-        return n;
-      });
-  }
-
-  return sortNodes(root.children);
 }
 
 export async function openDirectory(): Promise<{

--- a/src/types/fileTree.ts
+++ b/src/types/fileTree.ts
@@ -106,3 +106,59 @@ export function toFileTreeNodes(
   }
   return liveNodes;
 }
+
+/** Build a nested sidebar tree from flat path keys like "folder/sub/file.md". */
+export function buildVirtualTree(paths: string[]): SidebarTreeNode[] {
+  const root: SidebarDirectoryNode = {
+    kind: "directory",
+    name: "",
+    path: "",
+    children: [],
+  };
+
+  for (const path of paths) {
+    const parts = path.split("/");
+    let current = root;
+    for (let index = 0; index < parts.length; index += 1) {
+      const name = parts[index];
+      const subPath = parts.slice(0, index + 1).join("/");
+      if (index === parts.length - 1) {
+        current.children.push({ kind: "file", name, path });
+      } else {
+        const found = current.children.find(
+          (child) => child.kind === "directory" && child.name === name,
+        );
+        let directory: SidebarDirectoryNode | undefined =
+          found?.kind === "directory" ? found : undefined;
+        if (!directory) {
+          directory = {
+            kind: "directory",
+            name,
+            path: subPath,
+            children: [],
+          };
+          current.children.push(directory);
+        }
+        current = directory;
+      }
+    }
+  }
+
+  return sortSidebarTreeNodes(root.children);
+}
+
+function sortSidebarTreeNodes(nodes: SidebarTreeNode[]): SidebarTreeNode[] {
+  return nodes
+    .sort((leftNode, rightNode) => {
+      if (leftNode.kind !== rightNode.kind) {
+        return leftNode.kind === "directory" ? -1 : 1;
+      }
+      return leftNode.name.localeCompare(rightNode.name);
+    })
+    .map((node) => {
+      if (node.kind === "directory") {
+        return { ...node, children: sortSidebarTreeNodes(node.children) };
+      }
+      return node;
+    });
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -14,7 +14,7 @@ import { PresentationMode } from "./components/PresentationMode";
 import { UndoToast } from "./components/UndoToast";
 import { Toast } from "./components/Toast";
 import { PeerNamePrompt } from "./components/PeerNamePrompt";
-import { buildVirtualTree } from "../services/fileSystem";
+import { buildVirtualTree } from "../types/fileTree";
 import { findLiveFileInTree, toFileTreeNodes } from "../types/fileTree";
 import type { SidebarTreeNode } from "../types/fileTree";
 import { RestoreError } from "./components/RestoreError";
@@ -406,10 +406,7 @@ function App() {
         )}
       </div>
       {shareScope && (
-        <ShareDialog
-          onClose={() => setShareScope(null)}
-          scope={shareScope}
-        />
+        <ShareDialog onClose={() => setShareScope(null)} scope={shareScope} />
       )}
       <UndoToast />
       <Toast />


### PR DESCRIPTION
## Summary

- add src/runtime WorkspaceRuntime and webWorkspaceRuntime as the first runtime capability boundary
- route host workspace, host-review, and sharing file operations through the runtime barrel instead of importing browser filesystem services directly
- move buildVirtualTree into shared file-tree utilities and update architecture docs for the new runtime layer

## Testing

- npx tsc --noEmit
- npx vitest run src/runtime/webWorkspaceRuntime.test.ts src/services/fileSystem.test.ts src/services/fileTree.test.ts src/modules/workspace/test/tabRestore.test.ts src/modules/host-review/test/addComment.test.ts src/modules/host-review/test/hostReviewActions.test.ts src/modules/sharing/test/storeShareActions.test.ts src/ui/App.test.tsx
- npx eslint src/runtime src/types/fileTree.ts src/services/fileSystem.ts src/modules/workspace/storage.ts src/modules/host-review/controller.ts src/modules/sharing/controller.ts src/ui/App.tsx

Notes:
- yarn test is blocked locally by a parse error in /home/zonzujiro/.yarnrc.yml
- full npx vitest run still has existing unrelated failures in criticmarkup highlight parsing, peer-review discardUnsubmitted, shareSyncRetry relay mock, and relay controller mock setup