### PR TITLE
Add agent run controls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,6 +154,10 @@ review prompt to stdin, and tracks the child process by runtime run id. Runner
 processes remain outside Zustand; the store keeps only serializable run
 metadata.
 
+Host UI surfaces active agent run state per tab. The comment panel hides new
+agent-start actions while the tab has a queued/running/attention run and exposes
+a stop control that routes through the runtime before marking the run stopped.
+
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based
 objects reserved for desktop adapters. The web runtime rejects native targets

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -272,6 +272,11 @@ and stores only the returned runtime run id in app state. This keeps tmux, Codex
 CLI, and other runner choices behind the native runtime boundary instead of
 hard-coding one backend into the UI/store contract.
 
+Run-control implementation note: the comment panel now shows the active run for
+the current tab and exposes a stop action while the run is queued, running, or
+needs attention. Stopping calls the runtime before the serializable run status is
+updated to `stopped`.
+
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and a controller action for active-file threaded
 questions. The action builds an `AgentRunRequest` with one tab, one target path,

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -11,6 +11,8 @@ import type { TabState } from "../../types/tab";
 import type {
   AgentRunStartUnavailableReason,
   AgentRunStartResult,
+  AgentRunStopUnavailableReason,
+  AgentRunStopResult,
   AgentWorkflowActions,
   AgentWorkflowControllerActions,
   AgentWorkflowState,
@@ -105,6 +107,17 @@ function unavailableResult(input: {
   };
 }
 
+function unavailableStopResult(input: {
+  reason: AgentRunStopUnavailableReason;
+  message: string;
+}): AgentRunStopResult {
+  return {
+    status: "unavailable",
+    reason: input.reason,
+    message: input.message,
+  };
+}
+
 export function createAgentWorkflowControllerActions<
   StoreState extends AgentWorkflowControllerStoreState,
 >(
@@ -184,6 +197,54 @@ export function createAgentWorkflowControllerActions<
         deps.showToast("Agent run failed to start");
         return unavailableResult({
           reason: "agent_unavailable",
+          message,
+        });
+      }
+    },
+
+    stopActiveAgentRun: async () => {
+      const tab = deps.getActiveTab(deps.get);
+      if (!tab) {
+        return unavailableStopResult({
+          reason: "no_active_tab",
+          message: "Open a file or folder before stopping an agent run.",
+        });
+      }
+
+      const runId = deps.get().activeAgentRunIdByTabId[tab.id];
+      const run = runId ? deps.get().agentRuns[runId] : null;
+      if (!run) {
+        return unavailableStopResult({
+          reason: "no_active_run",
+          message: "No active agent run is attached to this tab.",
+        });
+      }
+
+      try {
+        if (run.terminalAttachmentId) {
+          await runtime.stopRun(run.terminalAttachmentId);
+        }
+        deps.get().updateAgentRunStatus({
+          runId: run.id,
+          status: "stopped",
+        });
+        deps.showToast("Agent run stopped");
+        return {
+          status: "stopped",
+          runId: run.id,
+        };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Agent run failed to stop";
+        console.error("[agent-workflow] failed to stop agent run:", error);
+        deps.get().updateAgentRunStatus({
+          runId: run.id,
+          status: "failed",
+          errorMessage: message,
+        });
+        deps.showToast("Agent run failed to stop");
+        return unavailableStopResult({
+          reason: "runtime_stop_failed",
           message,
         });
       }

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -158,4 +158,50 @@ describe("question thread agent run controller", () => {
     });
     expect(showToastMessages).toEqual(["Agent run started"]);
   });
+
+  it("stops the active tab run through the injected runtime", async () => {
+    const stoppedRuntimeRunIds: string[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: () => Promise.resolve("terminal-session-1"),
+      stopRun: (runId) => {
+        stoppedRuntimeRunIds.push(runId);
+        return Promise.resolve();
+      },
+    };
+    const showToastMessages: string[] = [];
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: (message) => {
+        showToastMessages.push(message);
+      },
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+    });
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "test-tab",
+      taskKind: "answer_questions",
+      targetPaths: ["spec.md"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+    });
+
+    const result = await actions.stopActiveAgentRun();
+
+    expect(result).toEqual({
+      status: "stopped",
+      runId: run.id,
+    });
+    expect(stoppedRuntimeRunIds).toEqual(["native-run-1"]);
+    expect(useAppStore.getState().agentRuns[run.id]?.status).toBe("stopped");
+    expect(showToastMessages).toEqual(["Agent run stopped"]);
+  });
 });

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -72,6 +72,23 @@ export type AgentRunStartResult =
       message: string;
     };
 
