### PR TITLE
Add Tauri command bridge

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,6 +138,11 @@ the native container for future filesystem, watcher, terminal, and agent runtime
 adapters. The website runtime remains the default `src/runtime/` export until a
 desktop-specific runtime entrypoint is added.
 
+The bridge from the frontend to native commands lives in
+`src/runtime/tauriBridge.ts`. It uses Tauri v2's global `window.__TAURI__.core`
+API, which is enabled only by the desktop shell config. Web execution therefore
+continues to reject desktop command calls instead of importing native APIs.
+
 ### `workspace`
 
 Owns host-side file session lifecycle:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -284,6 +284,11 @@ native shell. It loads the existing Vite app in a native window and adds
 APIs or add native agent execution; it creates the desktop container those
 runtime adapters will plug into.
 
+Tauri command bridge note: the desktop shell enables Tauri's global API and
+registers initial `dragon_runtime_ping` and `dragon_agent_runtime_available`
+commands. `src/runtime/tauriBridge.ts` is the frontend boundary for invoking
+those commands while still rejecting cleanly in the website runtime.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,20 @@
+#[tauri::command]
+fn dragon_runtime_ping() -> &'static str {
+    "ok"
+}
+
+#[tauri::command]
+fn dragon_agent_runtime_available() -> bool {
+    false
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            dragon_runtime_ping,
+            dragon_agent_runtime_available
+        ])
         .run(tauri::generate_context!())
         .expect("error while running Lollipop Dragon");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getTauriAgentRuntimeAvailable,
+  hasTauriBridge,
+  invokeTauriCommand,
+  pingTauriRuntime,
+} from "./tauriBridge";
+
+beforeEach(() => {
+  window.__TAURI__ = undefined;
+});
+
+describe("tauri bridge", () => {
+  it("reports unavailable outside the desktop shell", async () => {
+    expect(hasTauriBridge()).toBe(false);
+
+    await expect(
+      invokeTauriCommand({ command: "dragon_runtime_ping" }),
+    ).rejects.toThrow("Tauri runtime bridge is unavailable");
+  });
+
+  it("invokes desktop commands through the global Tauri core API", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
+    window.__TAURI__ = {
+      core: {
+        invoke: (command, args) => {
+          calls.push({ command, args });
+          return Promise.resolve("ok");
+        },
+      },
+    };
+
+    await expect(pingTauriRuntime()).resolves.toBe("ok");
+    expect(hasTauriBridge()).toBe(true);
+    expect(calls).toEqual([
+      {
+        command: "dragon_runtime_ping",
+        args: undefined,
+      },
+    ]);
+  });
+
+  it("reads the desktop agent capability command", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () => Promise.resolve(false),
+      },
+    };
+
+    await expect(getTauriAgentRuntimeAvailable()).resolves.toBe(false);
+  });
+
+  it("rejects unexpected command response shapes", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () => Promise.resolve("nope"),
+      },
+    };
+
+    await expect(getTauriAgentRuntimeAvailable()).rejects.toThrow(
+      "Unexpected Tauri agent capability response",
+    );
+  });
+});

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -1,0 +1,53 @@
+export type TauriCommand =
+  | "dragon_runtime_ping"
+  | "dragon_agent_runtime_available";
+
+interface TauriCoreApi {
+  invoke: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+}
+
+interface TauriGlobalApi {
+  core: TauriCoreApi;
+}
+
+declare global {
+  interface Window {
+    __TAURI__?: TauriGlobalApi;
+  }
+}
+
+export function hasTauriBridge(): boolean {
+  return Boolean(window.__TAURI__?.core);
+}
+
+export function invokeTauriCommand(input: {
+  command: TauriCommand;
+  args?: Record<string, unknown>;
+}): Promise<unknown> {
+  const core = window.__TAURI__?.core;
+  if (!core) {
+    return Promise.reject(new Error("Tauri runtime bridge is unavailable"));
+  }
+
+  return core.invoke(input.command, input.args);
+}
+
+export async function pingTauriRuntime(): Promise<"ok"> {
+  const result = await invokeTauriCommand({ command: "dragon_runtime_ping" });
+  if (result === "ok") {
+    return result;
+  }
+
+  throw new Error("Unexpected Tauri runtime ping response");
+}
+
+export async function getTauriAgentRuntimeAvailable(): Promise<boolean> {
+  const result = await invokeTauriCommand({
+    command: "dragon_agent_runtime_available",
+  });
+  if (typeof result === "boolean") {
+    return result;
+  }
+
+  throw new Error("Unexpected Tauri agent capability response");
+}


### PR DESCRIPTION
## Summary
- enable the Tauri v2 global API for the desktop shell
- register initial native commands for runtime ping and agent capability
- add a typed frontend bridge that rejects cleanly outside the desktop shell

## Verification
- npx tsc --noEmit
- npx vitest run src/runtime/tauriBridge.test.ts src/runtime/webAgentRuntime.test.ts
- npx eslint src/runtime/tauriBridge.ts src/runtime/tauriBridge.test.ts
- npx --yes @tauri-apps/cli@2.11.2 info (config recognized; WSL image still lacks Rust/Cargo, webkit2gtk-4.1, and rsvg2)

## References
- Tauri v2 JavaScript API: https://v2.tauri.app/reference/javascript/api/
- Tauri v2 core invoke API: https://v2.tauri.app/reference/javascript/api/namespacecore/