### PR TITLE
refactor: gate agent prompt UI by capability

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -265,6 +265,12 @@ that explicitly report local execution as unavailable. This keeps website
 behavior unchanged while giving desktop runtime work a stable state and
 capability boundary.
 
+UI capability note: the comment-panel threaded-question action now resolves
+through an agent action capability helper. In the web runtime it remains the
+existing "Copy agent prompt" action. Future desktop work can switch the same
+surface to "Ask agent" only after both local agent execution and the
+question-thread run handler are available.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src/ui/agentActions.test.ts
+++ b/src/ui/agentActions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getQuestionThreadAgentAction } from "./agentActions";
+
+describe("getQuestionThreadAgentAction", () => {
+  it("uses copy-prompt mode when local agent execution is unavailable", () => {
+    expect(
+      getQuestionThreadAgentAction({
+        canRunAgent: false,
+        canStartQuestionThreadRun: false,
+      }),
+    ).toEqual({
+      kind: "copy_prompt",
+      label: "Copy agent prompt",
+      title: "Copy instructions for answering threaded questions",
+    });
+  });
+
+  it("uses copy-prompt mode until question-thread runs are wired", () => {
+    expect(
+      getQuestionThreadAgentAction({
+        canRunAgent: true,
+        canStartQuestionThreadRun: false,
+      }).kind,
+    ).toBe("copy_prompt");
+  });
+
+  it("uses run-agent mode when both capabilities are available", () => {
+    expect(
+      getQuestionThreadAgentAction({
+        canRunAgent: true,
+        canStartQuestionThreadRun: true,
+      }),
+    ).toEqual({
+      kind: "run_agent",
+      label: "Ask agent",
+      title: "Ask the local agent to answer threaded questions",
+    });
+  });
+});

--- a/src/ui/agentActions.ts
+++ b/src/ui/agentActions.ts
@@ -1,0 +1,30 @@
+export type QuestionThreadAgentActionKind = "copy_prompt" | "run_agent";
+
+export interface QuestionThreadAgentAction {
+  kind: QuestionThreadAgentActionKind;
+  label: string;
+  title: string;
+}
+
+export interface AgentActionCapabilities {
+  canRunAgent: boolean;
+  canStartQuestionThreadRun: boolean;
+}
+
+export function getQuestionThreadAgentAction(
+  capabilities: AgentActionCapabilities,
+): QuestionThreadAgentAction {
+  if (capabilities.canRunAgent && capabilities.canStartQuestionThreadRun) {
+    return {
+      kind: "run_agent",
+      label: "Ask agent",
+      title: "Ask the local agent to answer threaded questions",
+    };
+  }
+
+  return {
+    kind: "copy_prompt",
+    label: "Copy agent prompt",
+    title: "Copy instructions for answering threaded questions",
+  };
+}

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -4,11 +4,13 @@ import {
   buildAgentReplyPrompt,
   buildCommentThreadGroups,
 } from "../../../markup";
+import { canRunAgent } from "../../../runtime";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
 import type { Comment, CommentType } from "../../../types/criticmarkup";
 import type { PeerComment } from "../../../types/share";
+import { getQuestionThreadAgentAction } from "../../agentActions";
 
 const ALL_TYPES: CommentType[] = [
   "fix",
@@ -110,7 +112,10 @@ interface Props {
 export function CommentPanel({ peerMode = false }: Props) {
   const tab = useActiveTab();
   const comments = tab?.comments ?? [];
-  const hostRootComments = useMemo(() => getRootOnlyComments(comments), [comments]);
+  const hostRootComments = useMemo(
+    () => getRootOnlyComments(comments),
+    [comments],
+  );
   const resolvedComments = tab?.resolvedComments ?? [];
   const activeCommentId = tab?.activeCommentId ?? null;
   const activeRootCommentId = useMemo(
@@ -315,7 +320,9 @@ export function CommentPanel({ peerMode = false }: Props) {
   }
 
   useEffect(() => {
-    const activePanelCommentId = peerMode ? activeCommentId : activeRootCommentId;
+    const activePanelCommentId = peerMode
+      ? activeCommentId
+      : activeRootCommentId;
     if (!activePanelCommentId) {
       return;
     }
@@ -333,6 +340,10 @@ export function CommentPanel({ peerMode = false }: Props) {
       : sourceComments.length;
   const showTypeFilters = !isResolved && activeTypes.length > 1;
   const showStatusFilters = !peerMode && resolvedComments.length > 0;
+  const questionThreadAgentAction = getQuestionThreadAgentAction({
+    canRunAgent,
+    canStartQuestionThreadRun: false,
+  });
 
   return (
     <aside className="comment-panel" aria-label="Comments">
@@ -351,9 +362,9 @@ export function CommentPanel({ peerMode = false }: Props) {
                 onClick={() => {
                   void handleCopyAgentPrompt();
                 }}
-                title="Copy instructions for answering threaded questions"
+                title={questionThreadAgentAction.title}
               >
-                Copy agent prompt
+                {questionThreadAgentAction.label}
               </button>
             )}
             <button


### PR DESCRIPTION
## Summary

- add a UI helper that chooses copy-prompt vs future run-agent mode from runtime capabilities
- wire CommentPanel threaded-question action through the helper while preserving web Copy agent prompt behavior
- document the UI capability gate in the desktop runtime architecture note

## Testing

- npx tsc --noEmit
- npx vitest run src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx src/runtime/webAgentRuntime.test.ts src/ui/App.test.tsx
- npx eslint src/ui/agentActions.ts src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.tsx docs/design/desktop-runtime-agent-architecture.md

Notes:
- touched-file eslint reports existing CommentPanel warnings and an ignored markdown config warning only
- yarn remains blocked locally by /home/zonzujiro/.yarnrc.yml parse error