### PR TITLE
Add native agent runner command

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,6 +148,12 @@ Desktop runtime composition lives in `src/runtime/desktop.ts`. The public
 `src/runtime/` facade imports `runtime.active`; website builds resolve that to
 `runtime.web`, while desktop builds resolve it to `runtime.desktop`.
 
+Desktop agent execution is routed through Tauri commands. The native side reads
+`DRAGON_AGENT_COMMAND`, starts that command in a shell, writes the generated
+review prompt to stdin, and tracks the child process by runtime run id. Runner
+processes remain outside Zustand; the store keeps only serializable run
+metadata.
+
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based
 objects reserved for desktop adapters. The web runtime rejects native targets

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -265,6 +265,13 @@ which selects the desktop runtime facade. Desktop open-file and open-folder
 actions use native Tauri dialogs and return native path targets, while normal web
 builds continue to use the browser file API runtime.
 
+Native runner implementation note: desktop agent runs now call Tauri
+`dragon_start_agent_run`. The command is intentionally configurable through
+`DRAGON_AGENT_COMMAND`; Dragon sends the generated prompt to the process stdin
+and stores only the returned runtime run id in app state. This keeps tmux, Codex
+CLI, and other runner choices behind the native runtime boundary instead of
+hard-coding one backend into the UI/store contract.
+
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and a controller action for active-file threaded
 questions. The action builds an `AgentRunRequest` with one tab, one target path,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,21 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::env;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri_plugin_dialog::DialogExt;
 
 const IGNORED_NAMES: [&str; 3] = ["node_modules", ".git", ".markreview"];
 const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
+const AGENT_COMMAND_ENV: &str = "DRAGON_AGENT_COMMAND";
+
+static AGENT_RUN_COUNTER: AtomicU64 = AtomicU64::new(1);
+static AGENT_RUNS: OnceLock<Mutex<HashMap<String, Child>>> = OnceLock::new();
 
 #[derive(Serialize)]
 #[serde(tag = "kind")]
@@ -25,6 +36,13 @@ struct NativePathTarget {
     name: String,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentRunRequestPayload {
+    prompt: String,
+    workspace_root_path: Option<String>,
+}
+
 fn path_target_from_path(path: PathBuf) -> NativePathTarget {
     let name = path
         .file_name()
@@ -37,6 +55,44 @@ fn path_target_from_path(path: PathBuf) -> NativePathTarget {
     }
 }
 
+fn active_agent_runs() -> &'static Mutex<HashMap<String, Child>> {
+    AGENT_RUNS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn configured_agent_command() -> Result<String, String> {
+    let command = env::var(AGENT_COMMAND_ENV)
+        .map_err(|_| format!("{AGENT_COMMAND_ENV} is not configured"))?
+        .trim()
+        .to_string();
+    if command.is_empty() {
+        return Err(format!("{AGENT_COMMAND_ENV} is empty"));
+    }
+
+    Ok(command)
+}
+
+fn create_agent_run_id() -> String {
+    let counter = AGENT_RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+
+    format!("agent-{timestamp}-{counter}")
+}
+
+fn shell_command(command: &str) -> Command {
+    if cfg!(target_os = "windows") {
+        let mut process = Command::new("cmd");
+        process.arg("/C").arg(command);
+        return process;
+    }
+
+    let mut process = Command::new("sh");
+    process.arg("-lc").arg(command);
+    process
+}
+
 fn is_ignored(name: &str) -> bool {
     name.starts_with('.') || IGNORED_NAMES.contains(&name)
 }
@@ -44,7 +100,9 @@ fn is_ignored(name: &str) -> bool {
 fn is_markdown_file(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
-        .map(|extension| MARKDOWN_EXTENSIONS.contains(&extension.to_lowercase().as_str()))
+        .map(|extension| {
+            MARKDOWN_EXTENSIONS.contains(&extension.to_lowercase().as_str())
+        })
         .unwrap_or(false)
 }
 
@@ -105,7 +163,7 @@ fn dragon_runtime_ping() -> &'static str {
 
 #[tauri::command]
 fn dragon_agent_runtime_available() -> bool {
-    false
+    configured_agent_command().is_ok()
 }
 
 #[tauri::command]
@@ -145,6 +203,50 @@ fn dragon_read_directory_tree(path: String) -> Result<Vec<NativeFileTreeNode>, S
     build_native_file_tree(Path::new(&path), "")
 }
 
+#[tauri::command]
+fn dragon_start_agent_run(request: AgentRunRequestPayload) -> Result<String, String> {
+    let command = configured_agent_command()?;
+    let run_id = create_agent_run_id();
+    let mut process = shell_command(&command);
+    process.stdin(Stdio::piped());
+    process.stdout(Stdio::null());
+    process.stderr(Stdio::null());
+
+    if let Some(workspace_root_path) = request.workspace_root_path {
+        if !workspace_root_path.trim().is_empty() {
+            process.current_dir(workspace_root_path);
+        }
+    }
+
+    let mut child = process.spawn().map_err(|error| error.to_string())?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(request.prompt.as_bytes())
+            .map_err(|error| error.to_string())?;
+        stdin.write_all(b"\n").map_err(|error| error.to_string())?;
+    }
+
+    let runs = active_agent_runs();
+    let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
+    locked_runs.insert(run_id.clone(), child);
+
+    Ok(run_id)
+}
+
+#[tauri::command]
+fn dragon_stop_agent_run(run_id: String) -> Result<(), String> {
+    let runs = active_agent_runs();
+    let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
+    if let Some(mut child) = locked_runs.remove(&run_id) {
+        if child.try_wait().map_err(|error| error.to_string())?.is_none() {
+            child.kill().map_err(|error| error.to_string())?;
+        }
+        let _status = child.wait().map_err(|error| error.to_string())?;
+    }
+
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -155,7 +257,9 @@ pub fn run() {
             dragon_open_directory,
             dragon_read_text_file,
             dragon_write_text_file,
-            dragon_read_directory_tree
+            dragon_read_directory_tree,
+            dragon_start_agent_run,
+            dragon_stop_agent_run
         ])
         .run(tauri::generate_context!())
         .expect("error while running Lollipop Dragon");

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -3,6 +3,10 @@ import { buildAgentReplyPrompt, buildCommentThreadGroups } from "../../markup";
 import { agentRuntime } from "../../runtime";
 import type { AgentRuntime, AgentRunRequest } from "../../runtime";
 import type { Comment } from "../../types/criticmarkup";
