### PR TITLE
Add desktop workspace runtime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -155,6 +155,8 @@ explicitly.
 The desktop shell registers native filesystem commands for reading text files,
 writing text files, and building markdown-only directory trees. Frontend access
 to those commands stays behind `src/runtime/tauriBridge.ts` response validation.
+`src/runtime/desktopWorkspaceRuntime.ts` adapts those commands to the shared
+`WorkspaceRuntime` interface for native path targets.
 
 ### `workspace`
 

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -305,6 +305,11 @@ reading and writing UTF-8 text files plus reading a markdown-only directory tree
 The frontend bridge validates those command responses before future desktop
 workspace adapters consume them.
 
+Desktop workspace runtime note: `src/runtime/desktopWorkspaceRuntime.ts` now
+implements read, write, and directory-tree operations for native path targets.
+Open-file and open-folder UI still use the web runtime until native dialog
+commands are added and the desktop shell switches to the desktop runtime module.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src/runtime/desktop.ts
+++ b/src/runtime/desktop.ts
@@ -1,9 +1,9 @@
-import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
 import { desktopAgentRuntime } from "./desktopAgentRuntime";
 import { desktopTerminalRuntime } from "./desktopTerminalRuntime";
+import { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";
 
 export const desktopRuntime = {
-  workspaceRuntime: webWorkspaceRuntime,
+  workspaceRuntime: desktopWorkspaceRuntime,
   agentRuntime: desktopAgentRuntime,
   terminalRuntime: desktopTerminalRuntime,
 };
@@ -14,3 +14,4 @@ export {
   getDesktopAgentCapability,
 } from "./desktopAgentRuntime";
 export { desktopTerminalRuntime } from "./desktopTerminalRuntime";
+export { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";

--- a/src/runtime/desktopWorkspaceRuntime.test.ts
+++ b/src/runtime/desktopWorkspaceRuntime.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./tauriBridge", () => ({
+  readTauriDirectoryTree: vi.fn(),
+  readTauriTextFile: vi.fn(),
+  writeTauriTextFile: vi.fn(),
+}));
+
+import {
+  readTauriDirectoryTree,
+  readTauriTextFile,
+  writeTauriTextFile,
+} from "./tauriBridge";
+import { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";
+import type { NativeWorkspaceFileTarget } from "./workspace";
+
+function createFileHandle(name: string): FileSystemFileHandle {
+  return {
+    kind: "file",
+    name,
+    createWritable: vi.fn(),
+    getFile: vi.fn(),
+    isSameEntry: vi.fn(),
+    queryPermission: vi.fn(),
+    requestPermission: vi.fn(),
+  };
+}
+
+function createDirectoryHandle(name: string): FileSystemDirectoryHandle {
+  return {
+    kind: "directory",
+    name,
+    getDirectoryHandle: vi.fn(),
+    getFileHandle: vi.fn(),
+    removeEntry: vi.fn(),
+    resolve: vi.fn(),
+    entries: vi.fn(),
+    keys: vi.fn(),
+    values: vi.fn(),
+    isSameEntry: vi.fn(),
+    queryPermission: vi.fn(),
+    requestPermission: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("desktopWorkspaceRuntime", () => {
+  it("delegates native file reads and writes to Tauri commands", async () => {
+    const target: NativeWorkspaceFileTarget = {
+      kind: "native_file",
+      path: "/tmp/project/notes.md",
+      name: "notes.md",
+    };
+    vi.mocked(readTauriTextFile).mockResolvedValue("# Notes");
+    vi.mocked(writeTauriTextFile).mockResolvedValue(null);
+
+    await expect(desktopWorkspaceRuntime.readFile(target)).resolves.toBe(
+      "# Notes",
+    );
+    await desktopWorkspaceRuntime.writeFile(target, "# Updated");
+
+    expect(readTauriTextFile).toHaveBeenCalledWith(target);
+    expect(writeTauriTextFile).toHaveBeenCalledWith(target, "# Updated");
+  });
+
+  it("maps native directory trees to live file tree nodes", async () => {
+    vi.mocked(readTauriDirectoryTree).mockResolvedValue([
+      {
+        kind: "directory",
+        name: "docs",
+        path: "docs",
+        children: [
+          {
+            kind: "file",
+            name: "intro.md",
+            path: "docs/intro.md",
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      desktopWorkspaceRuntime.buildFileTree({
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      }),
+    ).resolves.toEqual([
+      {
+        kind: "directory",
+        name: "docs",
+        path: "docs",
+        children: [
+          {
+            kind: "file",
+            name: "intro.md",
+            path: "docs/intro.md",
+            handle: {
+              kind: "native_file",
+              name: "intro.md",
+              path: "/tmp/project/docs/intro.md",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects browser handles in the desktop runtime", async () => {
+    await expect(
+      desktopWorkspaceRuntime.readFile(createFileHandle("notes.md")),
+    ).rejects.toThrow(
+      "Browser file handles are unavailable in the desktop runtime",
+    );
+
+    await expect(
+      desktopWorkspaceRuntime.buildFileTree(createDirectoryHandle("docs")),
+    ).rejects.toThrow(
+      "Browser directory handles are unavailable in the desktop runtime",
+    );
+  });
+});

--- a/src/runtime/desktopWorkspaceRuntime.ts
+++ b/src/runtime/desktopWorkspaceRuntime.ts
@@ -1,0 +1,79 @@
+import type { DirectoryNode, FileTreeNode } from "../types/fileTree";
+import {
+  readTauriDirectoryTree,
+  readTauriTextFile,
+  type TauriNativeTreeNode,
+  writeTauriTextFile,
+} from "./tauriBridge";
+import type { WorkspaceRuntime } from "./workspace";
+import {
+  isNativeWorkspaceDirectoryTarget,
+  isNativeWorkspaceFileTarget,
+} from "./workspace";
+
+function nativeTreeNodeToFileTreeNode(
+  node: TauriNativeTreeNode,
+  rootPath: string,
+): FileTreeNode {
+  if (node.kind === "file") {
+    return {
+      kind: "file",
+      name: node.name,
+      path: node.path,
+      handle: {
+        kind: "native_file",
+        name: node.name,
+        path: `${rootPath}/${node.path}`,
+      },
+    };
+  }
+
+  const directoryNode: DirectoryNode = {
+    kind: "directory",
+    name: node.name,
+    path: node.path,
+    children: node.children.map((child) =>
+      nativeTreeNodeToFileTreeNode(child, rootPath),
+    ),
+  };
+  return directoryNode;
+}
+
+export const desktopWorkspaceRuntime: WorkspaceRuntime = {
+  openFile: () => Promise.resolve(null),
+  openDirectory: () => Promise.resolve(null),
+  readFile: (target) => {
+    if (!isNativeWorkspaceFileTarget(target)) {
+      return Promise.reject(
+        new Error(
+          "Browser file handles are unavailable in the desktop runtime",
+        ),
+      );
+    }
+
+    return readTauriTextFile(target);
+  },
+  writeFile: (target, content) => {
+    if (!isNativeWorkspaceFileTarget(target)) {
+      return Promise.reject(
+        new Error(
+          "Browser file handles are unavailable in the desktop runtime",
+        ),
+      );
+    }
+
+    return writeTauriTextFile(target, content).then(() => undefined);
+  },
+  buildFileTree: async (target) => {
+    if (!isNativeWorkspaceDirectoryTarget(target)) {
+      return Promise.reject(
+        new Error(
+          "Browser directory handles are unavailable in the desktop runtime",
+        ),
+      );
+    }
+
+    const tree = await readTauriDirectoryTree(target);
+    return tree.map((node) => nativeTreeNodeToFileTreeNode(node, target.path));
+  },
+};

--- a/src/runtime/workspace.ts
+++ b/src/runtime/workspace.ts
@@ -1,24 +1,15 @@
-import type { FileTreeNode } from "../types/fileTree";
+import type {
+  DirectoryTarget,
+  FileTarget,
+  FileTreeNode,
+  NativeDirectoryTarget,
+  NativeFileTarget,
+} from "../types/fileTree";
 
-export interface NativeWorkspaceFileTarget {
-  kind: "native_file";
-  path: string;
-  name: string;
-}
-
-export interface NativeWorkspaceDirectoryTarget {
-  kind: "native_directory";
-  path: string;
-  name: string;
-}
-
-export type WorkspaceFileTarget =
-  | FileSystemFileHandle
-  | NativeWorkspaceFileTarget;
-
-export type WorkspaceDirectoryTarget =
-  | FileSystemDirectoryHandle
-  | NativeWorkspaceDirectoryTarget;
+export type NativeWorkspaceFileTarget = NativeFileTarget;
+export type NativeWorkspaceDirectoryTarget = NativeDirectoryTarget;
+export type WorkspaceFileTarget = FileTarget;
+export type WorkspaceDirectoryTarget = DirectoryTarget;
 
 export interface OpenedWorkspaceFile {
   handle: FileSystemFileHandle;

--- a/src/types/fileTree.ts
+++ b/src/types/fileTree.ts
@@ -1,8 +1,24 @@
+export interface NativeFileTarget {
+  kind: "native_file";
+  path: string;
+  name: string;
+}
+
+export interface NativeDirectoryTarget {
+  kind: "native_directory";
+  path: string;
+  name: string;
+}
+
+export type FileTarget = FileSystemFileHandle | NativeFileTarget;
+
+export type DirectoryTarget = FileSystemDirectoryHandle | NativeDirectoryTarget;
+
 export interface FileNode {
   kind: "file";
   name: string;
   path: string;
-  handle: FileSystemFileHandle;
+  handle: FileTarget;
 }
 
 export interface DirectoryNode {
@@ -31,7 +47,7 @@ export interface SidebarDirectoryNode {
 export type SidebarTreeNode = SidebarFileNode | SidebarDirectoryNode;
 
 export interface HydratedSidebarFileNode extends SidebarFileNode {
-  handle?: FileSystemFileHandle;
+  handle?: FileTarget;
 }
 
 export interface HydratedSidebarDirectoryNode {


### PR DESCRIPTION
## Summary
- widen live file tree nodes to carry browser handles or native file targets
- add a desktop workspace runtime that reads, writes, and builds file trees through native Tauri bridge commands
- keep web runtime behavior unchanged and document that native dialogs remain the next slice

## Verification
- npx tsc --noEmit
- npx vitest run src/runtime/desktopWorkspaceRuntime.test.ts src/runtime/webWorkspaceRuntime.test.ts src/runtime/tauriBridge.test.ts
- npx eslint src/types/fileTree.ts src/runtime/workspace.ts src/runtime/desktop.ts src/runtime/desktopWorkspaceRuntime.ts src/runtime/desktopWorkspaceRuntime.test.ts