+export type AgentRunStopUnavailableReason =
+  | "no_active_tab"
+  | "no_active_run"
+  | "runtime_stop_failed";
+
+export type AgentRunStopResult =
+  | {
+      status: "stopped";
+      runId: string;
+    }
+  | {
+      status: "unavailable";
+      reason: AgentRunStopUnavailableReason;
+      message: string;
+    };
+
 export interface AgentWorkflowControllerActions {
   startQuestionThreadAgentRun: () => Promise<AgentRunStartResult>;
+  stopActiveAgentRun: () => Promise<AgentRunStopResult>;
 }

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -129,6 +129,54 @@
   color: var(--text-secondary);
 }
 
+.comment-panel__agent-run {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--surface-alt);
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+}
+
+.comment-panel__agent-run-copy {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.comment-panel__agent-run-label {
+  font-weight: 650;
+  color: var(--text);
+}
+
+.comment-panel__agent-run-error {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--c-red);
+}
+
+.comment-panel__agent-run-action {
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 650;
+  padding: 0.18rem 0.5rem;
+}
+
+.comment-panel__agent-run-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .comment-panel__close {
   background: none;
   border: none;

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { CommentPanel } from "./index";
 import { useAppStore } from "../../../store";
 import { getActiveTab } from "../../../store/selectors";
@@ -12,280 +12,348 @@ import {
 import type { Comment } from "../../../types/criticmarkup";
 
 function makeResolvedComment(id: string, text: string) {
-  return makeCommentBase({ id, type: 'fix', text, raw: `{>>fix: ${text}<<}` })
+  return makeCommentBase({ id, type: "fix", text, raw: `{>>fix: ${text}<<}` });
 }
 
-function makeComment(id: string, type: Comment['type'], text: string, blockIndex = 0) {
-  return makeCommentBase({ id, type, text, raw: `{>>${text}<<}`, blockIndex })
+function makeComment(
+  id: string,
+  type: Comment["type"],
+  text: string,
+  blockIndex = 0,
+) {
+  return makeCommentBase({ id, type, text, raw: `{>>${text}<<}`, blockIndex });
 }
 
 const comments: Comment[] = [
-  makeComment('0', 'fix', 'fix the intro', 0),
-  makeComment('1', 'rewrite', 'rewrite paragraph', 1),
-  makeComment('2', 'fix', 'another fix', 2),
-]
+  makeComment("0", "fix", "fix the intro", 0),
+  makeComment("1", "rewrite", "rewrite paragraph", 1),
+  makeComment("2", "fix", "another fix", 2),
+];
 
 beforeEach(() => {
-  resetTestStore()
+  resetTestStore();
   setTestState({
     comments: [],
     resolvedComments: [],
     activeCommentId: null,
     commentPanelOpen: true,
-    commentFilter: 'all',
-  })
-  vi.restoreAllMocks()
-})
+    commentFilter: "all",
+  });
+  vi.restoreAllMocks();
+});
 