+import {
+  isNativeDirectoryTarget,
+  isNativeFileTarget,
+} from "../../types/fileTree";
 import type { TabState } from "../../types/tab";
 import type {
   AgentRunStartUnavailableReason,
@@ -30,6 +34,7 @@ interface QuestionThreadRunContext {
   tabId: string;
   targetPath: string;
   questionCommentIds: string[];
+  workspaceRootPath: string | null;
 }
 
 export function getQuestionThreadCommentIds(comments: Comment[]): string[] {
@@ -40,6 +45,29 @@ export function getQuestionThreadCommentIds(comments: Comment[]): string[] {
 
 function getAgentTargetPath(tab: TabState): string | null {
   return tab.activeFilePath ?? tab.fileName;
+}
+
+function getParentPath(path: string): string | null {
+  const slashIndex = path.lastIndexOf("/");
+  const backslashIndex = path.lastIndexOf("\\");
+  const separatorIndex = Math.max(slashIndex, backslashIndex);
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  return path.slice(0, separatorIndex);
+}
+
+function getAgentWorkspaceRootPath(tab: TabState): string | null {
+  if (tab.directoryHandle && isNativeDirectoryTarget(tab.directoryHandle)) {
+    return tab.directoryHandle.path;
+  }
+
+  if (tab.fileHandle && isNativeFileTarget(tab.fileHandle)) {
+    return getParentPath(tab.fileHandle.path);
+  }
+
+  return null;
 }
 
 export function buildQuestionThreadAgentRunRequest(
@@ -55,6 +83,7 @@ export function buildQuestionThreadAgentRunRequest(
     targetPaths: [context.targetPath],
     selectedCommentIds: [...context.questionCommentIds],
     runnerKind: "terminal",
+    workspaceRootPath: context.workspaceRootPath,
     prompt: `${buildAgentReplyPrompt()}
 
 Scope:
@@ -120,6 +149,7 @@ export function createAgentWorkflowControllerActions<
         tabId: tab.id,
         targetPath,
         questionCommentIds,
+        workspaceRootPath: getAgentWorkspaceRootPath(tab),
       });
       const run = deps.get().createAgentRun({
         tabId: request.tabId,

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -51,6 +51,7 @@ describe("question thread agent run context", () => {
       tabId: "tab-1",
       targetPath: "docs/spec.md",
       questionCommentIds: ["mr-question-1", "mr-question-2"],
+      workspaceRootPath: "/tmp/project",
     });
 
     expect(request).toMatchObject({
@@ -59,6 +60,7 @@ describe("question thread agent run context", () => {
       targetPaths: ["docs/spec.md"],
       selectedCommentIds: ["mr-question-1", "mr-question-2"],
       runnerKind: "terminal",
+      workspaceRootPath: "/tmp/project",
     });
     expect(request.prompt).toContain("Work only in docs/spec.md");
     expect(request.prompt).toContain("- mr-question-1");
@@ -115,6 +117,11 @@ describe("question thread agent run controller", () => {
     setTestState({
       fileName: "spec.md",
       activeFilePath: "docs/spec.md",
+      directoryHandle: {
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      },
       comments: [
         makeComment({
           type: "question",
@@ -135,6 +142,7 @@ describe("question thread agent run controller", () => {
       taskKind: "answer_questions",
       targetPaths: ["docs/spec.md"],
       selectedCommentIds: ["mr-question-1"],
+      workspaceRootPath: "/tmp/project",
     });
     const state = useAppStore.getState();
     const runId = state.activeAgentRunIdByTabId["test-tab"];

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -10,6 +10,7 @@ export interface AgentRunRequest {
   selectedCommentIds: string[];
   prompt: string;
   runnerKind: AgentRunnerKind | null;
+  workspaceRootPath: string | null;
 }
 
 export interface AgentRuntime {

--- a/src/runtime/desktopAgentRuntime.test.ts
+++ b/src/runtime/desktopAgentRuntime.test.ts
@@ -31,19 +31,27 @@ describe("desktop agent runtime", () => {
     await expect(getDesktopAgentCapability()).resolves.toBe(false);
   });
 
-  it("does not report runnable agent support until a runner is configured", async () => {
+  it("starts and stops runs through the native agent commands", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
     window.__TAURI__ = {
       core: {
-        invoke: (command) => {
+        invoke: (command, args) => {
+          calls.push({ command, args });
           if (command === "dragon_runtime_ping") {
             return Promise.resolve("ok");
           }
-          return Promise.resolve(false);
+          if (command === "dragon_start_agent_run") {
+            return Promise.resolve("native-run-1");
+          }
+          return Promise.resolve(null);
         },
       },
     };
 
-    expect(desktopAgentRuntime.canRunAgent).toBe(false);
+    expect(desktopAgentRuntime.canRunAgent).toBe(true);
     await expect(
       desktopAgentRuntime.startRun({
         tabId: "tab-1",
@@ -52,7 +60,40 @@ describe("desktop agent runtime", () => {
         selectedCommentIds: [],
         prompt: "Answer questions",
         runnerKind: "terminal",
+        workspaceRootPath: "/tmp/project",
       }),
-    ).rejects.toThrow("Desktop agent execution is not configured");
+    ).resolves.toBe("native-run-1");
+    await desktopAgentRuntime.stopRun("native-run-1");
+
+    expect(calls).toEqual([
+      {
+        command: "dragon_runtime_ping",
+        args: undefined,
+      },
+      {
+        command: "dragon_start_agent_run",
+        args: {
+          request: {
+            tabId: "tab-1",
+            taskKind: "answer_questions",
+            targetPaths: ["docs/spec.md"],
+            selectedCommentIds: [],
+            prompt: "Answer questions",
+            runnerKind: "terminal",
+            workspaceRootPath: "/tmp/project",
+          },
+        },
+      },
+      {
+        command: "dragon_runtime_ping",
+        args: undefined,
+      },
+      {
+        command: "dragon_stop_agent_run",
+        args: {
+          runId: "native-run-1",
+        },
+      },
+    ]);
   });
 });

--- a/src/runtime/desktopAgentRuntime.ts
+++ b/src/runtime/desktopAgentRuntime.ts
@@ -3,6 +3,8 @@ import {
   getTauriAgentRuntimeAvailable,
   hasTauriBridge,
   pingTauriRuntime,
+  startTauriAgentRun,
+  stopTauriAgentRun,
 } from "./tauriBridge";
 
 export async function assertDesktopRuntimeAvailable(): Promise<void> {
@@ -19,14 +21,13 @@ export async function getDesktopAgentCapability(): Promise<boolean> {
 }
 
 export const desktopAgentRuntime: AgentRuntime = {
-  canRunAgent: false,
-  startRun: async () => {
-    const canRunAgent = await getDesktopAgentCapability();
-    if (!canRunAgent) {
-      throw new Error("Desktop agent execution is not configured");
-    }
-
-    throw new Error("Desktop agent runner command is not implemented");
+  canRunAgent: true,
+  startRun: async (request) => {
+    await assertDesktopRuntimeAvailable();
+    return startTauriAgentRun(request);
   },
-  stopRun: () => Promise.resolve(),
+  stopRun: async (runId) => {
+    await assertDesktopRuntimeAvailable();
+    await stopTauriAgentRun(runId);
+  },
 };

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -8,6 +8,8 @@ import {
   pingTauriRuntime,
   readTauriDirectoryTree,
   readTauriTextFile,
+  startTauriAgentRun,
+  stopTauriAgentRun,
   writeTauriTextFile,
 } from "./tauriBridge";
 
@@ -68,6 +70,64 @@ describe("tauri bridge", () => {
     await expect(getTauriAgentRuntimeAvailable()).rejects.toThrow(
       "Unexpected Tauri agent capability response",
     );
+  });
+
+  it("starts and stops native agent runs through Tauri commands", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
+    window.__TAURI__ = {
+      core: {
+        invoke: (command, args) => {
+          calls.push({ command, args });
+          return Promise.resolve("native-run-1");
+        },
+      },
+    };
+    const request = {
+      tabId: "tab-1",
+      taskKind: "answer_questions",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["mr-question-1"],
+      prompt: "Answer questions",
+      runnerKind: "terminal",
+      workspaceRootPath: "/tmp/project",
+    };
+
+    await expect(startTauriAgentRun(request)).resolves.toBe("native-run-1");
+    await stopTauriAgentRun("native-run-1");
+
+    expect(calls).toEqual([
+      {
+        command: "dragon_start_agent_run",
+        args: { request },
+      },
+      {
+        command: "dragon_stop_agent_run",
+        args: { runId: "native-run-1" },
+      },
+    ]);
+  });
+
+  it("rejects malformed native agent run responses", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () => Promise.resolve(null),
+      },
+    };
+
+    await expect(
+      startTauriAgentRun({
+        tabId: "tab-1",
+        taskKind: "answer_questions",
+        targetPaths: ["docs/spec.md"],
+        selectedCommentIds: [],
+        prompt: "Answer questions",
+        runnerKind: "terminal",
+        workspaceRootPath: null,
+      }),
+    ).rejects.toThrow("Unexpected native agent run response");
   });
 
   it("reads and writes native text files through Tauri commands", async () => {

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -1,3 +1,4 @@
+import type { AgentRunRequest } from "./agent";
 import type {
   NativeWorkspaceDirectoryTarget,
   NativeWorkspaceFileTarget,
@@ -10,7 +11,9 @@ export type TauriCommand =
   | "dragon_open_directory"
   | "dragon_read_text_file"
   | "dragon_write_text_file"
-  | "dragon_read_directory_tree";
+  | "dragon_read_directory_tree"
+  | "dragon_start_agent_run"
+  | "dragon_stop_agent_run";
 
 export interface TauriNativeFileNode {
   kind: "file";
@@ -215,4 +218,25 @@ export async function readTauriDirectoryTree(
     args: { path: target.path },
   });
   return parseNativeTree(result);
+}
+
+export async function startTauriAgentRun(
+  request: AgentRunRequest,
+): Promise<string> {
+  const result = await invokeTauriCommand({
+    command: "dragon_start_agent_run",
+    args: { request },
+  });
+  if (typeof result === "string") {
+    return result;
+  }
+
+  throw new Error("Unexpected native agent run response");
+}
+
+export function stopTauriAgentRun(runId: string): Promise<unknown> {
+  return invokeTauriCommand({
+    command: "dragon_stop_agent_run",
+    args: { runId },
+  });
 }

--- a/src/runtime/webAgentRuntime.test.ts
+++ b/src/runtime/webAgentRuntime.test.ts
@@ -14,6 +14,7 @@ describe("web agent runtime capabilities", () => {
         selectedCommentIds: [],
         prompt: "Address comments",
         runnerKind: null,
+        workspaceRootPath: null,
       }),
     ).rejects.toThrow("Local agent execution is unavailable on web");
   });


### PR DESCRIPTION
## Summary
- Add native Tauri commands to start/stop configurable desktop agent runs via DRAGON_AGENT_COMMAND.
- Send the generated Dragon review prompt to the runner process over stdin and track child processes by runtime run id outside Zustand.
- Route desktopAgentRuntime.startRun/stopRun through the Tauri bridge and pass a native workspace root when available.
- Document the native runner boundary and configuration contract.

## Verification
- 
px tsc --noEmit
- 
px vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/runtime/webAgentRuntime.test.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts
- 
px eslint src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/runtime/agent.ts src/runtime/desktopAgentRuntime.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.ts src/runtime/tauriBridge.test.ts src/runtime/webAgentRuntime.test.ts
- 
px prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/runtime/agent.ts src/runtime/desktopAgentRuntime.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.ts src/runtime/tauriBridge.test.ts src/runtime/webAgentRuntime.test.ts
- 
px vite build --mode desktop
- 
px vite build
- git diff --check

## Notes
- Native Rust compile/format checks could not run in this WSL image because cargo is not installed. The desktop frontend bundle still builds in desktop mode.
