### PR TITLE
Select desktop runtime for Tauri

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -135,17 +135,18 @@ not in Zustand.
 
 The Tauri shell under `src-tauri/` loads the same React app as the website. It is
 the native container for future filesystem, watcher, terminal, and agent runtime
-adapters. The website runtime remains the default `src/runtime/` export until a
-desktop-specific runtime entrypoint is added.
+adapters. Normal Vite builds use the web runtime. Tauri dev/build commands run
+Vite in `desktop` mode, where `vite.config.ts` aliases the active runtime module
+to the desktop runtime implementation.
 
 The bridge from the frontend to native commands lives in
 `src/runtime/tauriBridge.ts`. It uses Tauri v2's global `window.__TAURI__.core`
 API, which is enabled only by the desktop shell config. Web execution therefore
 continues to reject desktop command calls instead of importing native APIs.
 
-Desktop runtime composition lives in `src/runtime/desktop.ts`. It is not the
-default website runtime export; it gives the desktop shell a separate module to
-adopt once native filesystem and agent adapters are ready.
+Desktop runtime composition lives in `src/runtime/desktop.ts`. The public
+`src/runtime/` facade imports `runtime.active`; website builds resolve that to
+`runtime.web`, while desktop builds resolve it to `runtime.desktop`.
 
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based
@@ -159,8 +160,8 @@ to those commands stays behind `src/runtime/tauriBridge.ts` response validation.
 `WorkspaceRuntime` interface for native path targets.
 
 Native open-file and open-folder dialogs are also exposed through Tauri bridge
-commands. They return path targets and are kept separate from the default web
-open flow until host tab state can store native workspace sessions.
+commands. The desktop workspace runtime uses those dialogs for host open flows
+and returns native path targets.
 
 Host tab state can store either browser handles or native path targets for live
 file and directory access. Browser handles remain the only targets persisted in

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -235,8 +235,9 @@ The desktop work should not remove or degrade the website:
 - The web runtime keeps copy-prompt handoff.
 - Peer mode remains browser-accessible.
 - Shared UI uses capability checks for desktop-only controls.
-- Desktop-specific setup, runner, and terminal code should not be imported by
-  the website bundle.
+- Normal Vite builds resolve the active runtime to `runtime.web`; Tauri
+  dev/build commands run Vite in `desktop` mode, where `vite.config.ts` resolves
+  the active runtime to `runtime.desktop`.
 
 ## Migration Strategy
 
@@ -258,6 +259,11 @@ Initial implementation note: the first foundation slice introduces
 runtime that delegates to the existing browser filesystem implementation. This
 does not add desktop execution yet; it creates the boundary the desktop runtime
 can implement later.
+
+Current implementation note: the Tauri shell now runs Vite in `desktop` mode,
+which selects the desktop runtime facade. Desktop open-file and open-folder
+actions use native Tauri dialogs and return native path targets, while normal web
+builds continue to use the browser file API runtime.
 
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and a controller action for active-file threaded

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.0.0",
   "identifier": "ink.critiq.lollipopdragon",
   "build": {
-    "beforeDevCommand": "npm run dev -- --host 127.0.0.1",
+    "beforeDevCommand": "npm run dev -- --host 127.0.0.1 --mode desktop",
     "devUrl": "http://127.0.0.1:5173",
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "npm run build -- --mode desktop",
     "frontendDist": "../dist"
   },
   "app": {

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -50,6 +50,15 @@ const HISTORY_KEY = "markreview-history";
 const HISTORY_LIMIT = 20;
 const HISTORY_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
+async function saveBrowserHandle(
+  key: string,
+  handle: FileTarget | DirectoryTarget,
+): Promise<void> {
+  if (isBrowserFileHandle(handle) || isBrowserDirectoryHandle(handle)) {
+    await saveHandle(key, handle);
+  }
+}
+
 function isHistoryEntry(value: unknown): value is HistoryEntry {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -750,7 +759,7 @@ export function createWorkspaceControllerActions<
         tabs: [...state.tabs, tab],
         activeTabId: tab.id,
       }));