-describe('CommentPanel — list rendering', () => {
-  it('shows empty state when there are no comments', () => {
-    render(<CommentPanel />)
-    expect(screen.getByText(/No comments in this document/)).toBeInTheDocument()
-  })
+describe("CommentPanel — list rendering", () => {
+  it("shows empty state when there are no comments", () => {
+    render(<CommentPanel />);
+    expect(
+      screen.getByText(/No comments in this document/),
+    ).toBeInTheDocument();
+  });
 
   it('shows all comments when filter is "all"', () => {
-    setTestState({ comments })
-    render(<CommentPanel />)
-    expect(screen.getByText('fix the intro')).toBeInTheDocument()
-    expect(screen.getByText('rewrite paragraph')).toBeInTheDocument()
-    expect(screen.getByText('another fix')).toBeInTheDocument()
-  })
+    setTestState({ comments });
+    render(<CommentPanel />);
+    expect(screen.getByText("fix the intro")).toBeInTheDocument();
+    expect(screen.getByText("rewrite paragraph")).toBeInTheDocument();
+    expect(screen.getByText("another fix")).toBeInTheDocument();
+  });
 
-  it('shows type badges for each comment', () => {
-    setTestState({ comments: [makeComment('0', 'fix', 'some text')] })
-    render(<CommentPanel />)
-    expect(screen.getByText('fix')).toBeInTheDocument()
-  })
+  it("shows type badges for each comment", () => {
+    setTestState({ comments: [makeComment("0", "fix", "some text")] });
+    render(<CommentPanel />);
+    expect(screen.getByText("fix")).toBeInTheDocument();
+  });
 
-  it('shows block ref for each comment', () => {
-    setTestState({ comments: [makeComment('0', 'note', 'note', 3)] })
-    render(<CommentPanel />)
-    expect(screen.getByText('¶4')).toBeInTheDocument()
-  })
+  it("shows block ref for each comment", () => {
+    setTestState({ comments: [makeComment("0", "note", "note", 3)] });
+    render(<CommentPanel />);
+    expect(screen.getByText("¶4")).toBeInTheDocument();
+  });
 
-  it('shows the total comment count', () => {
-    setTestState({ comments })
-    const { container } = render(<CommentPanel />)
-    expect(container.querySelector('.comment-panel__count')?.textContent).toBe('3')
-  })
-})
+  it("shows the total comment count", () => {
+    setTestState({ comments });
+    const { container } = render(<CommentPanel />);
+    expect(container.querySelector(".comment-panel__count")?.textContent).toBe(
+      "3",
+    );
+  });
+});
 
-describe('CommentPanel — filtering', () => {
+describe("CommentPanel — filtering", () => {
   beforeEach(() => {
-    setTestState({ comments })
-  })
+    setTestState({ comments });
+  });
 
-  it('shows filter buttons when multiple types are present', () => {
-    render(<CommentPanel />)
+  it("shows filter buttons when multiple types are present", () => {
+    render(<CommentPanel />);
     // Filter button accessible names include the count: "All 3", "fix 2", "rewrite 1"
-    expect(screen.getByRole('button', { name: /^All\s+\d/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^fix\s+\d/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^rewrite\s+\d/ })).toBeInTheDocument()
-  })
+    expect(
+      screen.getByRole("button", { name: /^All\s+\d/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^fix\s+\d/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^rewrite\s+\d/ }),
+    ).toBeInTheDocument();
+  });
 
-  it('filters comments by type when a filter button is clicked', async () => {
-    const user = userEvent.setup()
-    render(<CommentPanel />)
-    await user.click(screen.getByRole('button', { name: /^fix\s+\d/ }))
-    expect(screen.getByText('fix the intro')).toBeInTheDocument()
-    expect(screen.getByText('another fix')).toBeInTheDocument()
-    expect(screen.queryByText('rewrite paragraph')).not.toBeInTheDocument()
-  })
+  it("filters comments by type when a filter button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CommentPanel />);
+    await user.click(screen.getByRole("button", { name: /^fix\s+\d/ }));
+    expect(screen.getByText("fix the intro")).toBeInTheDocument();
+    expect(screen.getByText("another fix")).toBeInTheDocument();
+    expect(screen.queryByText("rewrite paragraph")).not.toBeInTheDocument();
+  });
 
-  it('shows "no comments match" message when filter yields nothing after store change', async () => {
+  it('shows "no comments match" message when filter yields nothing after store change', () => {
     // Set filter to 'expand' (no expand comments in the list)
-    setTestState({ commentFilter: 'expand' })
-    render(<CommentPanel />)
-    expect(screen.getByText(/No comments match/)).toBeInTheDocument()
-  })
+    setTestState({ commentFilter: "expand" });
+    render(<CommentPanel />);
+    expect(screen.getByText(/No comments match/)).toBeInTheDocument();
+  });
 
-  it('resets to all when clicking an active filter', async () => {
-    const user = userEvent.setup()
-    setTestState({ commentFilter: 'fix' })
-    render(<CommentPanel />)
-    await user.click(screen.getAllByRole('button', { name: /^fix/ })[0])
-    const tab = getActiveTab(useAppStore.getState())
-    expect(tab?.commentFilter).toBe('all')
-  })
-})
+  it("resets to all when clicking an active filter", async () => {
+    const user = userEvent.setup();
+    setTestState({ commentFilter: "fix" });
+    render(<CommentPanel />);
+    await user.click(screen.getAllByRole("button", { name: /^fix/ })[0]);
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.commentFilter).toBe("all");
+  });
+});
 
