### PR TITLE
Add desktop runtime module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -143,6 +143,10 @@ The bridge from the frontend to native commands lives in
 API, which is enabled only by the desktop shell config. Web execution therefore
 continues to reject desktop command calls instead of importing native APIs.
 
+Desktop runtime composition lives in `src/runtime/desktop.ts`. It is not the
+default website runtime export; it gives the desktop shell a separate module to
+adopt once native filesystem and agent adapters are ready.
+
 ### `workspace`
 
 Owns host-side file session lifecycle:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -289,6 +289,11 @@ registers initial `dragon_runtime_ping` and `dragon_agent_runtime_available`
 commands. `src/runtime/tauriBridge.ts` is the frontend boundary for invoking
 those commands while still rejecting cleanly in the website runtime.
 
+Desktop runtime module note: `src/runtime/desktop.ts` now composes desktop
+agent and terminal adapters behind the same runtime interfaces used by the web
+runtime. Those adapters intentionally report unavailable execution until native
+runner and terminal commands exist.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src/runtime/desktop.ts
+++ b/src/runtime/desktop.ts
@@ -1,0 +1,16 @@
+import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
+import { desktopAgentRuntime } from "./desktopAgentRuntime";
+import { desktopTerminalRuntime } from "./desktopTerminalRuntime";
+
+export const desktopRuntime = {
+  workspaceRuntime: webWorkspaceRuntime,
+  agentRuntime: desktopAgentRuntime,
+  terminalRuntime: desktopTerminalRuntime,
+};
+
+export {
+  assertDesktopRuntimeAvailable,
+  desktopAgentRuntime,
+  getDesktopAgentCapability,
+} from "./desktopAgentRuntime";
+export { desktopTerminalRuntime } from "./desktopTerminalRuntime";

--- a/src/runtime/desktopAgentRuntime.test.ts
+++ b/src/runtime/desktopAgentRuntime.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  assertDesktopRuntimeAvailable,
+  desktopAgentRuntime,
+  getDesktopAgentCapability,
+} from "./desktopAgentRuntime";
+
+beforeEach(() => {
+  window.__TAURI__ = undefined;
+});
+
+describe("desktop agent runtime", () => {
+  it("rejects when the desktop bridge is unavailable", async () => {
+    await expect(assertDesktopRuntimeAvailable()).rejects.toThrow(
+      "Desktop runtime bridge is unavailable",
+    );
+  });
+
+  it("reads the native agent capability through the Tauri bridge", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: (command) => {
+          if (command === "dragon_runtime_ping") {
+            return Promise.resolve("ok");
+          }
+          return Promise.resolve(false);
+        },
+      },
+    };
+
+    await expect(getDesktopAgentCapability()).resolves.toBe(false);
+  });
+
+  it("does not report runnable agent support until a runner is configured", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: (command) => {
+          if (command === "dragon_runtime_ping") {
+            return Promise.resolve("ok");
+          }
+          return Promise.resolve(false);
+        },
+      },
+    };
+
+    expect(desktopAgentRuntime.canRunAgent).toBe(false);
+    await expect(
+      desktopAgentRuntime.startRun({
+        tabId: "tab-1",
+        taskKind: "answer_questions",
+        targetPaths: ["docs/spec.md"],
+        selectedCommentIds: [],
+        prompt: "Answer questions",
+        runnerKind: "terminal",
+      }),
+    ).rejects.toThrow("Desktop agent execution is not configured");
+  });
+});

--- a/src/runtime/desktopAgentRuntime.ts
+++ b/src/runtime/desktopAgentRuntime.ts
@@ -1,0 +1,32 @@
+import type { AgentRuntime } from "./agent";
+import {
+  getTauriAgentRuntimeAvailable,
+  hasTauriBridge,
+  pingTauriRuntime,
+} from "./tauriBridge";
+
+export async function assertDesktopRuntimeAvailable(): Promise<void> {
+  if (!hasTauriBridge()) {
+    throw new Error("Desktop runtime bridge is unavailable");
+  }
+
+  await pingTauriRuntime();
+}
+
+export async function getDesktopAgentCapability(): Promise<boolean> {
+  await assertDesktopRuntimeAvailable();
+  return getTauriAgentRuntimeAvailable();
+}
+
+export const desktopAgentRuntime: AgentRuntime = {
+  canRunAgent: false,
+  startRun: async () => {
+    const canRunAgent = await getDesktopAgentCapability();
+    if (!canRunAgent) {
+      throw new Error("Desktop agent execution is not configured");
+    }
+
+    throw new Error("Desktop agent runner command is not implemented");
+  },
+  stopRun: () => Promise.resolve(),
+};

--- a/src/runtime/desktopTerminalRuntime.test.ts
+++ b/src/runtime/desktopTerminalRuntime.test.ts
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { desktopTerminalRuntime } from "./desktopTerminalRuntime";
+
+beforeEach(() => {
+  window.__TAURI__ = undefined;
+});
+
+describe("desktop terminal runtime", () => {
+  it("does not report terminal attachment support yet", async () => {
+    expect(desktopTerminalRuntime.canShowTerminal).toBe(false);
+
+    await expect(desktopTerminalRuntime.attach("run-1")).rejects.toThrow(
+      "Desktop runtime bridge is unavailable",
+    );
+  });
+});

--- a/src/runtime/desktopTerminalRuntime.ts
+++ b/src/runtime/desktopTerminalRuntime.ts
@@ -1,0 +1,10 @@
+import type { TerminalRuntime } from "./terminal";
+import { assertDesktopRuntimeAvailable } from "./desktopAgentRuntime";
+
+export const desktopTerminalRuntime: TerminalRuntime = {
+  canShowTerminal: false,
+  attach: async () => {
+    await assertDesktopRuntimeAvailable();
+    throw new Error("Desktop terminal attachment is not implemented");
+  },
+};


### PR DESCRIPTION
## Summary
- add a desktop runtime composition module alongside the existing web runtime export
- add desktop agent and terminal adapters that use the Tauri bridge but intentionally report unavailable execution
- document that the desktop runtime module is not yet the website default runtime

## Verification
- npx tsc --noEmit
- npx vitest run src/runtime/desktopAgentRuntime.test.ts src/runtime/desktopTerminalRuntime.test.ts src/runtime/tauriBridge.test.ts src/runtime/webAgentRuntime.test.ts
- npx eslint src/runtime/desktop.ts src/runtime/desktopAgentRuntime.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/desktopTerminalRuntime.ts src/runtime/desktopTerminalRuntime.test.ts