### PR TITLE
Add question thread agent run action

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,6 +125,7 @@ Owns serializable host-mode agent review run metadata:
 - run records
 - active run per tab mapping
 - run lifecycle status
+- active-file question-thread run request orchestration
 
 Mutable runner, process, socket, and terminal objects stay in runtime services,
 not in Zustand.

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -259,6 +259,13 @@ runtime that delegates to the existing browser filesystem implementation. This
 does not add desktop execution yet; it creates the boundary the desktop runtime
 can implement later.
 
+Agent workflow implementation note: `src/modules/agent-workflow/` now owns
+serializable run metadata and a controller action for active-file threaded
+questions. The action builds an `AgentRunRequest` with one tab, one target path,
+and explicit question thread ids. The web runtime still reports
+`canRunAgent: false`, so the website keeps the copy-prompt path until a desktop
+runtime provides an executable `AgentRuntime`.
+
 Second implementation note: the next foundation slice adds serializable
 `agent-workflow` run metadata plus web runtime agent and terminal capabilities
 that explicitly report local execution as unavailable. This keeps website

--- a/src/modules/agent-workflow/README.md
+++ b/src/modules/agent-workflow/README.md
@@ -3,12 +3,15 @@
 ## Purpose
 
 Owns serializable metadata for host-mode agent review runs.
+Also owns the host-mode controller action that turns Dragon UI intent into a
+narrow agent run request.
 
 ## Owns
 
 - agent run records
 - active run per tab mapping
 - run lifecycle status metadata
+- active-file question-thread run request construction
 
 ## Does not own
 
@@ -17,6 +20,7 @@ Owns serializable metadata for host-mode agent review runs.
 - sockets
 - agent CLI configuration
 - peer-mode review state
+- broad folder/workspace agent prompting
 
 ## Invariants
 
@@ -25,3 +29,13 @@ Owns serializable metadata for host-mode agent review runs.
 - A tab has at most one active run in the current model.
 - Web runtime support can expose the same metadata while reporting that local
   execution is unavailable.