-      await saveHandle(`tab:${tab.id}:file`, result.handle);
+      await saveBrowserHandle(`tab:${tab.id}:file`, result.handle);
     },
 
     openDirectoryInNewTab: async () => {
@@ -781,7 +790,7 @@ export function createWorkspaceControllerActions<
         activeTabId: tab.id,
       }));
 
-      await saveHandle(`tab:${tab.id}:directory`, result.handle);
+      await saveBrowserHandle(`tab:${tab.id}:directory`, result.handle);
       const tree = await buildFileTree(result.handle);
       set((state) => ({
         tabs: buildUpdatedTabs(state.tabs, tab.id, () => ({
@@ -807,7 +816,7 @@ export function createWorkspaceControllerActions<
             return;
           }
 
-          await saveHandle(`tab:${tabId}:directory`, result.handle);
+          await saveBrowserHandle(`tab:${tabId}:directory`, result.handle);
           const tree = await buildFileTree(result.handle);
           const restoredFile = await restoreActiveFileFromTree({
             tree,
@@ -865,7 +874,7 @@ export function createWorkspaceControllerActions<
           return;
         }
 
-        await saveHandle(`tab:${tabId}:file`, result.handle);
+        await saveBrowserHandle(`tab:${tabId}:file`, result.handle);
         const rawContent = await readFile(result.handle);
         set((state) => ({
           tabs: buildUpdatedTabs(state.tabs, tabId, () => ({

--- a/src/runtime/desktopWorkspaceRuntime.test.ts
+++ b/src/runtime/desktopWorkspaceRuntime.test.ts
@@ -1,18 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./tauriBridge", () => ({
+  openTauriDirectory: vi.fn(),
+  openTauriTextFile: vi.fn(),
   readTauriDirectoryTree: vi.fn(),
   readTauriTextFile: vi.fn(),
   writeTauriTextFile: vi.fn(),
 }));
 
 import {
+  openTauriDirectory,
+  openTauriTextFile,
   readTauriDirectoryTree,
   readTauriTextFile,
   writeTauriTextFile,
 } from "./tauriBridge";
 import { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";
-import type { NativeWorkspaceFileTarget } from "./workspace";
+import type {
+  NativeWorkspaceDirectoryTarget,
+  NativeWorkspaceFileTarget,
+} from "./workspace";
 
 function createFileHandle(name: string): FileSystemFileHandle {
   return {
@@ -48,6 +55,33 @@ beforeEach(() => {
 });
 
 describe("desktopWorkspaceRuntime", () => {
+  it("delegates native file and directory opens to Tauri dialogs", async () => {
+    const fileTarget: NativeWorkspaceFileTarget = {
+      kind: "native_file",
+      path: "/tmp/project/notes.md",
+      name: "notes.md",
+    };
+    const directoryTarget: NativeWorkspaceDirectoryTarget = {
+      kind: "native_directory",
+      path: "/tmp/project",
+      name: "project",
+    };
+    vi.mocked(openTauriTextFile).mockResolvedValue(fileTarget);
+    vi.mocked(openTauriDirectory).mockResolvedValue(directoryTarget);
+
+    await expect(desktopWorkspaceRuntime.openFile()).resolves.toEqual({
+      handle: fileTarget,
+      name: "notes.md",
+    });
+    await expect(desktopWorkspaceRuntime.openDirectory()).resolves.toEqual({
+      handle: directoryTarget,
+      name: "project",
+    });
+
+    expect(openTauriTextFile).toHaveBeenCalled();
+    expect(openTauriDirectory).toHaveBeenCalled();
+  });
+
   it("delegates native file reads and writes to Tauri commands", async () => {
     const target: NativeWorkspaceFileTarget = {
       kind: "native_file",

--- a/src/runtime/desktopWorkspaceRuntime.ts
+++ b/src/runtime/desktopWorkspaceRuntime.ts
@@ -1,5 +1,7 @@
 import type { DirectoryNode, FileTreeNode } from "../types/fileTree";
 import {
+  openTauriDirectory,
+  openTauriTextFile,
   readTauriDirectoryTree,
   readTauriTextFile,
   type TauriNativeTreeNode,
@@ -40,8 +42,28 @@ function nativeTreeNodeToFileTreeNode(
 }
 
 export const desktopWorkspaceRuntime: WorkspaceRuntime = {
-  openFile: () => Promise.resolve(null),
-  openDirectory: () => Promise.resolve(null),
+  openFile: async () => {
+    const target = await openTauriTextFile();
+    if (!target) {
+      return null;
+    }
+
+    return {
+      handle: target,
+      name: target.name,
+    };
+  },
+  openDirectory: async () => {
+    const target = await openTauriDirectory();
+    if (!target) {
+      return null;
+    }
+
+    return {
+      handle: target,
+      name: target.name,
+    };
+  },
   readFile: (target) => {
     if (!isNativeWorkspaceFileTarget(target)) {
       return Promise.reject(

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,6 +1,4 @@
-import { webAgentRuntime } from "./agent";
-import { webTerminalRuntime } from "./terminal";
-import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
+import { activeRuntime } from "./runtime.active";
 import type {
   WorkspaceDirectoryTarget,
   WorkspaceFileTarget,
@@ -22,9 +20,9 @@ export {
   isNativeWorkspaceFileTarget,
 } from "./workspace";
 
-export const workspaceRuntime = webWorkspaceRuntime;
-export const agentRuntime = webAgentRuntime;
-export const terminalRuntime = webTerminalRuntime;
+export const workspaceRuntime = activeRuntime.workspaceRuntime;
+export const agentRuntime = activeRuntime.agentRuntime;
+export const terminalRuntime = activeRuntime.terminalRuntime;
 
 export const canRunAgent = agentRuntime.canRunAgent;
 export const canShowTerminal = terminalRuntime.canShowTerminal;

--- a/src/runtime/runtime.active.ts
+++ b/src/runtime/runtime.active.ts
@@ -1,0 +1,1 @@
+export { activeRuntime } from "./runtime.web";

--- a/src/runtime/runtime.desktop.ts
+++ b/src/runtime/runtime.desktop.ts
@@ -1,0 +1,4 @@
+import { desktopRuntime } from "./desktop";
+import type { RuntimeBundle } from "./runtimeBundle";
+
+export const activeRuntime: RuntimeBundle = desktopRuntime;

--- a/src/runtime/runtime.web.ts
+++ b/src/runtime/runtime.web.ts
@@ -1,0 +1,10 @@
+import { webAgentRuntime } from "./agent";
+import type { RuntimeBundle } from "./runtimeBundle";
+import { webTerminalRuntime } from "./terminal";
+import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
+
+export const activeRuntime: RuntimeBundle = {
+  workspaceRuntime: webWorkspaceRuntime,
+  agentRuntime: webAgentRuntime,
+  terminalRuntime: webTerminalRuntime,
+};

--- a/src/runtime/runtimeBundle.ts
+++ b/src/runtime/runtimeBundle.ts
@@ -1,0 +1,9 @@
+import type { AgentRuntime } from "./agent";
+import type { TerminalRuntime } from "./terminal";
+import type { WorkspaceRuntime } from "./workspace";
+
+export interface RuntimeBundle {
+  workspaceRuntime: WorkspaceRuntime;
+  agentRuntime: AgentRuntime;
+  terminalRuntime: TerminalRuntime;
+}

--- a/src/runtime/workspace.ts
+++ b/src/runtime/workspace.ts
@@ -13,12 +13,12 @@ export type WorkspaceFileTarget = FileTarget;
 export type WorkspaceDirectoryTarget = DirectoryTarget;
 
 export interface OpenedWorkspaceFile {
-  handle: FileSystemFileHandle;
+  handle: WorkspaceFileTarget;
   name: string;
 }
 
 export interface OpenedWorkspaceDirectory {
-  handle: FileSystemDirectoryHandle;
+  handle: WorkspaceDirectoryTarget;
   name: string;
 }
 

--- a/src/types/fileTree.ts
+++ b/src/types/fileTree.ts
@@ -27,13 +27,13 @@ export function isNativeDirectoryTarget(
 }
 
 export function isBrowserFileHandle(
-  target: FileTarget,
+  target: FileTarget | DirectoryTarget,
 ): target is FileSystemFileHandle {
   return target.kind === "file";
 }
 
 export function isBrowserDirectoryHandle(
-  target: DirectoryTarget,
+  target: FileTarget | DirectoryTarget,
 ): target is FileSystemDirectoryHandle {
   return target.kind === "directory";
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,43 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  base: '/',
-  plugins: [react()],
+function runtimeModuleForMode(mode: string): string {
+  if (mode === "desktop") {
+    return fileURLToPath(
+      new URL("./src/runtime/runtime.desktop.ts", import.meta.url),
+    );
+  }
+
+  return fileURLToPath(
+    new URL("./src/runtime/runtime.web.ts", import.meta.url),
+  );
+}
+
+export default defineConfig(({ mode }) => ({
+  base: "/",
+  plugins: react(),
+  resolve: {
+    alias: [
+      {
+        find: "./runtime.active",
+        replacement: runtimeModuleForMode(mode),
+      },
+    ],
+  },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    setupFiles: './src/testing/setup.ts',
+    setupFiles: "./src/testing/setup.ts",
     coverage: {
-      provider: 'v8',
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: ['src/**/test/**', 'src/**/*.test.{ts,tsx}', 'src/testing/**', 'src/**/*.d.ts'],
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/test/**",
+        "src/**/*.test.{ts,tsx}",
+        "src/testing/**",
+        "src/**/*.d.ts",
+      ],
       thresholds: {
         lines: 60,
         functions: 60,
@@ -20,4 +46,4 @@ export default defineConfig({
       },
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
- Add an active runtime facade that resolves to web by default and to desktop when Vite runs in desktop mode.
- Configure Tauri dev/build commands to run Vite with --mode desktop while keeping normal website builds on the web runtime.
- Wire the desktop workspace runtime open-file/open-folder methods to native Tauri dialogs and keep IndexedDB handle persistence browser-only.
- Update architecture docs for the active-runtime split.

## Verification
- 
px tsc --noEmit
- 
px vitest run src/runtime/webWorkspaceRuntime.test.ts src/runtime/desktopWorkspaceRuntime.test.ts src/runtime/webAgentRuntime.test.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/desktopTerminalRuntime.test.ts src/runtime/tauriBridge.test.ts src/modules/workspace/test/nativeTargets.test.ts
- 
px vite build
- 
px vite build --mode desktop
- 
px prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md src-tauri/tauri.conf.json vite.config.ts src/runtime/runtimeBundle.ts src/runtime/runtime.web.ts src/runtime/runtime.desktop.ts src/runtime/runtime.active.ts src/runtime/index.ts src/runtime/workspace.ts src/runtime/desktopWorkspaceRuntime.ts src/runtime/desktopWorkspaceRuntime.test.ts src/types/fileTree.ts src/modules/workspace/controller.ts
- git diff --check
- Focused eslint on touched runtime/config/workspace files: 0 errors; existing unsafe-resolution warnings remain in src/modules/workspace/controller.ts.

## Notes
- 
pm run build still runs 	sc -b first and currently fails on existing broad project type errors outside this slice; direct Vite production and desktop-mode builds pass.
