### PR TITLE
Add workspace runtime targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,6 +147,11 @@ Desktop runtime composition lives in `src/runtime/desktop.ts`. It is not the
 default website runtime export; it gives the desktop shell a separate module to
 adopt once native filesystem and agent adapters are ready.
 
+Workspace runtime file operations accept runtime targets. Browser targets are
+the current `FileSystem*Handle` values, while native targets are path-based
+objects reserved for desktop adapters. The web runtime rejects native targets
+explicitly.
+
 ### `workspace`
 
 Owns host-side file session lifecycle:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -294,6 +294,12 @@ agent and terminal adapters behind the same runtime interfaces used by the web
 runtime. Those adapters intentionally report unavailable execution until native
 runner and terminal commands exist.
 
+Workspace target abstraction note: workspace runtime file operations now accept
+browser handles or native path targets. The web runtime continues to delegate
+browser handles to the existing File System Access API implementation and rejects
+native targets, which lets desktop filesystem adapters land without widening
+browser-only call sites first.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,13 +1,25 @@
 import { webAgentRuntime } from "./agent";
 import { webTerminalRuntime } from "./terminal";
 import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
+import type {
+  WorkspaceDirectoryTarget,
+  WorkspaceFileTarget,
+} from "./workspace";
 
 export type { AgentRuntime, AgentRunRequest } from "./agent";
 export type { TerminalAttachment, TerminalRuntime } from "./terminal";
 export type {
+  NativeWorkspaceDirectoryTarget,
+  NativeWorkspaceFileTarget,
   OpenedWorkspaceDirectory,
   OpenedWorkspaceFile,
+  WorkspaceDirectoryTarget,
+  WorkspaceFileTarget,
   WorkspaceRuntime,
+} from "./workspace";
+export {
+  isNativeWorkspaceDirectoryTarget,
+  isNativeWorkspaceFileTarget,
 } from "./workspace";
 
 export const workspaceRuntime = webWorkspaceRuntime;
@@ -25,17 +37,17 @@ export function openDirectory() {
   return workspaceRuntime.openDirectory();
 }
 
-export function readFile(handle: FileSystemFileHandle) {
-  return workspaceRuntime.readFile(handle);
+export function readFile(target: WorkspaceFileTarget) {
+  return workspaceRuntime.readFile(target);
 }
 
-export function writeFile(handle: FileSystemFileHandle, content: string) {
-  return workspaceRuntime.writeFile(handle, content);
+export function writeFile(target: WorkspaceFileTarget, content: string) {
+  return workspaceRuntime.writeFile(target, content);
 }
 
 export function buildFileTree(
-  handle: FileSystemDirectoryHandle,
+  target: WorkspaceDirectoryTarget,
   basePath?: string,
 ) {
-  return workspaceRuntime.buildFileTree(handle, basePath);
+  return workspaceRuntime.buildFileTree(target, basePath);
 }

--- a/src/runtime/webWorkspaceRuntime.test.ts
+++ b/src/runtime/webWorkspaceRuntime.test.ts
@@ -99,6 +99,26 @@ describe("workspaceRuntime", () => {
     );
 
     expect(openDirectory).toHaveBeenCalled();
-    expect(buildFileTree).toHaveBeenCalledWith(directoryHandle);
+    expect(buildFileTree).toHaveBeenCalledWith(directoryHandle, undefined);
+  });
+
+  it("rejects native targets in the web runtime", async () => {
+    await expect(
+      workspaceRuntime.readFile({
+        kind: "native_file",
+        path: "/tmp/notes.md",
+        name: "notes.md",
+      }),
+    ).rejects.toThrow("Native file targets are unavailable in the web runtime");
+
+    await expect(
+      workspaceRuntime.buildFileTree({
+        kind: "native_directory",
+        path: "/tmp/docs",
+        name: "docs",
+      }),
+    ).rejects.toThrow(
+      "Native directory targets are unavailable in the web runtime",
+    );
   });
 });

--- a/src/runtime/webWorkspaceRuntime.ts
+++ b/src/runtime/webWorkspaceRuntime.ts
@@ -5,12 +5,44 @@ import {
   readFile,
   writeFile,
 } from "../services/fileSystem";
