### PR TITLE
Add native dialog commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,6 +158,10 @@ to those commands stays behind `src/runtime/tauriBridge.ts` response validation.
 `src/runtime/desktopWorkspaceRuntime.ts` adapts those commands to the shared
 `WorkspaceRuntime` interface for native path targets.
 
+Native open-file and open-folder dialogs are also exposed through Tauri bridge
+commands. They return path targets and are kept separate from the default web
+open flow until host tab state can store native workspace sessions.
+
 ### `workspace`
 
 Owns host-side file session lifecycle:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -310,6 +310,11 @@ implements read, write, and directory-tree operations for native path targets.
 Open-file and open-folder UI still use the web runtime until native dialog
 commands are added and the desktop shell switches to the desktop runtime module.
 
+Native dialog command note: the Tauri shell now registers native open-file and
+open-folder commands through `tauri-plugin-dialog`. The frontend bridge converts
+their results into native path targets, while the visible host open flow remains
+on browser handles until tab state is widened to store native sessions.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,3 +17,4 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use tauri_plugin_dialog::DialogExt;
 
 const IGNORED_NAMES: [&str; 3] = ["node_modules", ".git", ".markreview"];
 const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
@@ -16,6 +17,24 @@ enum NativeFileTreeNode {
         path: String,
         children: Vec<NativeFileTreeNode>,
     },