+- The first executable action is scoped to the active tab's active file and
+  threaded `question:` comments only.
+
+## Public API
+
+- `createAgentWorkflowActions` creates serializable run metadata actions.
+- `createAgentWorkflowControllerActions` creates side-effecting run start
+  actions backed by the active `AgentRuntime`.
+- `buildQuestionThreadAgentRunRequest` builds the narrow request passed to the
+  runtime for answering active-file question threads.

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -1,0 +1,162 @@
+import type { StoreApi } from "zustand";
+import { buildAgentReplyPrompt, buildCommentThreadGroups } from "../../markup";
+import { agentRuntime } from "../../runtime";
+import type { AgentRuntime, AgentRunRequest } from "../../runtime";
+import type { Comment } from "../../types/criticmarkup";
+import type { TabState } from "../../types/tab";
+import type {
+  AgentRunStartUnavailableReason,
+  AgentRunStartResult,
+  AgentWorkflowActions,
+  AgentWorkflowControllerActions,
+  AgentWorkflowState,
+} from "./types";
+
+type GetState<StoreState> = StoreApi<StoreState>["getState"];
+
+interface AgentWorkflowControllerStoreState
+  extends AgentWorkflowState, AgentWorkflowActions {}
+
+interface AgentWorkflowControllerDeps<
+  StoreState extends AgentWorkflowControllerStoreState,
+> {
+  get: GetState<StoreState>;
+  getActiveTab: (get: () => StoreState) => TabState | null;
+  showToast: (message: string) => void;
+  runtime?: AgentRuntime;
+}
+
+interface QuestionThreadRunContext {
+  tabId: string;
+  targetPath: string;
+  questionCommentIds: string[];
+}
+
+export function getQuestionThreadCommentIds(comments: Comment[]): string[] {
+  return buildCommentThreadGroups(comments)
+    .filter((group) => group.root.type === "question" && !!group.root.thread)
+    .map((group) => group.root.thread?.commentId ?? group.root.id);
+}
+
+function getAgentTargetPath(tab: TabState): string | null {
+  return tab.activeFilePath ?? tab.fileName;
+}
+
+export function buildQuestionThreadAgentRunRequest(
+  context: QuestionThreadRunContext,
+): AgentRunRequest {
+  const questionList = context.questionCommentIds
+    .map((commentId) => `- ${commentId}`)
+    .join("\n");
+
+  return {
+    tabId: context.tabId,
+    taskKind: "answer_questions",
+    targetPaths: [context.targetPath],
+    selectedCommentIds: [...context.questionCommentIds],
+    runnerKind: "terminal",
+    prompt: `${buildAgentReplyPrompt()}
+
+Scope:
+- Work only in ${context.targetPath}.
+- Answer only these MarkReview question thread ids:
+${questionList}
+- Do not edit unrelated files or unrelated comments.`,
+  };
+}
+
+function unavailableResult(input: {
+  reason: AgentRunStartUnavailableReason;
+  message: string;
+}): AgentRunStartResult {
+  return {
+    status: "unavailable",
+    reason: input.reason,
+    message: input.message,
+  };
+}
+
+export function createAgentWorkflowControllerActions<
+  StoreState extends AgentWorkflowControllerStoreState,
+>(
+  deps: AgentWorkflowControllerDeps<StoreState>,
+): AgentWorkflowControllerActions {
+  const runtime = deps.runtime ?? agentRuntime;
+
+  return {
+    startQuestionThreadAgentRun: async () => {
+      if (!runtime.canRunAgent) {
+        return unavailableResult({
+          reason: "agent_unavailable",
+          message: "Local agent execution is unavailable in this runtime.",
+        });
+      }
+
+      const tab = deps.getActiveTab(deps.get);
+      if (!tab) {
+        return unavailableResult({
+          reason: "no_active_tab",
+          message: "Open a file or folder before starting an agent run.",
+        });
+      }
+
+      const targetPath = getAgentTargetPath(tab);
+      if (!targetPath) {
+        return unavailableResult({
+          reason: "no_active_file",
+          message: "Select a markdown file before starting an agent run.",
+        });
+      }
+
+      const questionCommentIds = getQuestionThreadCommentIds(tab.comments);
+      if (questionCommentIds.length === 0) {
+        return unavailableResult({
+          reason: "no_question_threads",
+          message: "No threaded questions are available for the active file.",
+        });
+      }
+
+      const request = buildQuestionThreadAgentRunRequest({
+        tabId: tab.id,
+        targetPath,
+        questionCommentIds,
+      });
+      const run = deps.get().createAgentRun({
+        tabId: request.tabId,
+        taskKind: request.taskKind,
+        targetPaths: request.targetPaths,
+        selectedCommentIds: request.selectedCommentIds,
+        runnerKind: request.runnerKind,
+      });
+
+      try {
+        const runtimeRunId = await runtime.startRun(request);
+        deps.get().updateAgentRunStatus({
+          runId: run.id,
+          status: "running",
+          terminalAttachmentId: runtimeRunId,
+        });
+        deps.showToast("Agent run started");
+        return {
+          status: "started",
+          run,
+          runtimeRunId,
+        };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Agent run failed to start";
+        console.error("[agent-workflow] failed to start agent run:", error);
+        deps.get().updateAgentRunStatus({
+          runId: run.id,
+          status: "failed",
+          errorMessage: message,
+        });
+        deps.showToast("Agent run failed to start");
+        return unavailableResult({
+          reason: "agent_unavailable",
+          message,
+        });
+      }
+    },
+  };
+}