-import type { WorkspaceRuntime } from "./workspace";
+import type {
+  WorkspaceDirectoryTarget,
+  WorkspaceFileTarget,
+  WorkspaceRuntime,
+} from "./workspace";
+import {
+  isNativeWorkspaceDirectoryTarget,
+  isNativeWorkspaceFileTarget,
+} from "./workspace";
+
+function requireBrowserFileHandle(
+  target: WorkspaceFileTarget,
+): FileSystemFileHandle {
+  if (isNativeWorkspaceFileTarget(target)) {
+    throw new Error("Native file targets are unavailable in the web runtime");
+  }
+
+  return target;
+}
+
+function requireBrowserDirectoryHandle(
+  target: WorkspaceDirectoryTarget,
+): FileSystemDirectoryHandle {
+  if (isNativeWorkspaceDirectoryTarget(target)) {
+    throw new Error(
+      "Native directory targets are unavailable in the web runtime",
+    );
+  }
+
+  return target;
+}
 
 export const webWorkspaceRuntime: WorkspaceRuntime = {
   openFile,
   openDirectory,
-  readFile,
-  writeFile,
-  buildFileTree,
+  readFile: async (target) => readFile(requireBrowserFileHandle(target)),
+  writeFile: async (target, content) =>
+    writeFile(requireBrowserFileHandle(target), content),
+  buildFileTree: async (target, basePath) =>
+    buildFileTree(requireBrowserDirectoryHandle(target), basePath),
 };

--- a/src/runtime/workspace.ts
+++ b/src/runtime/workspace.ts
@@ -1,5 +1,25 @@
 import type { FileTreeNode } from "../types/fileTree";
 
+export interface NativeWorkspaceFileTarget {
+  kind: "native_file";
+  path: string;
+  name: string;
+}
+
+export interface NativeWorkspaceDirectoryTarget {
+  kind: "native_directory";
+  path: string;
+  name: string;
+}
+
+export type WorkspaceFileTarget =
+  | FileSystemFileHandle
+  | NativeWorkspaceFileTarget;
+
+export type WorkspaceDirectoryTarget =
+  | FileSystemDirectoryHandle
+  | NativeWorkspaceDirectoryTarget;
+
 export interface OpenedWorkspaceFile {
   handle: FileSystemFileHandle;
   name: string;
@@ -13,10 +33,22 @@ export interface OpenedWorkspaceDirectory {
 export interface WorkspaceRuntime {
   openFile(): Promise<OpenedWorkspaceFile | null>;
   openDirectory(): Promise<OpenedWorkspaceDirectory | null>;
-  readFile(handle: FileSystemFileHandle): Promise<string>;
-  writeFile(handle: FileSystemFileHandle, content: string): Promise<void>;
+  readFile(target: WorkspaceFileTarget): Promise<string>;
+  writeFile(target: WorkspaceFileTarget, content: string): Promise<void>;
   buildFileTree(
-    handle: FileSystemDirectoryHandle,
+    target: WorkspaceDirectoryTarget,
     basePath?: string,
   ): Promise<FileTreeNode[]>;
+}
+
+export function isNativeWorkspaceFileTarget(
+  target: WorkspaceFileTarget,
+): target is NativeWorkspaceFileTarget {
+  return target.kind === "native_file";
+}
+
+export function isNativeWorkspaceDirectoryTarget(
+  target: WorkspaceDirectoryTarget,
+): target is NativeWorkspaceDirectoryTarget {
+  return target.kind === "native_directory";
 }


### PR DESCRIPTION
## Summary
- introduce browser-handle and native-path workspace runtime targets
- keep web open flows unchanged while making read/write/tree methods accept future native targets
- reject native targets explicitly in the web runtime and document the boundary

## Verification
- npx tsc --noEmit
- npx vitest run src/runtime/webWorkspaceRuntime.test.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts
- npx eslint src/runtime/workspace.ts src/runtime/webWorkspaceRuntime.ts src/runtime/webWorkspaceRuntime.test.ts src/runtime/index.ts