+}
+
+#[derive(Serialize)]
+struct NativePathTarget {
+    path: String,
+    name: String,
+}
+
+fn path_target_from_path(path: PathBuf) -> NativePathTarget {
+    let name = path
+        .file_name()
+        .map(|file_name| file_name.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+
+    NativePathTarget {
+        path: path.to_string_lossy().to_string(),
+        name,
+    }
 }
 
 fn is_ignored(name: &str) -> bool {
@@ -90,6 +109,28 @@ fn dragon_agent_runtime_available() -> bool {
 }
 
 #[tauri::command]
+fn dragon_open_text_file(app: tauri::AppHandle) -> Result<Option<NativePathTarget>, String> {
+    let selected = app
+        .dialog()
+        .file()
+        .add_filter("Markdown", &["md", "markdown"])
+        .blocking_pick_file();
+
+    Ok(selected
+        .and_then(|file_path| file_path.as_path().map(|path| path.to_path_buf()))
+        .map(path_target_from_path))
+}
+
+#[tauri::command]
+fn dragon_open_directory(app: tauri::AppHandle) -> Result<Option<NativePathTarget>, String> {
+    let selected = app.dialog().file().blocking_pick_folder();
+
+    Ok(selected
+        .and_then(|file_path| file_path.as_path().map(|path| path.to_path_buf()))
+        .map(path_target_from_path))
+}
+
+#[tauri::command]
 fn dragon_read_text_file(path: String) -> Result<String, String> {
     fs::read_to_string(path).map_err(|error| error.to_string())
 }
@@ -110,6 +151,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             dragon_runtime_ping,
             dragon_agent_runtime_available,
+            dragon_open_text_file,
+            dragon_open_directory,
             dragon_read_text_file,
             dragon_write_text_file,
             dragon_read_directory_tree

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -3,6 +3,8 @@ import {
   getTauriAgentRuntimeAvailable,
   hasTauriBridge,
   invokeTauriCommand,
+  openTauriDirectory,
+  openTauriTextFile,
   pingTauriRuntime,
   readTauriDirectoryTree,
   readTauriTextFile,
@@ -103,6 +105,65 @@ describe("tauri bridge", () => {
         args: { path: "/tmp/notes.md", content: "# Updated" },
       },
     ]);
+  });
+
+  it("opens native file and directory targets through Tauri commands", async () => {
+    const calls: string[] = [];
+    window.__TAURI__ = {
+      core: {
+        invoke: (command) => {
+          calls.push(command);
+          if (command === "dragon_open_text_file") {
+            return Promise.resolve({
+              path: "/tmp/project/notes.md",
+              name: "notes.md",
+            });
+          }
+          return Promise.resolve({
+            path: "/tmp/project",
+            name: "project",
+          });
+        },
+      },
+    };
+
+    await expect(openTauriTextFile()).resolves.toEqual({
+      kind: "native_file",
+      path: "/tmp/project/notes.md",
+      name: "notes.md",
+    });
+    await expect(openTauriDirectory()).resolves.toEqual({
+      kind: "native_directory",
+      path: "/tmp/project",
+      name: "project",
+    });
+    expect(calls).toEqual(["dragon_open_text_file", "dragon_open_directory"]);
+  });
+
+  it("returns null when native open dialogs are cancelled", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () => Promise.resolve(null),
+      },
+    };
+
+    await expect(openTauriTextFile()).resolves.toBeNull();
+    await expect(openTauriDirectory()).resolves.toBeNull();
+  });
+
+  it("rejects malformed native open dialog responses", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () =>
+          Promise.resolve({
+            path: "/tmp/project/notes.md",
+          }),
+      },
+    };
+
+    await expect(openTauriTextFile()).rejects.toThrow(
+      "Unexpected native file tree name field",
+    );
   });
 
   it("reads native directory trees through Tauri commands", async () => {

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -6,6 +6,8 @@ import type {
 export type TauriCommand =
   | "dragon_runtime_ping"
   | "dragon_agent_runtime_available"
+  | "dragon_open_text_file"
+  | "dragon_open_directory"
   | "dragon_read_text_file"
   | "dragon_write_text_file"
   | "dragon_read_directory_tree";
@@ -26,6 +28,11 @@ export interface TauriNativeDirectoryNode {
 export type TauriNativeTreeNode =
   | TauriNativeFileNode
   | TauriNativeDirectoryNode;
+
+interface NativePathTargetPayload {
+  path: string;
+  name: string;
+}
 
 interface TauriCoreApi {
   invoke: (command: string, args?: Record<string, unknown>) => Promise<unknown>;
@@ -128,6 +135,52 @@ function parseNativeTree(value: unknown): TauriNativeTreeNode[] {
   }
 
   return value.map(parseNativeTreeNode);
+}
+
+function parseNativePathTarget(value: unknown): NativePathTargetPayload | null {
+  if (value === null) {
+    return null;
+  }
+  if (!isRecord(value)) {
+    throw new Error("Unexpected native path target response");
+  }
+
+  return {
+    path: readStringField(value, "path"),
+    name: readStringField(value, "name"),
+  };
+}
+
+export async function openTauriTextFile(): Promise<NativeWorkspaceFileTarget | null> {
+  const result = await invokeTauriCommand({
+    command: "dragon_open_text_file",
+  });
+  const target = parseNativePathTarget(result);
+  if (!target) {
+    return null;
+  }
+
+  return {
+    kind: "native_file",
+    path: target.path,
+    name: target.name,
+  };
+}
+
+export async function openTauriDirectory(): Promise<NativeWorkspaceDirectoryTarget | null> {
+  const result = await invokeTauriCommand({
+    command: "dragon_open_directory",
+  });
+  const target = parseNativePathTarget(result);
+  if (!target) {
+    return null;
+  }
+
+  return {
+    kind: "native_directory",
+    path: target.path,
+    name: target.name,
+  };
 }
 
 export async function readTauriTextFile(


### PR DESCRIPTION
## Summary
- add tauri-plugin-dialog to the desktop shell
- register native open-file and open-folder commands returning path targets
- add typed frontend bridge helpers and tests for native dialog selection, cancellation, and malformed responses

## Verification
- npx tsc --noEmit
- npx vitest run src/runtime/tauriBridge.test.ts src/runtime/desktopWorkspaceRuntime.test.ts
- npx eslint src/runtime/tauriBridge.ts src/runtime/tauriBridge.test.ts
- npx --yes @tauri-apps/cli@2.11.2 info (config recognized; Rust dialog plugin detected; WSL image still lacks Rust/Cargo, webkit2gtk-4.1, and rsvg2)

## References
- Tauri v2 dialog plugin: https://v2.tauri.app/plugin/dialog/

## Notes
- Native build was not run because this WSL image does not have the required Tauri native prerequisites installed.