-describe('CommentPanel — active entry', () => {
-  it('marks the active comment entry', () => {
-    setTestState({ comments, activeCommentId: '1' })
-    const { container } = render(<CommentPanel />)
-    const active = container.querySelector('.comment-panel__entry--active')
-    expect(active).toBeInTheDocument()
-    expect(active?.textContent).toContain('rewrite paragraph')
-  })
+describe("CommentPanel — active entry", () => {
+  it("marks the active comment entry", () => {
+    setTestState({ comments, activeCommentId: "1" });
+    const { container } = render(<CommentPanel />);
+    const active = container.querySelector(".comment-panel__entry--active");
+    expect(active).toBeInTheDocument();
+    expect(active?.textContent).toContain("rewrite paragraph");
+  });
 
-  it('sets activeCommentId when clicking an entry', async () => {
-    const user = userEvent.setup()
-    setTestState({ comments })
-    render(<CommentPanel />)
-    await user.click(screen.getByText('fix the intro'))
-    const tab = getActiveTab(useAppStore.getState())
-    expect(tab?.activeCommentId).toBe('0')
-  })
+  it("sets activeCommentId when clicking an entry", async () => {
+    const user = userEvent.setup();
+    setTestState({ comments });
+    render(<CommentPanel />);
+    await user.click(screen.getByText("fix the intro"));
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.activeCommentId).toBe("0");
+  });
 
-  it('clears activeCommentId when clicking the active entry again', async () => {
-    const user = userEvent.setup()
-    setTestState({ comments, activeCommentId: '0' })
-    render(<CommentPanel />)
-    await user.click(screen.getByText('fix the intro'))
-    const tab = getActiveTab(useAppStore.getState())
-    expect(tab?.activeCommentId).toBeNull()
-  })
+  it("clears activeCommentId when clicking the active entry again", async () => {
+    const user = userEvent.setup();
+    setTestState({ comments, activeCommentId: "0" });
+    render(<CommentPanel />);
+    await user.click(screen.getByText("fix the intro"));
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.activeCommentId).toBeNull();
+  });
 
-  it('keeps threaded replies out of the panel list and highlights the root entry', () => {
+  it("keeps threaded replies out of the panel list and highlights the root entry", () => {
     setTestState({
       comments: [
         makeCommentBase({
-          id: 'question-root',
-          type: 'question',
-          text: 'Why is this here?',
+          id: "question-root",
+          type: "question",
+          text: "Why is this here?",
           blockIndex: 0,
           thread: {
-            commentId: 'mr-question-1',
-            threadId: 'mr-question-1',
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
           },
         }),
         makeCommentBase({
-          id: 'answer-reply',
-          type: 'answer',
-          text: 'Because it explains reconnect fallback.',
+          id: "answer-reply",
+          type: "answer",
+          text: "Because it explains reconnect fallback.",
           blockIndex: 0,
           thread: {
-            commentId: 'mr-answer-1',
-            threadId: 'mr-question-1',
-            replyTo: 'mr-question-1',
-            authorLabel: 'Codex',
+            commentId: "mr-answer-1",
+            threadId: "mr-question-1",
+            replyTo: "mr-question-1",
+            authorLabel: "Codex",
           },
         }),
       ],
-      activeCommentId: 'answer-reply',
-    })
+      activeCommentId: "answer-reply",
+    });
 
-    const { container } = render(<CommentPanel />)
+    const { container } = render(<CommentPanel />);
 
-    expect(screen.getByText('Why is this here?')).toBeInTheDocument()
+    expect(screen.getByText("Why is this here?")).toBeInTheDocument();
     expect(
-      screen.queryByText('Because it explains reconnect fallback.'),
-    ).not.toBeInTheDocument()
+      screen.queryByText("Because it explains reconnect fallback."),
+    ).not.toBeInTheDocument();
 
-    const active = container.querySelector('.comment-panel__entry--active')
-    expect(active?.textContent).toContain('Why is this here?')
-  })
-})
+    const active = container.querySelector(".comment-panel__entry--active");
+    expect(active?.textContent).toContain("Why is this here?");
+  });
+});
 
