### PR TITLE
feat: add agent workflow foundation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,6 +118,17 @@ Owns application-level shell state:
 - focus mode
 - presentation mode
 
+### `agent-workflow`
+
+Owns serializable host-mode agent review run metadata:
+
+- run records
+- active run per tab mapping
+- run lifecycle status
+
+Mutable runner, process, socket, and terminal objects stay in runtime services,
+not in Zustand.
+
 ### `workspace`
 
 Owns host-side file session lifecycle:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -259,6 +259,12 @@ runtime that delegates to the existing browser filesystem implementation. This
 does not add desktop execution yet; it creates the boundary the desktop runtime
 can implement later.
 
+Second implementation note: the next foundation slice adds serializable
+`agent-workflow` run metadata plus web runtime agent and terminal capabilities
+that explicitly report local execution as unavailable. This keeps website
+behavior unchanged while giving desktop runtime work a stable state and
+capability boundary.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src/modules/agent-workflow/README.md
+++ b/src/modules/agent-workflow/README.md
@@ -1,0 +1,27 @@
+# agent-workflow
+
+## Purpose
+
+Owns serializable metadata for host-mode agent review runs.
+
+## Owns
+
+- agent run records
+- active run per tab mapping
+- run lifecycle status metadata
+
+## Does not own
+
+- process handles
+- terminal or PTY objects
+- sockets
+- agent CLI configuration
+- peer-mode review state
+
+## Invariants
+
+- Agent runs are host-mode concepts.
+- Runtime-owned objects stay outside Zustand.
+- A tab has at most one active run in the current model.
+- Web runtime support can expose the same metadata while reporting that local
+  execution is unavailable.

--- a/src/modules/agent-workflow/index.ts
+++ b/src/modules/agent-workflow/index.ts
@@ -1,0 +1,3 @@
+export * from "./selectors";
+export * from "./state";
+export * from "./types";

--- a/src/modules/agent-workflow/selectors.ts
+++ b/src/modules/agent-workflow/selectors.ts
@@ -1,0 +1,32 @@
+import type { AgentRun, AgentWorkflowState } from "./types";
+
+export function getAgentRun(
+  state: AgentWorkflowState,
+  runId: string,
+): AgentRun | null {
+  return state.agentRuns[runId] ?? null;
+}
+
+export function getActiveAgentRunForTab(
+  state: AgentWorkflowState,
+  tabId: string,
+): AgentRun | null {
+  const runId = state.activeAgentRunIdByTabId[tabId];
+  if (!runId) {
+    return null;
+  }
+  return getAgentRun(state, runId);
+}
+
+export function hasActiveAgentRunForTab(
+  state: AgentWorkflowState,
+  tabId: string,
+): boolean {
+  const run = getActiveAgentRunForTab(state, tabId);
+  return Boolean(
+    run &&
+    (run.status === "queued" ||
+      run.status === "running" ||
+      run.status === "needs_attention"),
+  );
+}

