### PR TITLE
Wire question thread agent action

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -272,11 +272,11 @@ that explicitly report local execution as unavailable. This keeps website
 behavior unchanged while giving desktop runtime work a stable state and
 capability boundary.
 
-UI capability note: the comment-panel threaded-question action now resolves
-through an agent action capability helper. In the web runtime it remains the
-existing "Copy agent prompt" action. Future desktop work can switch the same
-surface to "Ask agent" only after both local agent execution and the
-question-thread run handler are available.
+UI capability note: the comment-panel threaded-question action resolves through
+an agent action capability helper. In the web runtime it remains the existing
+"Copy agent prompt" action. When a desktop runtime reports local agent
+execution, the same surface becomes "Ask agent" and calls the
+question-thread run controller action.
 
 ## Risks
 

--- a/src/ui/agentActions.test.ts
+++ b/src/ui/agentActions.test.ts
@@ -15,7 +15,7 @@ describe("getQuestionThreadAgentAction", () => {
     });
   });
 
-  it("uses copy-prompt mode until question-thread runs are wired", () => {
+  it("uses copy-prompt mode when question-thread runs are unavailable", () => {
     expect(
       getQuestionThreadAgentAction({
         canRunAgent: true,

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -141,6 +141,9 @@ export function CommentPanel({ peerMode = false }: Props) {
   const editPeerComment = useAppStore((state) => state.editPeerComment);
   const deletePeerComment = useAppStore((state) => state.deletePeerComment);
   const selectPeerFile = useAppStore((state) => state.selectPeerFile);
+  const startQuestionThreadAgentRun = useAppStore(
+    (state) => state.startQuestionThreadAgentRun,
+  );
   const sharedContent = useAppStore((state) => state.sharedContent);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
 
@@ -319,6 +322,23 @@ export function CommentPanel({ peerMode = false }: Props) {
     }
   }
 
+  const questionThreadAgentAction = getQuestionThreadAgentAction({
+    canRunAgent,
+    canStartQuestionThreadRun: true,
+  });
+
+  async function handleQuestionThreadAgentAction() {
+    if (questionThreadAgentAction.kind === "copy_prompt") {
+      await handleCopyAgentPrompt();
+      return;
+    }
+
+    const result = await startQuestionThreadAgentRun();
+    if (result.status === "unavailable") {
+      showToast(result.message);
+    }
+  }
+
   useEffect(() => {
     const activePanelCommentId = peerMode
       ? activeCommentId
@@ -340,10 +360,6 @@ export function CommentPanel({ peerMode = false }: Props) {
       : sourceComments.length;
   const showTypeFilters = !isResolved && activeTypes.length > 1;
   const showStatusFilters = !peerMode && resolvedComments.length > 0;
-  const questionThreadAgentAction = getQuestionThreadAgentAction({
-    canRunAgent,
-    canStartQuestionThreadRun: false,
-  });
 
   return (
     <aside className="comment-panel" aria-label="Comments">
@@ -360,7 +376,7 @@ export function CommentPanel({ peerMode = false }: Props) {
               <button
                 className="comment-panel__secondary-action"
                 onClick={() => {
-                  void handleCopyAgentPrompt();
+                  void handleQuestionThreadAgentAction();
                 }}
                 title={questionThreadAgentAction.title}
               >


### PR DESCRIPTION
## Summary
- route the CommentPanel threaded-question button through the capability action
- keep web behavior as Copy agent prompt while allowing desktop runtimes to call startQuestionThreadAgentRun
- update the desktop runtime design note for the now-wired UI action

## Verification
- npx tsc --noEmit
- npx vitest run src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx src/modules/agent-workflow/test/agentWorkflowController.test.ts
- npx eslint src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/modules/agent-workflow/controller.ts (existing CommentPanel warnings only)