### PR TITLE
Add Tauri desktop shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules
 dist
 dist-ssr
 *.local
+src-tauri/target
 
 # Yarn Berry
 .yarn/cache

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,7 @@ Shared module shape:
 Lower-level reusable code lives outside modules:
 
 - `src/runtime/`: runtime capability boundaries and active runtime adapters
+- `src-tauri/`: native desktop shell configuration and Rust entrypoint
 - `src/services/`: browser, network, crypto, and file-system adapters
 - `src/markup/`: CriticMarkup parsing and editing helpers
 - `src/types/`: shared application types
@@ -129,6 +130,13 @@ Owns serializable host-mode agent review run metadata:
 
 Mutable runner, process, socket, and terminal objects stay in runtime services,
 not in Zustand.
+
+### Desktop Shell
+
+The Tauri shell under `src-tauri/` loads the same React app as the website. It is
+the native container for future filesystem, watcher, terminal, and agent runtime
+adapters. The website runtime remains the default `src/runtime/` export until a
+desktop-specific runtime entrypoint is added.
 
 ### `workspace`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Comments live directly in the markdown using CriticMarkup syntax, so any LLM can
 
 **Peer mode** (viewing shared links): any modern browser.
 
+**Desktop shell**: Rust and the platform prerequisites required by Tauri v2. The
+desktop shell runs the same React app inside a native window and is currently
+the foundation for future native filesystem and agent runtime adapters.
+
 ## Getting started
 
 ```bash
@@ -40,16 +44,18 @@ VITE_WORKER_URL=https://your-worker.dev yarn dev
 
 ## Scripts
 
-| Command | Description |
-|---------|-------------|
-| `yarn dev` | Start the Vite dev server |
-| `yarn build` | Type-check and build for production |
-| `yarn preview` | Preview the production build locally |
-| `yarn test` | Run all tests once |
-| `yarn test:watch` | Run tests in watch mode |
-| `yarn test:coverage` | Run tests with coverage |
-| `yarn lint` | Run ESLint |
-| `yarn deploy:worker` | Deploy the Cloudflare Worker |
+| Command              | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `yarn dev`           | Start the Vite dev server                    |
+| `yarn desktop:dev`   | Start the Tauri desktop shell in development |
+| `yarn desktop:build` | Build the Tauri desktop app                  |
+| `yarn build`         | Type-check and build for production          |
+| `yarn preview`       | Preview the production build locally         |
+| `yarn test`          | Run all tests once                           |
+| `yarn test:watch`    | Run tests in watch mode                      |
+| `yarn test:coverage` | Run tests with coverage                      |
+| `yarn lint`          | Run ESLint                                   |
+| `yarn deploy:worker` | Deploy the Cloudflare Worker                 |
 
 ## Project structure
 
@@ -70,17 +76,17 @@ docs/                 Contributing guide, feature specs, and architecture notes
 
 ## Tech stack
 
-| Layer | Technology |
-|-------|-----------|
-| UI | React 19, TypeScript |
-| Build | Vite 6 |
-| State | Zustand 5 with persist middleware |
-| Markdown | react-markdown, remark-gfm, unified |
-| Syntax highlighting | Shiki 4 |
-| Diagrams | Mermaid 11 |
-| Testing | Vitest, Testing Library |
-| Sharing backend | Cloudflare Worker + KV + SQLite-backed Durable Objects |
-| Deployment | GitHub Pages (static), Cloudflare Worker (API) |
+| Layer               | Technology                                             |
+| ------------------- | ------------------------------------------------------ |
+| UI                  | React 19, TypeScript                                   |
+| Build               | Vite 6                                                 |
+| State               | Zustand 5 with persist middleware                      |
+| Markdown            | react-markdown, remark-gfm, unified                    |
+| Syntax highlighting | Shiki 4                                                |
+| Diagrams            | Mermaid 11                                             |
+| Testing             | Vitest, Testing Library                                |
+| Sharing backend     | Cloudflare Worker + KV + SQLite-backed Durable Objects |
+| Deployment          | GitHub Pages (static), Cloudflare Worker (API)         |
 
 ## Architecture
 
@@ -110,9 +116,9 @@ No accounts, no plaintext on the server. The Worker sees encrypted payloads and 
 
 ## Environment variables
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `VITE_WORKER_URL` | No | Cloudflare Worker URL. If unset, sharing features are hidden. |
+| Variable          | Required | Description                                                   |
+| ----------------- | -------- | ------------------------------------------------------------- |
+| `VITE_WORKER_URL` | No       | Cloudflare Worker URL. If unset, sharing features are hidden. |
 
 ## License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -5,12 +5,14 @@
 - Node.js 18+
 - Yarn 4 (`corepack enable && corepack prepare yarn@4.12.0`)
 - Chrome or Edge (for testing host mode — requires File System Access API over HTTPS/localhost)
+- Rust and Tauri v2 platform prerequisites for desktop shell development
 
 ## Setup
 
 ```bash
 yarn install
 yarn dev          # starts dev server at http://localhost:5173
+yarn desktop:dev  # starts the Tauri desktop shell
 ```
 
 To enable sharing features locally:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -278,6 +278,12 @@ an agent action capability helper. In the web runtime it remains the existing
 execution, the same surface becomes "Ask agent" and calls the
 question-thread run controller action.
 
+Desktop shell implementation note: `src-tauri/` now contains the first Tauri v2
+native shell. It loads the existing Vite app in a native window and adds
+`desktop:dev` / `desktop:build` scripts. This does not yet replace browser file
+APIs or add native agent execution; it creates the desktop container those
+runtime adapters will plug into.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "packageManager": "yarn@4.12.0",
   "scripts": {
     "dev": "vite",
+    "desktop:build": "npx --yes @tauri-apps/cli@2.11.2 build",
+    "desktop:dev": "npx --yes @tauri-apps/cli@2.11.2 dev",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "lollipop-dragon"
+version = "0.0.0"
+description = "Desktop shell for Lollipop Dragon"
+authors = ["Lollipop Dragon"]
+license = "private"
+repository = ""
+edition = "2021"
+
+[lib]
+name = "lollipop_dragon_lib"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+tauri = { version = "2", features = [] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default desktop window permissions",
+  "windows": ["main"],
+  "permissions": ["core:default"]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,0 +1,6 @@
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running Lollipop Dragon");
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    lollipop_dragon_lib::run()
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Lollipop Dragon",
+  "version": "0.0.0",
+  "identifier": "ink.critiq.lollipopdragon",
+  "build": {
+    "beforeDevCommand": "npm run dev -- --host 127.0.0.1",
+    "devUrl": "http://127.0.0.1:5173",
+    "beforeBuildCommand": "npm run build",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "Lollipop Dragon",
+        "width": 1280,
+        "height": 860,
+        "minWidth": 900,
+        "minHeight": 640
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all"
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal Tauri v2 desktop shell under src-tauri
- add desktop:dev and desktop:build scripts that invoke the pinned Tauri CLI through npx
- document desktop prerequisites and clarify that native runtime adapters are still future slices

## Verification
- npx tsc --noEmit
- npx --yes @tauri-apps/cli@2.11.2 --version
- npx --yes @tauri-apps/cli@2.11.2 info (config recognized; WSL image is missing Rust/Cargo, webkit2gtk-4.1, and rsvg2)
- package.json, src-tauri/tauri.conf.json, and src-tauri/capabilities/default.json parse as JSON

## Notes
- Native desktop build was not run in this WSL environment because Tauri prerequisites are not installed here.
- npm run build currently fails on existing project-wide TypeScript/build errors unrelated to this shell scaffold.