--- a/src/modules/agent-workflow/state.ts
+++ b/src/modules/agent-workflow/state.ts
@@ -1,0 +1,163 @@
+import type { StoreApi } from "zustand";
+import type {
+  AgentRun,
+  AgentRunStatus,
+  AgentWorkflowActions,
+  AgentWorkflowState,
+} from "./types";
+
+type SetState<StoreState> = StoreApi<StoreState>["setState"];
+
+const TERMINAL_STATUSES = new Set<AgentRunStatus>([
+  "completed",
+  "failed",
+  "stopped",
+]);
+
+export function createAgentWorkflowState(): AgentWorkflowState {
+  return {
+    agentRuns: {},
+    activeAgentRunIdByTabId: {},
+  };
+}
+
+function createRunId(): string {
+  return crypto.randomUUID();
+}
+
+function isTerminalAgentRunStatus(status: AgentRunStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+function createRun(input: {
+  id: string;
+  tabId: string;
+  taskKind: AgentRun["taskKind"];
+  targetPaths: string[];
+  selectedCommentIds: string[];
+  runnerKind: AgentRun["runnerKind"];
+  createdAt: string;
+}): AgentRun {
+  return {
+    id: input.id,
+    tabId: input.tabId,
+    status: "queued",
+    taskKind: input.taskKind,
+    targetPaths: input.targetPaths,
+    selectedCommentIds: input.selectedCommentIds,
+    createdAt: input.createdAt,
+    completedAt: null,
+    runnerKind: input.runnerKind,
+    terminalAttachmentId: null,
+    errorMessage: null,
+  };
+}
+
+export function createAgentWorkflowActions<
+  StoreState extends AgentWorkflowState,
+>(set: SetState<StoreState>): AgentWorkflowActions {
+  return {
+    createAgentRun: (input) => {
+      const run = createRun({
+        id: createRunId(),
+        tabId: input.tabId,
+        taskKind: input.taskKind,
+        targetPaths: [...input.targetPaths],
+        selectedCommentIds: [...(input.selectedCommentIds ?? [])],
+        runnerKind: input.runnerKind ?? null,
+        createdAt: new Date().toISOString(),
+      });
+
+      set((state) => {
+        const previousRunId = state.activeAgentRunIdByTabId[run.tabId];
+        const nextRuns = { ...state.agentRuns };
+        if (previousRunId) {
+          delete nextRuns[previousRunId];
+        }
+        nextRuns[run.id] = run;
+
+        return {
+          agentRuns: nextRuns,
+          activeAgentRunIdByTabId: {
+            ...state.activeAgentRunIdByTabId,
+            [run.tabId]: run.id,
+          },
+        };
+      });
+
+      return run;
+    },
+
+    updateAgentRunStatus: (input) => {
+      set((state) => {
+        const run = state.agentRuns[input.runId];
+        if (!run) {
+          return {};
+        }
+
+        const updatedRun: AgentRun = {
+          ...run,
+          status: input.status,
+          completedAt: isTerminalAgentRunStatus(input.status)
+            ? new Date().toISOString()
+            : run.completedAt,
+          errorMessage:
+            input.errorMessage !== undefined
+              ? input.errorMessage
+              : run.errorMessage,
+          terminalAttachmentId:
+            input.terminalAttachmentId !== undefined
+              ? input.terminalAttachmentId
+              : run.terminalAttachmentId,
+        };
+
+        return {
+          agentRuns: {
+            ...state.agentRuns,
+            [input.runId]: updatedRun,
+          },
+        };
+      });
+    },
+
+    clearAgentRun: (runId) => {
+      set((state) => {
+        const run = state.agentRuns[runId];
+        if (!run) {
+          return {};
+        }
+
+        const nextRuns = { ...state.agentRuns };
+        delete nextRuns[runId];
+        const nextActiveByTab = { ...state.activeAgentRunIdByTabId };
+        if (nextActiveByTab[run.tabId] === runId) {
+          delete nextActiveByTab[run.tabId];
+        }
+
+        return {
+          agentRuns: nextRuns,
+          activeAgentRunIdByTabId: nextActiveByTab,
+        };
+      });
+    },
+
+    clearTabAgentRun: (tabId) => {
+      set((state) => {
+        const runId = state.activeAgentRunIdByTabId[tabId];
+        if (!runId) {
+          return {};
+        }
+
+        const nextRuns = { ...state.agentRuns };
+        delete nextRuns[runId];
+        const nextActiveByTab = { ...state.activeAgentRunIdByTabId };
+        delete nextActiveByTab[tabId];
+
+        return {
+          agentRuns: nextRuns,
+          activeAgentRunIdByTabId: nextActiveByTab,
+        };
+      });
+    },
+  };
+}

--- a/src/modules/agent-workflow/test/agentWorkflowState.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowState.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../../store";
+import { resetTestStore } from "../../../testing/testHelpers";
+import { getActiveAgentRunForTab, hasActiveAgentRunForTab } from "../selectors";
+
+beforeEach(() => {
+  resetTestStore();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-12T18:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("agent workflow state", () => {
+  it("creates a queued run scoped to one tab", () => {
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "tab-1",
+      taskKind: "address_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["comment-1"],
+      runnerKind: "terminal",
+    });
+
+    const state = useAppStore.getState();
+    expect(run).toMatchObject({
+      tabId: "tab-1",
+      status: "queued",
+      taskKind: "address_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["comment-1"],
+      createdAt: "2026-06-12T18:00:00.000Z",
+      completedAt: null,
+      runnerKind: "terminal",
+      terminalAttachmentId: null,
+      errorMessage: null,
+    });
+    expect(state.agentRuns[run.id]).toEqual(run);
+    expect(state.activeAgentRunIdByTabId["tab-1"]).toBe(run.id);
+    expect(getActiveAgentRunForTab(state, "tab-1")).toEqual(run);
+    expect(hasActiveAgentRunForTab(state, "tab-1")).toBe(true);
+  });
+
+  it("marks terminal statuses as completed", () => {
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "tab-1",
+      taskKind: "answer_questions",
+      targetPaths: ["docs/spec.md"],
+    });
+
+    vi.setSystemTime(new Date("2026-06-12T18:01:00.000Z"));
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "failed",
+      errorMessage: "Agent unavailable",
+    });
+
+    const updatedRun = useAppStore.getState().agentRuns[run.id];
+    expect(updatedRun?.status).toBe("failed");
+    expect(updatedRun?.completedAt).toBe("2026-06-12T18:01:00.000Z");
+    expect(updatedRun?.errorMessage).toBe("Agent unavailable");
+    expect(hasActiveAgentRunForTab(useAppStore.getState(), "tab-1")).toBe(
+      false,
+    );
+  });
+
+  it("replaces the active run for the same tab", () => {
+    const firstRun = useAppStore.getState().createAgentRun({
+      tabId: "tab-1",
+      taskKind: "address_comments",
+      targetPaths: ["docs/first.md"],
+    });
+    const secondRun = useAppStore.getState().createAgentRun({
+      tabId: "tab-1",
+      taskKind: "answer_questions",
+      targetPaths: ["docs/second.md"],
+    });
+
+    const state = useAppStore.getState();
+    expect(state.agentRuns[firstRun.id]).toBeUndefined();
+    expect(state.agentRuns[secondRun.id]).toEqual(secondRun);
+    expect(state.activeAgentRunIdByTabId["tab-1"]).toBe(secondRun.id);
+  });
+
+  it("clears the active run for a tab", () => {
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "tab-1",
+      taskKind: "review_peer_comments",
+      targetPaths: ["docs/spec.md"],
+    });
+
+    useAppStore.getState().clearTabAgentRun("tab-1");
+
+    const state = useAppStore.getState();
+    expect(state.agentRuns[run.id]).toBeUndefined();
+    expect(state.activeAgentRunIdByTabId["tab-1"]).toBeUndefined();
+  });
+});

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -1,0 +1,55 @@
+export type AgentRunStatus =
+  | "queued"
+  | "running"
+  | "needs_attention"
+  | "completed"
+  | "failed"
+  | "stopped";
+
+export type AgentRunTaskKind =
+  | "address_comments"
+  | "answer_questions"
+  | "review_peer_comments";
+
+export type AgentRunnerKind = "terminal" | "codex_app_server";
+
+export interface AgentRun {
+  id: string;
+  tabId: string;
+  status: AgentRunStatus;
+  taskKind: AgentRunTaskKind;
+  targetPaths: string[];
+  selectedCommentIds: string[];
+  createdAt: string;
+  completedAt: string | null;
+  runnerKind: AgentRunnerKind | null;
+  terminalAttachmentId: string | null;
+  errorMessage: string | null;
+}
+
+export interface CreateAgentRunInput {
+  tabId: string;
+  taskKind: AgentRunTaskKind;
+  targetPaths: string[];
+  selectedCommentIds?: string[];
+  runnerKind?: AgentRunnerKind | null;
+}
+
+export interface UpdateAgentRunStatusInput {
+  runId: string;
+  status: AgentRunStatus;
+  errorMessage?: string | null;
+  terminalAttachmentId?: string | null;
+}
+
+export interface AgentWorkflowState {
+  agentRuns: Record<string, AgentRun>;
+  activeAgentRunIdByTabId: Record<string, string>;
+}
+
+export interface AgentWorkflowActions {
+  createAgentRun: (input: CreateAgentRunInput) => AgentRun;
+  updateAgentRunStatus: (input: UpdateAgentRunStatusInput) => void;
+  clearAgentRun: (runId: string) => void;
+  clearTabAgentRun: (tabId: string) => void;
+}

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -1,0 +1,26 @@
+import type {
+  AgentRunTaskKind,
+  AgentRunnerKind,
+} from "../modules/agent-workflow";
+
+export interface AgentRunRequest {
+  tabId: string;
+  taskKind: AgentRunTaskKind;
+  targetPaths: string[];
+  selectedCommentIds: string[];
+  prompt: string;
+  runnerKind: AgentRunnerKind | null;
+}
+
+export interface AgentRuntime {
+  canRunAgent: boolean;
+  startRun(request: AgentRunRequest): Promise<string>;
+  stopRun(runId: string): Promise<void>;
+}
+
+export const webAgentRuntime: AgentRuntime = {
+  canRunAgent: false,
+  startRun: () =>
+    Promise.reject(new Error("Local agent execution is unavailable on web")),
+  stopRun: () => Promise.resolve(),
+};

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,5 +1,9 @@
+import { webAgentRuntime } from "./agent";
+import { webTerminalRuntime } from "./terminal";
 import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
 
