### PR TITLE
Add native filesystem commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,6 +152,10 @@ the current `FileSystem*Handle` values, while native targets are path-based
 objects reserved for desktop adapters. The web runtime rejects native targets
 explicitly.
 
+The desktop shell registers native filesystem commands for reading text files,
+writing text files, and building markdown-only directory trees. Frontend access
+to those commands stays behind `src/runtime/tauriBridge.ts` response validation.
+
 ### `workspace`
 
 Owns host-side file session lifecycle:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -300,6 +300,11 @@ browser handles to the existing File System Access API implementation and reject
 native targets, which lets desktop filesystem adapters land without widening
 browser-only call sites first.
 
+Native filesystem command note: the Tauri shell now registers commands for
+reading and writing UTF-8 text files plus reading a markdown-only directory tree.
+The frontend bridge validates those command responses before future desktop
+workspace adapters consume them.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,4 +15,5 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = [] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,84 @@
+use serde::Serialize;
+use std::fs;
+use std::path::Path;
+
+const IGNORED_NAMES: [&str; 3] = ["node_modules", ".git", ".markreview"];
+const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
+
+#[derive(Serialize)]
+#[serde(tag = "kind")]
+enum NativeFileTreeNode {
+    #[serde(rename = "file")]
+    File { name: String, path: String },
+    #[serde(rename = "directory")]
+    Directory {
+        name: String,
+        path: String,
+        children: Vec<NativeFileTreeNode>,
+    },
+}
+
+fn is_ignored(name: &str) -> bool {
+    name.starts_with('.') || IGNORED_NAMES.contains(&name)
+}
+
+fn is_markdown_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| MARKDOWN_EXTENSIONS.contains(&extension.to_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+fn build_native_file_tree(
+    directory_path: &Path,
+    base_path: &str,
+) -> Result<Vec<NativeFileTreeNode>, String> {
+    let mut directories = Vec::new();
+    let mut files = Vec::new();
+    let entries = fs::read_dir(directory_path).map_err(|error| error.to_string())?;
+
+    for entry_result in entries {
+        let entry = entry_result.map_err(|error| error.to_string())?;
+        let file_type = entry.file_type().map_err(|error| error.to_string())?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if is_ignored(&name) {
+            continue;
+        }
+
+        let path = if base_path.is_empty() {
+            name.clone()
+        } else {
+            format!("{}/{}", base_path, name)
+        };
+        let entry_path = entry.path();
+
+        if file_type.is_dir() {
+            let children = build_native_file_tree(&entry_path, &path)?;
+            if !children.is_empty() {
+                directories.push(NativeFileTreeNode::Directory {
+                    name,
+                    path,
+                    children,
+                });
+            }
+        } else if file_type.is_file() && is_markdown_file(&entry_path) {
+            files.push(NativeFileTreeNode::File { name, path });
+        }
+    }
+
+    directories.sort_by_key(|node| match node {
+        NativeFileTreeNode::Directory { name, .. } => name.clone(),
+        NativeFileTreeNode::File { name, .. } => name.clone(),
+    });
+    files.sort_by_key(|node| match node {
+        NativeFileTreeNode::Directory { name, .. } => name.clone(),
+        NativeFileTreeNode::File { name, .. } => name.clone(),
+    });
+    directories.extend(files);
+
+    Ok(directories)
+}
+
 #[tauri::command]
 fn dragon_runtime_ping() -> &'static str {
     "ok"
@@ -8,12 +89,30 @@ fn dragon_agent_runtime_available() -> bool {
     false
 }
 
+#[tauri::command]
+fn dragon_read_text_file(path: String) -> Result<String, String> {
+    fs::read_to_string(path).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn dragon_write_text_file(path: String, content: String) -> Result<(), String> {
+    fs::write(path, content).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn dragon_read_directory_tree(path: String) -> Result<Vec<NativeFileTreeNode>, String> {
+    build_native_file_tree(Path::new(&path), "")
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             dragon_runtime_ping,
-            dragon_agent_runtime_available
+            dragon_agent_runtime_available,
+            dragon_read_text_file,
+            dragon_write_text_file,
+            dragon_read_directory_tree
         ])
         .run(tauri::generate_context!())
         .expect("error while running Lollipop Dragon");

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -4,6 +4,9 @@ import {
   hasTauriBridge,
   invokeTauriCommand,
   pingTauriRuntime,
+  readTauriDirectoryTree,
+  readTauriTextFile,
+  writeTauriTextFile,
 } from "./tauriBridge";
 
 beforeEach(() => {
@@ -63,5 +66,107 @@ describe("tauri bridge", () => {
     await expect(getTauriAgentRuntimeAvailable()).rejects.toThrow(
       "Unexpected Tauri agent capability response",
     );
+  });
+
+  it("reads and writes native text files through Tauri commands", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
+    window.__TAURI__ = {
+      core: {
+        invoke: (command, args) => {
+          calls.push({ command, args });
+          if (command === "dragon_read_text_file") {
+            return Promise.resolve("# Notes");
+          }
+          return Promise.resolve(null);
+        },
+      },
+    };
+    const target = {
+      kind: "native_file",
+      path: "/tmp/notes.md",
+      name: "notes.md",
+    };
+
+    await expect(readTauriTextFile(target)).resolves.toBe("# Notes");
+    await writeTauriTextFile(target, "# Updated");
+
+    expect(calls).toEqual([
+      {
+        command: "dragon_read_text_file",
+        args: { path: "/tmp/notes.md" },
+      },
+      {
+        command: "dragon_write_text_file",
+        args: { path: "/tmp/notes.md", content: "# Updated" },
+      },
+    ]);
+  });
+
+  it("reads native directory trees through Tauri commands", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () =>
+          Promise.resolve([
+            {
+              kind: "directory",
+              name: "docs",
+              path: "docs",
+              children: [
+                {
+                  kind: "file",
+                  name: "intro.md",
+                  path: "docs/intro.md",
+                },
+              ],
+            },
+          ]),
+      },
+    };
+
+    await expect(
+      readTauriDirectoryTree({
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      }),
+    ).resolves.toEqual([
+      {
+        kind: "directory",
+        name: "docs",
+        path: "docs",
+        children: [
+          {
+            kind: "file",
+            name: "intro.md",
+            path: "docs/intro.md",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects malformed native directory tree responses", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () =>
+          Promise.resolve([
+            {
+              kind: "file",
+              name: "intro.md",
+            },
+          ]),
+      },
+    };
+
+    await expect(
+      readTauriDirectoryTree({
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      }),
+    ).rejects.toThrow("Unexpected native file tree path field");
   });
 });

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -1,6 +1,31 @@
+import type {
+  NativeWorkspaceDirectoryTarget,
+  NativeWorkspaceFileTarget,
+} from "./workspace";
+
 export type TauriCommand =
   | "dragon_runtime_ping"
-  | "dragon_agent_runtime_available";
+  | "dragon_agent_runtime_available"
+  | "dragon_read_text_file"
+  | "dragon_write_text_file"
+  | "dragon_read_directory_tree";
+
+export interface TauriNativeFileNode {
+  kind: "file";
+  name: string;
+  path: string;
+}
+
+export interface TauriNativeDirectoryNode {
+  kind: "directory";
+  name: string;
+  path: string;
+  children: TauriNativeTreeNode[];
+}
+
+export type TauriNativeTreeNode =
+  | TauriNativeFileNode
+  | TauriNativeDirectoryNode;
 
 interface TauriCoreApi {
   invoke: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
@@ -50,4 +75,91 @@ export async function getTauriAgentRuntimeAvailable(): Promise<boolean> {
   }
 
   throw new Error("Unexpected Tauri agent capability response");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringField(
+  record: Record<string, unknown>,
+  fieldName: string,
+): string {
+  const value = record[fieldName];
+  if (typeof value === "string") {
+    return value;
+  }
+
+  throw new Error(`Unexpected native file tree ${fieldName} field`);
+}
+
+function parseNativeTreeNode(value: unknown): TauriNativeTreeNode {
+  if (!isRecord(value)) {
+    throw new Error("Unexpected native file tree node");
+  }
+
+  const kind = value.kind;
+  const name = readStringField(value, "name");
+  const path = readStringField(value, "path");
+  if (kind === "file") {
+    return { kind, name, path };
+  }
+
+  if (kind === "directory") {
+    const childrenValue = value.children;
+    if (!Array.isArray(childrenValue)) {
+      throw new Error("Unexpected native file tree children field");
+    }
+
+    return {
+      kind,
+      name,
+      path,
+      children: childrenValue.map(parseNativeTreeNode),
+    };
+  }
+
+  throw new Error("Unexpected native file tree kind");
+}
+
+function parseNativeTree(value: unknown): TauriNativeTreeNode[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Unexpected native file tree response");
+  }
+
+  return value.map(parseNativeTreeNode);
+}
+
+export async function readTauriTextFile(
+  target: NativeWorkspaceFileTarget,
+): Promise<string> {
+  const result = await invokeTauriCommand({
+    command: "dragon_read_text_file",
+    args: { path: target.path },
+  });
+  if (typeof result === "string") {
+    return result;
+  }
+
+  throw new Error("Unexpected native file read response");
+}
+
+export function writeTauriTextFile(
+  target: NativeWorkspaceFileTarget,
+  content: string,
+): Promise<unknown> {
+  return invokeTauriCommand({
+    command: "dragon_write_text_file",
+    args: { path: target.path, content },
+  });
+}
+
+export async function readTauriDirectoryTree(
+  target: NativeWorkspaceDirectoryTarget,
+): Promise<TauriNativeTreeNode[]> {
+  const result = await invokeTauriCommand({
+    command: "dragon_read_directory_tree",
+    args: { path: target.path },
+  });
+  return parseNativeTree(result);
 }


### PR DESCRIPTION
## Summary
- add Tauri commands for reading text files, writing text files, and reading markdown directory trees
- add typed frontend bridge helpers with response validation for native filesystem commands
- document the native filesystem command boundary

## Verification
- npx tsc --noEmit
- npx vitest run src/runtime/tauriBridge.test.ts src/runtime/desktopAgentRuntime.test.ts
- npx eslint src/runtime/tauriBridge.ts src/runtime/tauriBridge.test.ts
- npx --yes @tauri-apps/cli@2.11.2 info (config recognized; WSL image still lacks Rust/Cargo, webkit2gtk-4.1, and rsvg2)

## Notes
- Native build was not run because this WSL image does not have the required Tauri native prerequisites installed.