--- a/src/modules/agent-workflow/index.ts
+++ b/src/modules/agent-workflow/index.ts
@@ -1,3 +1,4 @@
+export * from "./controller";
 export * from "./selectors";
 export * from "./state";
 export * from "./types";

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "../../../store";
+import { getActiveTab } from "../../../store/selectors";
+import {
+  makeComment,
+  resetTestStore,
+  setTestState,
+} from "../../../testing/testHelpers";
+import type { AgentRuntime, AgentRunRequest } from "../../../runtime";
+import {
+  buildQuestionThreadAgentRunRequest,
+  createAgentWorkflowControllerActions,
+  getQuestionThreadCommentIds,
+} from "../controller";
+
+beforeEach(() => {
+  resetTestStore();
+});
+
+describe("question thread agent run context", () => {
+  it("selects question thread roots by MarkReview comment id", () => {
+    const commentIds = getQuestionThreadCommentIds([
+      makeComment({
+        id: "question-root",
+        type: "question",
+        thread: {
+          commentId: "mr-question-1",
+          threadId: "mr-question-1",
+        },
+      }),
+      makeComment({
+        id: "answer-reply",
+        type: "answer",
+        thread: {
+          commentId: "mr-answer-1",
+          threadId: "mr-question-1",
+          replyTo: "mr-question-1",
+        },
+      }),
+      makeComment({
+        id: "plain-note",
+        type: "note",
+      }),
+    ]);
+
+    expect(commentIds).toEqual(["mr-question-1"]);
+  });
+
+  it("builds a narrow active-file request for answering questions", () => {
+    const request = buildQuestionThreadAgentRunRequest({
+      tabId: "tab-1",
+      targetPath: "docs/spec.md",
+      questionCommentIds: ["mr-question-1", "mr-question-2"],
+    });
+
+    expect(request).toMatchObject({
+      tabId: "tab-1",
+      taskKind: "answer_questions",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["mr-question-1", "mr-question-2"],
+      runnerKind: "terminal",
+    });
+    expect(request.prompt).toContain("Work only in docs/spec.md");
+    expect(request.prompt).toContain("- mr-question-1");
+    expect(request.prompt).toContain("- mr-question-2");
+    expect(request.prompt).toContain("Do not edit unrelated files");
+  });
+});
+
+describe("question thread agent run controller", () => {
+  it("returns unavailable without creating a run in the web runtime", async () => {
+    setTestState({
+      fileName: "spec.md",
+      comments: [
+        makeComment({
+          type: "question",
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+      ],
+    });
+
+    const result = await useAppStore.getState().startQuestionThreadAgentRun();
+
+    expect(result).toEqual({
+      status: "unavailable",
+      reason: "agent_unavailable",
+      message: "Local agent execution is unavailable in this runtime.",
+    });
+    expect(useAppStore.getState().agentRuns).toEqual({});
+  });
+
+  it("creates a run and starts the injected runtime", async () => {
+    const requests: AgentRunRequest[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: (request) => {
+        requests.push(request);
+        return Promise.resolve("terminal-session-1");
+      },
+      stopRun: () => Promise.resolve(),
+    };
+    const showToastMessages: string[] = [];
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: (message) => {
+        showToastMessages.push(message);
+      },
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+      activeFilePath: "docs/spec.md",
+      comments: [
+        makeComment({
+          type: "question",
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+      ],
+    });
+
+    const result = await actions.startQuestionThreadAgentRun();
+
+    expect(result.status).toBe("started");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      tabId: "test-tab",
+      taskKind: "answer_questions",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["mr-question-1"],
+    });
+    const state = useAppStore.getState();
+    const runId = state.activeAgentRunIdByTabId["test-tab"];
+    const run = runId ? state.agentRuns[runId] : null;
+    expect(run).toMatchObject({
+      tabId: "test-tab",
+      status: "running",
+      taskKind: "answer_questions",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["mr-question-1"],
+      runnerKind: "terminal",
+      terminalAttachmentId: "terminal-session-1",
+    });
+    expect(showToastMessages).toEqual(["Agent run started"]);
+  });
+});

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -53,3 +53,25 @@ export interface AgentWorkflowActions {
   clearAgentRun: (runId: string) => void;
   clearTabAgentRun: (tabId: string) => void;
 }
+
+export type AgentRunStartUnavailableReason =
+  | "agent_unavailable"
+  | "no_active_tab"
+  | "no_active_file"
+  | "no_question_threads";
+
+export type AgentRunStartResult =
+  | {
+      status: "started";
+      run: AgentRun;
+      runtimeRunId: string;
+    }
+  | {
+      status: "unavailable";
+      reason: AgentRunStartUnavailableReason;
+      message: string;
+    };
+
+export interface AgentWorkflowControllerActions {
+  startQuestionThreadAgentRun: () => Promise<AgentRunStartResult>;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,10 +2,12 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import {
   createAgentWorkflowActions,
+  createAgentWorkflowControllerActions,
   createAgentWorkflowState,
 } from "../modules/agent-workflow";
 import type {
   AgentWorkflowActions,
+  AgentWorkflowControllerActions,
   AgentWorkflowState,
 } from "../modules/agent-workflow";
 import {
@@ -67,6 +69,7 @@ interface AppState
   extends
     AgentWorkflowState,
     AgentWorkflowActions,
+    AgentWorkflowControllerActions,
     AppShellState,
     AppShellActions,
     WorkspaceState,
@@ -182,6 +185,13 @@ export const useAppStore = create<AppState>()(
         get,
       );
       const relayActions = createRelayActions(set);
+      const agentWorkflowActions = createAgentWorkflowActions(set);
+      const agentWorkflowControllerActions =
+        createAgentWorkflowControllerActions({
+          get,
+          getActiveTab: activeTab,
+          showToast: appShellActions.showToast,
+        });
 
       return {
         ...createWorkspaceState(loadWorkspaceHistory()),
@@ -198,7 +208,8 @@ export const useAppStore = create<AppState>()(
         ...workspaceControllerActions,
 
         // ── Agent workflow metadata ───────────────────────────────────────
-        ...createAgentWorkflowActions(set),
+        ...agentWorkflowActions,
+        ...agentWorkflowControllerActions,
 
         // ── Tab-scoped actions ──────────────────────────────────────────────
         ...hostReviewActions,


### PR DESCRIPTION
## Summary
- add an agent-workflow controller action for active-file threaded question runs
- build narrow AgentRunRequest payloads with tab, target path, and question thread ids
- keep web runtime behavior unavailable while documenting the controller boundary

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/runtime/webAgentRuntime.test.ts src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx
- npx eslint src/modules/agent-workflow/controller.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/index.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/store/index.ts (existing store warning only)