### PR TITLE
Support native tab targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -162,6 +162,11 @@ Native open-file and open-folder dialogs are also exposed through Tauri bridge
 commands. They return path targets and are kept separate from the default web
 open flow until host tab state can store native workspace sessions.
 
+Host tab state can store either browser handles or native path targets for live
+file and directory access. Browser handles remain the only targets persisted in
+IndexedDB restore storage; native target persistence is a separate desktop
+runtime concern.
+
 ### `workspace`
 
 Owns host-side file session lifecycle:

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -315,6 +315,11 @@ open-folder commands through `tauri-plugin-dialog`. The frontend bridge converts
 their results into native path targets, while the visible host open flow remains
 on browser handles until tab state is widened to store native sessions.
 
+Native tab target note: host tab state now accepts browser handles or native path
+targets for live file and directory access. Existing browser handle restore logic
+is preserved; native restore/session persistence will be handled in a later
+desktop runtime slice.
+
 ## Risks
 
 - Runtime abstraction may be too broad if introduced before the first desktop

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -9,6 +9,7 @@ import {
   shiftCommentRawOffsets,
 } from "../../markup";
 import { findLiveFileInTree } from "../../types/fileTree";
+import type { FileTarget } from "../../types/fileTree";
 import type { Comment } from "../../types/criticmarkup";
 import type { FileNode, FileTreeNode } from "../../types/fileTree";
 import { readFile, writeFile } from "../../runtime";
@@ -84,7 +85,7 @@ export async function writeAndUpdate<
     activeTabId: string | null,
     updater: (tab: TabState) => Partial<TabState>,
   ) => TabState[];
-  fileHandle: FileSystemFileHandle;
+  fileHandle: FileTarget;
   newRawContent: string;
 }): Promise<boolean> {
   const { set, buildUpdatedActiveTabs, fileHandle, newRawContent } = input;

--- a/src/modules/sharing/controller.ts
+++ b/src/modules/sharing/controller.ts
@@ -12,6 +12,7 @@ import {
   keyToBase64url,
 } from "../../services/crypto";
 import { readFile } from "../../runtime";
+import { isBrowserFileHandle } from "../../types/fileTree";
 import type { FileTreeNode } from "../../types/fileTree";
 import type { ShareRecord } from "../../types/share";
 import type { TabState } from "../../types/tab";
@@ -500,12 +501,16 @@ export function createSharingControllerActions<
         return;
       }
 