-describe('CommentPanel — close', () => {
-  it('calls toggleCommentPanel when close button is clicked', async () => {
-    const user = userEvent.setup()
-    const mockToggle = vi.fn()
-    useAppStore.setState({ toggleCommentPanel: mockToggle })
-    render(<CommentPanel />)
-    await user.click(screen.getByRole('button', { name: 'Close comments panel' }))
-    expect(mockToggle).toHaveBeenCalledOnce()
-  })
-})
+describe("CommentPanel — close", () => {
+  it("calls toggleCommentPanel when close button is clicked", async () => {
+    const user = userEvent.setup();
+    const mockToggle = vi.fn();
+    useAppStore.setState({ toggleCommentPanel: mockToggle });
+    render(<CommentPanel />);
+    await user.click(
+      screen.getByRole("button", { name: "Close comments panel" }),
+    );
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+});
 
-describe('CommentPanel — agent prompt', () => {
-  it('shows a copy prompt button when question threads exist', () => {
+describe("CommentPanel — agent prompt", () => {
+  it("shows a copy prompt button when question threads exist", () => {
     setTestState({
       comments: [
         makeCommentBase({
-          id: 'question-root',
-          type: 'question',
-          text: 'Why is this here?',
+          id: "question-root",
+          type: "question",
+          text: "Why is this here?",
           thread: {
-            commentId: 'mr-question-1',
-            threadId: 'mr-question-1',
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
           },
         }),
       ],
-    })
+    });
 
-    render(<CommentPanel />)
+    render(<CommentPanel />);
     expect(
-      screen.getByRole('button', { name: 'Copy agent prompt' }),
-    ).toBeInTheDocument()
-  })
+      screen.getByRole("button", { name: "Copy agent prompt" }),
+    ).toBeInTheDocument();
+  });
 
-  it('copies the agent prompt to the clipboard', async () => {
-    const user = userEvent.setup()
+  it("copies the agent prompt to the clipboard", async () => {
+    const user = userEvent.setup();
     const writeText = vi
-      .spyOn(navigator.clipboard, 'writeText')
-      .mockResolvedValue(undefined)
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
 
     setTestState({
       comments: [
         makeCommentBase({
-          id: 'question-root',
-          type: 'question',
-          text: 'Why is this here?',
+          id: "question-root",
+          type: "question",
+          text: "Why is this here?",
           thread: {
-            commentId: 'mr-question-1',
-            threadId: 'mr-question-1',
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
           },
         }),
       ],
-    })
+    });
 
-    render(<CommentPanel />)
-    await user.click(screen.getByRole('button', { name: 'Copy agent prompt' }))
+    render(<CommentPanel />);
+    await user.click(screen.getByRole("button", { name: "Copy agent prompt" }));
 
-    expect(writeText).toHaveBeenCalledOnce()
-    expect(useAppStore.getState().toast).toBe('Agent prompt copied')
-  })
-})
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(useAppStore.getState().toast).toBe("Agent prompt copied");
+  });
 