+export type { AgentRuntime, AgentRunRequest } from "./agent";
+export type { TerminalAttachment, TerminalRuntime } from "./terminal";
 export type {
   OpenedWorkspaceDirectory,
   OpenedWorkspaceFile,
@@ -7,6 +11,11 @@ export type {
 } from "./workspace";
 
 export const workspaceRuntime = webWorkspaceRuntime;
+export const agentRuntime = webAgentRuntime;
+export const terminalRuntime = webTerminalRuntime;
+
+export const canRunAgent = agentRuntime.canRunAgent;
+export const canShowTerminal = terminalRuntime.canShowTerminal;
 
 export function openFile() {
   return workspaceRuntime.openFile();

--- a/src/runtime/terminal.ts
+++ b/src/runtime/terminal.ts
@@ -1,0 +1,15 @@
+export interface TerminalAttachment {
+  id: string;
+  runId: string;
+}
+
+export interface TerminalRuntime {
+  canShowTerminal: boolean;
+  attach(runId: string): Promise<TerminalAttachment>;
+}
+
+export const webTerminalRuntime: TerminalRuntime = {
+  canShowTerminal: false,
+  attach: () =>
+    Promise.reject(new Error("Terminal sessions are unavailable on web")),
+};

--- a/src/runtime/webAgentRuntime.test.ts
+++ b/src/runtime/webAgentRuntime.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { agentRuntime, canRunAgent, canShowTerminal, terminalRuntime } from ".";
+
+describe("web agent runtime capabilities", () => {
+  it("reports that local agent execution is unavailable on web", async () => {
+    expect(canRunAgent).toBe(false);
+    expect(agentRuntime.canRunAgent).toBe(false);
+
+    await expect(
+      agentRuntime.startRun({
+        tabId: "tab-1",
+        taskKind: "address_comments",
+        targetPaths: ["docs/spec.md"],
+        selectedCommentIds: [],
+        prompt: "Address comments",
+        runnerKind: null,
+      }),
+    ).rejects.toThrow("Local agent execution is unavailable on web");
+  });
+
+  it("reports that terminal attachment is unavailable on web", async () => {
+    expect(canShowTerminal).toBe(false);
+    expect(terminalRuntime.canShowTerminal).toBe(false);
+
+    await expect(terminalRuntime.attach("run-1")).rejects.toThrow(
+      "Terminal sessions are unavailable on web",
+    );
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,14 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import {
+  createAgentWorkflowActions,
+  createAgentWorkflowState,
+} from "../modules/agent-workflow";
+import type {
+  AgentWorkflowActions,
+  AgentWorkflowState,
+} from "../modules/agent-workflow";
+import {
   createAppShellActions,
   createAppShellControllerActions,
   createAppShellState,
@@ -31,9 +39,7 @@ import {
   createSharingControllerActions,
 } from "../modules/sharing";
 import type { SharingActions } from "../modules/sharing";
-import {
-  syncActiveShares as syncActiveSharesService,
-} from "../modules/sharing/sync";
+import { syncActiveShares as syncActiveSharesService } from "../modules/sharing/sync";
 import {
   buildUpdatedActiveTabs,
   buildUpdatedTabs,
@@ -44,10 +50,7 @@ import {
   getLiveFileTree,
   loadWorkspaceHistory,
 } from "../modules/workspace";
-import type {
-  WorkspaceActions,
-  WorkspaceState,
-} from "../modules/workspace";
+import type { WorkspaceActions, WorkspaceState } from "../modules/workspace";
 import { toPersistedTree } from "../types/fileTree";
 import type {
   HydratedSidebarTreeNode,
@@ -61,7 +64,10 @@ import type { ShareRecord } from "../types/share";
 const SHARES_KEY = "markreview-shares";
 
 interface AppState
-  extends AppShellState,
+  extends
+    AgentWorkflowState,
+    AgentWorkflowActions,
+    AppShellState,
     AppShellActions,
     WorkspaceState,
     WorkspaceActions,
@@ -179,6 +185,7 @@ export const useAppStore = create<AppState>()(
 
       return {
         ...createWorkspaceState(loadWorkspaceHistory()),
+        ...createAgentWorkflowState(),
         ...createAppShellState(),
         ...createRelayState(),
         ...createPeerReviewState(),
@@ -189,6 +196,9 @@ export const useAppStore = create<AppState>()(
 
         ...workspaceActions,
         ...workspaceControllerActions,
+
+        // ── Agent workflow metadata ───────────────────────────────────────
+        ...createAgentWorkflowActions(set),
 
         // ── Tab-scoped actions ──────────────────────────────────────────────
         ...hostReviewActions,
@@ -330,10 +340,12 @@ export const useAppStore = create<AppState>()(
           : current.tabs;
         const relayDefaults = createRelayState();
         const peerReviewDefaults = createPeerReviewState();
+        const agentWorkflowDefaults = createAgentWorkflowState();
         return {
           ...current,
           ...p,
           tabs,
+          ...agentWorkflowDefaults,
           ...peerReviewDefaults,
           submittedPeerCommentIds: Array.isArray(p.submittedPeerCommentIds)
             ? p.submittedPeerCommentIds

--- a/src/testing/testHelpers.ts
+++ b/src/testing/testHelpers.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from "../store";
+import { createAgentWorkflowState } from "../modules/agent-workflow";
 import { createAppShellState } from "../modules/app-shell";
 import { createPeerReviewState } from "../modules/peer-review";
 import { createRelayState } from "../modules/relay";
@@ -90,12 +91,14 @@ export function makePeerComment(
  */
 export function resetTestStore() {
   const appShellState = createAppShellState();
+  const agentWorkflowState = createAgentWorkflowState();
   const peerReviewState = createPeerReviewState();
   const relayState = createRelayState();
   useAppStore.setState({
     tabs: [],
     activeTabId: null,
     ...appShellState,
+    ...agentWorkflowState,
     ...peerReviewState,
     history: [],
     historyDropdownOpen: false,


### PR DESCRIPTION
## Summary

- add an agent-workflow module for serializable host-mode agent run metadata
- add web agent and terminal runtime capability stubs that explicitly report local execution as unavailable
- reset agent workflow test state and document the new module/runtime foundation

## Testing

- npx tsc --noEmit
- npx vitest run src/modules/agent-workflow/test/agentWorkflowState.test.ts src/runtime/webAgentRuntime.test.ts src/runtime/webWorkspaceRuntime.test.ts src/ui/App.test.tsx
- npx eslint src/modules/agent-workflow src/runtime src/store/index.ts src/testing/testHelpers.ts

Notes:
- touched-file eslint reports one existing store warning: src/store/index.ts no-unsafe-assignment at persisted tabs migration
- yarn remains blocked locally by /home/zonzujiro/.yarnrc.yml parse error