-      const readPermission = await tab.fileHandle.queryPermission({
-        mode: "read",
-      });
-      const writePermission = await tab.fileHandle.queryPermission({
-        mode: "readwrite",
-      });
+      const readPermission = isBrowserFileHandle(tab.fileHandle)
+        ? await tab.fileHandle.queryPermission({
+            mode: "read",
+          })
+        : "native";
+      const writePermission = isBrowserFileHandle(tab.fileHandle)
+        ? await tab.fileHandle.queryPermission({
+            mode: "readwrite",
+          })
+        : "native";
       console.log("[mergeComment] proceeding", {
         tabId: tab.id,
         fileName: tab.fileName,

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -6,9 +6,20 @@ import {
   restoreShareKeys,
   stableShareKey,
 } from "../sharing";
-import { findLiveFileInTree } from "../../types/fileTree";
-import type { FileNode } from "../../types/fileTree";
+import {
+  findLiveFileInTree,
+  isBrowserDirectoryHandle,
+  isBrowserFileHandle,
+  isNativeDirectoryTarget,
+  isNativeFileTarget,
+} from "../../types/fileTree";
+import type {
+  DirectoryTarget,
+  FileNode,
+  FileTarget,
+} from "../../types/fileTree";
 import type { HistoryEntry } from "../../types/history";
+import type { ShareRecord } from "../../types/share";
 import type { TabState } from "../../types/tab";
 import { createDefaultTab } from "../../types/tab";
 import {
@@ -242,13 +253,45 @@ export async function restoreDirectoryTabState<
 
 export async function findTabByHandle(
   tabs: TabState[],
-  handle: FileSystemFileHandle | FileSystemDirectoryHandle,
+  handle: FileTarget | DirectoryTarget,
   kind: "file" | "directory",
 ): Promise<TabState | null> {
   for (const tab of tabs) {
     const existingHandle =
       kind === "file" ? tab.fileHandle : tab.directoryHandle;
-    if (existingHandle && (await existingHandle.isSameEntry(handle))) {
+    if (!existingHandle) {
+      continue;
+    }
+
+    if (
+      isNativeFileTarget(existingHandle) &&
+      isNativeFileTarget(handle) &&
+      existingHandle.path === handle.path
+    ) {
+      return tab;
+    }
+
+    if (
+      isNativeDirectoryTarget(existingHandle) &&
+      isNativeDirectoryTarget(handle) &&
+      existingHandle.path === handle.path
+    ) {
+      return tab;
+    }
+
+    if (
+      isBrowserFileHandle(existingHandle) &&
+      isBrowserFileHandle(handle) &&
+      (await existingHandle.isSameEntry(handle))
+    ) {
+      return tab;
+    }
+
+    if (
+      isBrowserDirectoryHandle(existingHandle) &&
+      isBrowserDirectoryHandle(handle) &&
+      (await existingHandle.isSameEntry(handle))
+    ) {
       return tab;
     }
   }
@@ -256,10 +299,8 @@ export async function findTabByHandle(
   return null;
 }
 
-interface WorkspaceControllerStoreState extends WorkspaceState {}
-
 interface WorkspaceControllerActionDeps<
-  StoreState extends WorkspaceControllerStoreState,
+  StoreState extends WorkspaceState,
 > extends WorkspaceControllerDeps {
   set: SetState<StoreState>;
   get: GetState<StoreState>;
@@ -349,7 +390,7 @@ async function restoreActiveFileFromTree(input: {
   persistedFileName: string | null;
   persistedRawContent: string;
 }): Promise<{
-  fileHandle: FileSystemFileHandle | null;
+  fileHandle: FileTarget | null;
   fileName: string | null;
   rawContent: string;
   restoreMessage: string | null;
@@ -606,14 +647,17 @@ export function createWorkspaceControllerActions<
         return;
       }
 
-      const docIdsToUnsubscribe = tab.shares
-        .map((share) => share.docId)
-        .filter(
-          (docId) =>
-            !nextTabState.updatedTabs.some((currentTab) =>
-              currentTab.shares.some((share) => share.docId === docId),
-            ),
+      const docIdsToUnsubscribe: string[] = [];
+      for (const share of tab.shares) {
+        const isStillOpen = nextTabState.updatedTabs.some((currentTab) =>
+          currentTab.shares.some(
+            (currentShare) => currentShare.docId === share.docId,
+          ),
         );
+        if (!isStillOpen) {
+          docIdsToUnsubscribe.push(share.docId);
+        }
+      }
 
       const historyEntry = createHistoryEntry(tab);
       if (historyEntry) {
@@ -1105,7 +1149,10 @@ export function createWorkspaceControllerActions<
         }));
       }
 
-      const activeShares = get().tabs.flatMap((tab) => tab.shares);
+      const activeShares: ShareRecord[] = [];
+      for (const tab of get().tabs) {
+        activeShares.push(...tab.shares);
+      }
       ensureRelaySubscriptions(activeShares);
     },
   };

--- a/src/modules/workspace/test/nativeTargets.test.ts
+++ b/src/modules/workspace/test/nativeTargets.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultTab } from "../../../types/tab";
+import { findTabByHandle } from "../controller";
+
+describe("native workspace targets", () => {
+  it("matches existing file tabs by native path", async () => {
+    const tab = createDefaultTab({
+      id: "tab-1",
+      label: "notes.md",
+      fileHandle: {
+        kind: "native_file",
+        path: "/tmp/project/notes.md",
+        name: "notes.md",
+      },
+    });
+
+    await expect(
+      findTabByHandle(
+        [tab],
+        {
+          kind: "native_file",
+          path: "/tmp/project/notes.md",
+          name: "notes.md",
+        },
+        "file",
+      ),
+    ).resolves.toBe(tab);
+  });
+
+  it("matches existing directory tabs by native path", async () => {
+    const tab = createDefaultTab({
+      id: "tab-1",
+      label: "project",
+      directoryHandle: {
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      },
+    });
+
+    await expect(
+      findTabByHandle(
+        [tab],
+        {
+          kind: "native_directory",
+          path: "/tmp/project",
+          name: "project",
+        },
+        "directory",
+      ),
+    ).resolves.toBe(tab);
+  });
+});

--- a/src/runtime/workspace.ts
+++ b/src/runtime/workspace.ts
@@ -5,6 +5,7 @@ import type {
   NativeDirectoryTarget,
   NativeFileTarget,
 } from "../types/fileTree";
+import { isNativeDirectoryTarget, isNativeFileTarget } from "../types/fileTree";
 
 export type NativeWorkspaceFileTarget = NativeFileTarget;
 export type NativeWorkspaceDirectoryTarget = NativeDirectoryTarget;
@@ -35,11 +36,11 @@ export interface WorkspaceRuntime {
 export function isNativeWorkspaceFileTarget(
   target: WorkspaceFileTarget,
 ): target is NativeWorkspaceFileTarget {
-  return target.kind === "native_file";
+  return isNativeFileTarget(target);
 }
 
 export function isNativeWorkspaceDirectoryTarget(
   target: WorkspaceDirectoryTarget,
 ): target is NativeWorkspaceDirectoryTarget {
-  return target.kind === "native_directory";
+  return isNativeDirectoryTarget(target);
 }

--- a/src/types/fileTree.ts
+++ b/src/types/fileTree.ts
@@ -14,6 +14,30 @@ export type FileTarget = FileSystemFileHandle | NativeFileTarget;
 
 export type DirectoryTarget = FileSystemDirectoryHandle | NativeDirectoryTarget;
 
+export function isNativeFileTarget(
+  target: FileTarget,
+): target is NativeFileTarget {
+  return target.kind === "native_file";
+}
+
+export function isNativeDirectoryTarget(
+  target: DirectoryTarget,
+): target is NativeDirectoryTarget {
+  return target.kind === "native_directory";
+}
+
+export function isBrowserFileHandle(
+  target: FileTarget,
+): target is FileSystemFileHandle {
+  return target.kind === "file";
+}
+
+export function isBrowserDirectoryHandle(
+  target: DirectoryTarget,
+): target is FileSystemDirectoryHandle {
+  return target.kind === "directory";
+}
+
 export interface FileNode {
   kind: "file";
   name: string;

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -1,4 +1,5 @@
 import type { HydratedSidebarTreeNode } from "./fileTree";
+import type { DirectoryTarget, FileTarget } from "./fileTree";
 import {
   createSharingTabState,
   type SharingTabState,
@@ -14,11 +15,11 @@ export interface TabState extends SharingTabState, HostReviewTabState {
   id: string;
   label: string;
 
-  fileHandle: FileSystemFileHandle | null;
+  fileHandle: FileTarget | null;
   fileName: string | null;
   rawContent: string;
 
-  directoryHandle: FileSystemDirectoryHandle | null;
+  directoryHandle: DirectoryTarget | null;
   directoryName: string | null;
   fileTree: HydratedSidebarTreeNode[];
   activeFilePath: string | null;


### PR DESCRIPTION
## Summary
- Widen host tab/file-tree state to store either browser handles or native desktop path targets.
- Match existing native file and directory tabs by path so desktop opens reuse the right tab.
- Document the browser/native target split and add native target matching coverage.

## Verification
- 
px tsc --noEmit
- 
px vitest run src/modules/workspace/test/nativeTargets.test.ts src/runtime/desktopWorkspaceRuntime.test.ts src/runtime/webWorkspaceRuntime.test.ts src/modules/workspace/test/refreshFile.test.ts src/modules/host-review/test/addComment.test.ts src/modules/sharing/test/storeShareActions.test.ts
- 
px eslint src/types/fileTree.ts src/types/tab.ts src/modules/workspace/controller.ts src/modules/workspace/test/nativeTargets.test.ts src/modules/host-review/controller.ts src/modules/sharing/controller.ts src/runtime/workspace.ts (0 errors; existing unsafe-resolution warnings in large controller files)
- 
px prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md src/types/fileTree.ts src/types/tab.ts src/runtime/workspace.ts src/modules/workspace/controller.ts src/modules/workspace/test/nativeTargets.test.ts src/modules/host-review/controller.ts src/modules/sharing/controller.ts
- git diff --check