-describe('CommentPanel — resolved filter', () => {
+  it("shows and stops an active agent run for the current tab", async () => {
+    const user = userEvent.setup();
+
+    setTestState({
+      comments: [
+        makeCommentBase({
+          id: "question-root",
+          type: "question",
+          text: "Why is this here?",
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+      ],
+    });
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "test-tab",
+      taskKind: "answer_questions",
+      targetPaths: ["spec.md"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+    });
+
+    render(<CommentPanel />);
+
+    expect(screen.getByText("Agent Running")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy agent prompt" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(useAppStore.getState().agentRuns[run.id]?.status).toBe("stopped");
+    expect(useAppStore.getState().toast).toBe("Agent run stopped");
+  });
+});
+
+describe("CommentPanel — resolved filter", () => {
   const resolved = [
-    makeResolvedComment('r0', 'already fixed'),
-    makeResolvedComment('r1', 'was removed'),
-  ]
+    makeResolvedComment("r0", "already fixed"),
+    makeResolvedComment("r1", "was removed"),
+  ];
 
-  it('shows Pending and Resolved buttons when resolvedComments exist', () => {
-    setTestState({ resolvedComments: resolved })
-    render(<CommentPanel />)
-    expect(screen.getByRole('button', { name: /^Pending/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^Resolved/ })).toBeInTheDocument()
-  })
+  it("shows Pending and Resolved buttons when resolvedComments exist", () => {
+    setTestState({ resolvedComments: resolved });
+    render(<CommentPanel />);
+    expect(
+      screen.getByRole("button", { name: /^Pending/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Resolved/ }),
+    ).toBeInTheDocument();
+  });
 
-  it('does not show status filter buttons when resolvedComments is empty', () => {
-    render(<CommentPanel />)
-    expect(screen.queryByRole('button', { name: /^Pending/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^Resolved/ })).not.toBeInTheDocument()
-  })
+  it("does not show status filter buttons when resolvedComments is empty", () => {
+    render(<CommentPanel />);
+    expect(
+      screen.queryByRole("button", { name: /^Pending/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^Resolved/ }),
+    ).not.toBeInTheDocument();
+  });
 
-  it('shows resolved comments in the list when Resolved filter is active', () => {
-    setTestState({ resolvedComments: resolved, commentFilter: 'resolved' })
-    render(<CommentPanel />)
-    expect(screen.getByText('already fixed')).toBeInTheDocument()
-    expect(screen.getByText('was removed')).toBeInTheDocument()
-  })
+  it("shows resolved comments in the list when Resolved filter is active", () => {
+    setTestState({ resolvedComments: resolved, commentFilter: "resolved" });
+    render(<CommentPanel />);
+    expect(screen.getByText("already fixed")).toBeInTheDocument();
+    expect(screen.getByText("was removed")).toBeInTheDocument();
+  });
 
-  it('resolved entries have strikethrough styling', () => {
-    setTestState({ resolvedComments: resolved, commentFilter: 'resolved' })
-    const { container } = render(<CommentPanel />)
-    const resolvedTexts = container.querySelectorAll('.comment-panel__text--resolved')
-    expect(resolvedTexts.length).toBe(2)
-  })
+  it("resolved entries have strikethrough styling", () => {
+    setTestState({ resolvedComments: resolved, commentFilter: "resolved" });
+    const { container } = render(<CommentPanel />);
+    const resolvedTexts = container.querySelectorAll(
+      ".comment-panel__text--resolved",
+    );
+    expect(resolvedTexts.length).toBe(2);
+  });
 
-  it('clicking Resolved sets commentFilter to resolved', async () => {
-    const user = userEvent.setup()
-    setTestState({ resolvedComments: resolved })
-    render(<CommentPanel />)
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }))
-    const tab = getActiveTab(useAppStore.getState())
-    expect(tab?.commentFilter).toBe('resolved')
-  })
+  it("clicking Resolved sets commentFilter to resolved", async () => {
+    const user = userEvent.setup();
+    setTestState({ resolvedComments: resolved });
+    render(<CommentPanel />);
+    await user.click(screen.getByRole("button", { name: /^Resolved/ }));
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.commentFilter).toBe("resolved");
+  });
 
-  it('clicking Resolved again resets to all', async () => {
-    const user = userEvent.setup()
-    setTestState({ resolvedComments: resolved, commentFilter: 'resolved' })
-    render(<CommentPanel />)
-    await user.click(screen.getByRole('button', { name: /^Resolved/ }))
-    const tab = getActiveTab(useAppStore.getState())
-    expect(tab?.commentFilter).toBe('all')
-  })
-})
+  it("clicking Resolved again resets to all", async () => {
+    const user = userEvent.setup();
+    setTestState({ resolvedComments: resolved, commentFilter: "resolved" });
+    render(<CommentPanel />);
+    await user.click(screen.getByRole("button", { name: /^Resolved/ }));
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.commentFilter).toBe("all");
+  });
+});

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -4,6 +4,8 @@ import {
   buildAgentReplyPrompt,
   buildCommentThreadGroups,
 } from "../../../markup";
+import { getActiveAgentRunForTab } from "../../../modules/agent-workflow";
+import type { AgentRunStatus } from "../../../modules/agent-workflow";
 import { canRunAgent } from "../../../runtime";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
@@ -32,6 +34,19 @@ const COMMENT_TYPES: CommentType[] = [
   "remove",
 ];
 const EDITABLE_CRITIC_TYPES: Comment["criticType"][] = ["comment", "highlight"];
+const ACTIVE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
+  "queued",
+  "running",
+  "needs_attention",
+]);
+const AGENT_RUN_STATUS_LABEL: Record<AgentRunStatus, string> = {
+  queued: "Queued",
+  running: "Running",
+  needs_attention: "Needs attention",
+  completed: "Completed",
+  failed: "Failed",
+  stopped: "Stopped",
+};
 
 function scrollToBlock(blockIndex: number | undefined) {
   if (blockIndex === undefined) {
@@ -143,6 +158,11 @@ export function CommentPanel({ peerMode = false }: Props) {
   const selectPeerFile = useAppStore((state) => state.selectPeerFile);
   const startQuestionThreadAgentRun = useAppStore(
     (state) => state.startQuestionThreadAgentRun,
+  );
+  const stopActiveAgentRun = useAppStore((state) => state.stopActiveAgentRun);
+  const clearAgentRun = useAppStore((state) => state.clearAgentRun);
+  const activeAgentRun = useAppStore((state) =>
+    tab?.id ? getActiveAgentRunForTab(state, tab.id) : null,
   );
   const sharedContent = useAppStore((state) => state.sharedContent);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
@@ -326,6 +346,10 @@ export function CommentPanel({ peerMode = false }: Props) {
     canRunAgent,
     canStartQuestionThreadRun: true,
   });
+  const canStopAgentRun = Boolean(
+    activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
+  );
+  const showAgentRunStatus = !peerMode && activeAgentRun;
 
   async function handleQuestionThreadAgentAction() {
     if (questionThreadAgentAction.kind === "copy_prompt") {
@@ -334,6 +358,13 @@ export function CommentPanel({ peerMode = false }: Props) {
     }
 
     const result = await startQuestionThreadAgentRun();
+    if (result.status === "unavailable") {
+      showToast(result.message);
+    }
+  }
+
+  async function handleStopAgentRun() {
+    const result = await stopActiveAgentRun();
     if (result.status === "unavailable") {
       showToast(result.message);
     }
@@ -372,7 +403,7 @@ export function CommentPanel({ peerMode = false }: Props) {
         </span>
         {!peerMode && displayCount > 0 && (
           <>
-            {hasQuestionThreads && (
+            {hasQuestionThreads && !canStopAgentRun && (
               <button
                 className="comment-panel__secondary-action"
                 onClick={() => {
@@ -401,13 +432,45 @@ export function CommentPanel({ peerMode = false }: Props) {
         </button>
       </div>
 
+      {showAgentRunStatus && (
+        <div className="comment-panel__agent-run" role="status">
+          <div className="comment-panel__agent-run-copy">
+            <span className="comment-panel__agent-run-label">
+              Agent {AGENT_RUN_STATUS_LABEL[activeAgentRun.status]}
+            </span>
+            {activeAgentRun.errorMessage && (
+              <span className="comment-panel__agent-run-error">
+                {activeAgentRun.errorMessage}
+              </span>
+            )}
+          </div>
+          {canStopAgentRun ? (
+            <button
+              className="comment-panel__agent-run-action"
+              onClick={() => {
+                void handleStopAgentRun();
+              }}
+            >
+              Stop
+            </button>
+          ) : (
+            <button
+              className="comment-panel__agent-run-action"
+              onClick={() => clearAgentRun(activeAgentRun.id)}
+            >
+              Dismiss
+            </button>
+          )}
+        </div>
+      )}
+
       {confirmDeleteAll && (
         <div className="comment-panel__danger-confirm" role="alert">
           <span>Delete all comments from this file?</span>
           <button
             className="comment-panel__danger-confirm-delete"
             onClick={() => {
-              deleteAllComments();
+              void deleteAllComments();
               setConfirmDeleteAll(false);
             }}
           >


### PR DESCRIPTION
## Summary
- add a store/controller stop action for the active tab agent run
- show active run status in the comment panel with Stop and Dismiss controls
- hide the start action while a run is active, and document the run-control behavior

## Verification
- 
px tsc --noEmit
- 
px vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx src/ui/agentActions.test.ts
- 
px eslint src/modules/agent-workflow/types.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.test.tsx (0 errors; existing CommentPanel warnings remain)
- 
px prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md src/modules/agent-workflow/types.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.css src/ui/components/CommentPanel/CommentPanel.test.tsx && git diff --check
- 
px vite build
- 
px vite build --mode desktop

## Notes
- src/ui/components/CommentPanel/CommentPanel.test.tsx was reformatted by the repo Prettier hook, so the test file diff is larger than the behavioral change.
