### PR TITLE
Sync native agent run status

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -152,11 +152,15 @@ Desktop agent execution is routed through Tauri commands. The native side reads
 `DRAGON_AGENT_COMMAND`, starts that command in a shell, writes the generated
 review prompt to stdin, and tracks the child process by runtime run id. Runner
 processes remain outside Zustand; the store keeps only serializable run
-metadata.
+metadata. The frontend can poll a runtime run id through the Tauri bridge to
+move the tab-scoped run from `running` to `completed` or `failed` when the child
+process exits.
 
 Host UI surfaces active agent run state per tab. The comment panel hides new
 agent-start actions while the tab has a queued/running/attention run and exposes
 a stop control that routes through the runtime before marking the run stopped.
+In desktop runtime mode, the same panel polls the native run status while an
+active runtime run id is attached.
 
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -65,6 +65,7 @@ interface AgentRuntime {
   canRunAgent: boolean;
   startRun(request: AgentRunRequest): Promise<AgentRunId>;
   stopRun(runId: AgentRunId): Promise<void>;
+  getRunStatus(runId: AgentRunId): Promise<AgentRunStatus>;
 }
 
 interface TerminalRuntime {
@@ -276,6 +277,14 @@ Run-control implementation note: the comment panel now shows the active run for
 the current tab and exposes a stop action while the run is queued, running, or
 needs attention. Stopping calls the runtime before the serializable run status is
 updated to `stopped`.
+
+Run-status implementation note: desktop agent runs now expose
+`dragon_get_agent_run_status` through the Tauri bridge. The native command polls
+the tracked child process with `try_wait`, removes completed children from the
+native process map, and returns `running`, `completed`, `failed`, or `not_found`
+to the shared runtime boundary. The comment panel polls this status only when
+the active runtime can execute agents, then reconciles the tab-scoped
+serializable run state to `completed` or `failed`.
 
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and a controller action for active-file threaded

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -222,16 +222,27 @@ The website should remain honest about what it can do:
 The website may later gain an upgrade path such as "open in desktop", but that is
 outside this first desktop planning scope.
 
+## Current Implementation Notes
+
+- The shared app now has runtime capability facades for web and desktop builds.
+- Normal website builds keep browser file APIs and prompt-copy handoff.
+- Tauri desktop builds can open native file and folder targets.
+- Desktop agent runs start through `DRAGON_AGENT_COMMAND`, receive the generated
+  review prompt through stdin, and keep process handles outside Zustand.
+- Agent run state is tab-scoped and serializable. The comment panel can stop an
+  active run and polls native run status so completed or failed processes are
+  reflected in the UI.
+
 ## Open Questions
 
-- Which desktop shell should host the first implementation: Tauri, Electrobun, or
-  another runtime?
-- Which runner should be built first: terminal/tmux runner, Codex app-server
-  runner, or both behind one interface?
 - What is the exact global concurrency limit for active runs?
 - How should desktop handle agent authentication and first-run setup?
 - What is the minimum Windows backend for terminal/session support if `tmux` is
   not available?
+- How much native file/session persistence should desktop restore across app
+  restarts?
+- Which structured runner should follow the first configurable terminal-command
+  runner?
 
 ## References
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,14 @@ struct AgentRunRequestPayload {
     workspace_root_path: Option<String>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentRunStatusPayload {
+    status: String,
+    exit_code: Option<i32>,
+    message: Option<String>,
+}
+
 fn path_target_from_path(path: PathBuf) -> NativePathTarget {
     let name = path
         .file_name()
@@ -247,6 +255,48 @@ fn dragon_stop_agent_run(run_id: String) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+fn dragon_get_agent_run_status(run_id: String) -> Result<AgentRunStatusPayload, String> {
+    let runs = active_agent_runs();
+    let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
+    let wait_status = if let Some(child) = locked_runs.get_mut(&run_id) {
+        child.try_wait().map_err(|error| error.to_string())?
+    } else {
+        return Ok(AgentRunStatusPayload {
+            status: "not_found".to_string(),
+            exit_code: None,
+            message: Some("Agent run is no longer available".to_string()),
+        });
+    };
+
+    let Some(exit_status) = wait_status else {
+        return Ok(AgentRunStatusPayload {
+            status: "running".to_string(),
+            exit_code: None,
+            message: None,
+        });
+    };
+
+    locked_runs.remove(&run_id);
+    if exit_status.success() {
+        return Ok(AgentRunStatusPayload {
+            status: "completed".to_string(),
+            exit_code: exit_status.code(),
+            message: None,
+        });
+    }
+
+    let exit_code = exit_status.code();
+    let message = exit_code
+        .map(|code| format!("Agent exited with code {code}"))
+        .unwrap_or_else(|| "Agent exited without an exit code".to_string());
+    Ok(AgentRunStatusPayload {
+        status: "failed".to_string(),
+        exit_code,
+        message: Some(message),
+    })
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -259,7 +309,8 @@ pub fn run() {
             dragon_write_text_file,
             dragon_read_directory_tree,
             dragon_start_agent_run,
-            dragon_stop_agent_run
+            dragon_stop_agent_run,
+            dragon_get_agent_run_status
         ])
         .run(tauri::generate_context!())
         .expect("error while running Lollipop Dragon");

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -1,7 +1,11 @@
 import type { StoreApi } from "zustand";
 import { buildAgentReplyPrompt, buildCommentThreadGroups } from "../../markup";
 import { agentRuntime } from "../../runtime";
-import type { AgentRuntime, AgentRunRequest } from "../../runtime";
+import type {
+  AgentRuntime,
+  AgentRunRequest,
+  AgentRuntimeRunStatus,
+} from "../../runtime";
 import type { Comment } from "../../types/criticmarkup";
 import {
   isNativeDirectoryTarget,
@@ -11,6 +15,9 @@ import type { TabState } from "../../types/tab";
 import type {
   AgentRunStartUnavailableReason,
   AgentRunStartResult,
+  AgentRunStatus,
+  AgentRunSyncStatusResult,
+  AgentRunSyncStatusUnavailableReason,
   AgentRunStopUnavailableReason,
   AgentRunStopResult,
   AgentWorkflowActions,
@@ -38,6 +45,12 @@ interface QuestionThreadRunContext {
   questionCommentIds: string[];
   workspaceRootPath: string | null;
 }
+
+const SYNCABLE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
+  "queued",
+  "running",
+  "needs_attention",
+]);
 
 export function getQuestionThreadCommentIds(comments: Comment[]): string[] {
   return buildCommentThreadGroups(comments)
@@ -116,6 +129,38 @@ function unavailableStopResult(input: {
     reason: input.reason,
     message: input.message,
   };
+}
+
+function unchangedSyncResult(input: {
+  reason: AgentRunSyncStatusUnavailableReason;
+  message: string;
+}): AgentRunSyncStatusResult {
+  return {
+    status: "unchanged",
+    reason: input.reason,
+    message: input.message,
+  };
+}
+
+function unavailableSyncResult(input: {
+  reason: AgentRunSyncStatusUnavailableReason;
+  message: string;
+}): AgentRunSyncStatusResult {
+  return {
+    status: "unavailable",
+    reason: input.reason,
+    message: input.message,
+  };
+}
+
+function failedRuntimeStatusMessage(status: AgentRuntimeRunStatus): string {
+  if (status.status === "failed") {
+    return status.message;
+  }
+  if (status.status === "not_found") {
+    return status.message;
+  }
+  return "Agent run failed";
 }
 
 export function createAgentWorkflowControllerActions<
@@ -245,6 +290,88 @@ export function createAgentWorkflowControllerActions<
         deps.showToast("Agent run failed to stop");
         return unavailableStopResult({
           reason: "runtime_stop_failed",
+          message,
+        });
+      }
+    },
+
+    syncActiveAgentRunStatus: async () => {
+      const tab = deps.getActiveTab(deps.get);
+      if (!tab) {
+        return unchangedSyncResult({
+          reason: "no_active_tab",
+          message: "Open a file or folder before syncing an agent run.",
+        });
+      }
+
+      const runId = deps.get().activeAgentRunIdByTabId[tab.id];
+      const run = runId ? deps.get().agentRuns[runId] : null;
+      if (!run) {
+        return unchangedSyncResult({
+          reason: "no_active_run",
+          message: "No active agent run is attached to this tab.",
+        });
+      }
+
+      if (!run.terminalAttachmentId) {
+        return unchangedSyncResult({
+          reason: "no_runtime_run",
+          message: "The active agent run has no native runtime id.",
+        });
+      }
+
+      if (!SYNCABLE_AGENT_RUN_STATUSES.has(run.status)) {
+        return unchangedSyncResult({
+          reason: "terminal_run",
+          message: "The active agent run is already finished.",
+        });
+      }
+
+      try {
+        const runtimeStatus = await runtime.getRunStatus(
+          run.terminalAttachmentId,
+        );
+        if (runtimeStatus.status === "running") {
+          return {
+            status: "synced",
+            runId: run.id,
+            runStatus: "running",
+          };
+        }
+
+        if (runtimeStatus.status === "completed") {
+          deps.get().updateAgentRunStatus({
+            runId: run.id,
+            status: "completed",
+          });
+          deps.showToast("Agent run completed");
+          return {
+            status: "synced",
+            runId: run.id,
+            runStatus: "completed",
+          };
+        }
+
+        const message = failedRuntimeStatusMessage(runtimeStatus);
+        deps.get().updateAgentRunStatus({
+          runId: run.id,
+          status: "failed",
+          errorMessage: message,
+        });
+        deps.showToast("Agent run failed");
+        return {
+          status: "synced",
+          runId: run.id,
+          runStatus: "failed",
+        };
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Agent run status failed to sync";
+        console.error("[agent-workflow] failed to sync agent run:", error);
+        return unavailableSyncResult({
+          reason: "runtime_status_failed",
           message,
         });
       }

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -103,6 +103,7 @@ describe("question thread agent run controller", () => {
         return Promise.resolve("terminal-session-1");
       },
       stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running" }),
     };
     const showToastMessages: string[] = [];
     const actions = createAgentWorkflowControllerActions({
@@ -168,6 +169,7 @@ describe("question thread agent run controller", () => {
         stoppedRuntimeRunIds.push(runId);
         return Promise.resolve();
       },
+      getRunStatus: () => Promise.resolve({ status: "running" }),
     };
     const showToastMessages: string[] = [];
     const actions = createAgentWorkflowControllerActions({
@@ -203,5 +205,107 @@ describe("question thread agent run controller", () => {
     expect(stoppedRuntimeRunIds).toEqual(["native-run-1"]);
     expect(useAppStore.getState().agentRuns[run.id]?.status).toBe("stopped");
     expect(showToastMessages).toEqual(["Agent run stopped"]);
+  });
+
+  it("syncs a completed native runtime run into the active tab run", async () => {
+    const checkedRuntimeRunIds: string[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: () => Promise.resolve("terminal-session-1"),
+      stopRun: () => Promise.resolve(),
+      getRunStatus: (runId) => {
+        checkedRuntimeRunIds.push(runId);
+        return Promise.resolve({
+          status: "completed",
+          exitCode: 0,
+        });
+      },
+    };
+    const showToastMessages: string[] = [];
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: (message) => {
+        showToastMessages.push(message);
+      },
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+    });
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "test-tab",
+      taskKind: "answer_questions",
+      targetPaths: ["spec.md"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+    });
+
+    const result = await actions.syncActiveAgentRunStatus();
+
+    expect(result).toEqual({
+      status: "synced",
+      runId: run.id,
+      runStatus: "completed",
+    });
+    expect(checkedRuntimeRunIds).toEqual(["native-run-1"]);
+    expect(useAppStore.getState().agentRuns[run.id]?.status).toBe("completed");
+    expect(showToastMessages).toEqual(["Agent run completed"]);
+  });
+
+  it("syncs a failed native runtime run into the active tab run", async () => {
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: () => Promise.resolve("terminal-session-1"),
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () =>
+        Promise.resolve({
+          status: "failed",
+          exitCode: 7,
+          message: "Agent exited with code 7",
+        }),
+    };
+    const showToastMessages: string[] = [];
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: (message) => {
+        showToastMessages.push(message);
+      },
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+    });
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "test-tab",
+      taskKind: "answer_questions",
+      targetPaths: ["spec.md"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+    });
+
+    const result = await actions.syncActiveAgentRunStatus();
+
+    expect(result).toEqual({
+      status: "synced",
+      runId: run.id,
+      runStatus: "failed",
+    });
+    expect(useAppStore.getState().agentRuns[run.id]).toMatchObject({
+      status: "failed",
+      errorMessage: "Agent exited with code 7",
+    });
+    expect(showToastMessages).toEqual(["Agent run failed"]);
   });
 });

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -88,7 +88,32 @@ export type AgentRunStopResult =
       message: string;
     };
 
+export type AgentRunSyncStatusUnavailableReason =
+  | "no_active_tab"
+  | "no_active_run"
+  | "no_runtime_run"
+  | "terminal_run"
+  | "runtime_status_failed";
+
+export type AgentRunSyncStatusResult =
+  | {
+      status: "synced";
+      runId: string;
+      runStatus: AgentRunStatus;
+    }
+  | {
+      status: "unchanged";
+      reason: AgentRunSyncStatusUnavailableReason;
+      message: string;
+    }
+  | {
+      status: "unavailable";
+      reason: AgentRunSyncStatusUnavailableReason;
+      message: string;
+    };
+
 export interface AgentWorkflowControllerActions {
   startQuestionThreadAgentRun: () => Promise<AgentRunStartResult>;
   stopActiveAgentRun: () => Promise<AgentRunStopResult>;
+  syncActiveAgentRunStatus: () => Promise<AgentRunSyncStatusResult>;
 }

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -13,10 +13,29 @@ export interface AgentRunRequest {
   workspaceRootPath: string | null;
 }
 
+export type AgentRuntimeRunStatus =
+  | {
+      status: "running";
+    }
+  | {
+      status: "completed";
+      exitCode: number | null;
+    }
+  | {
+      status: "failed";
+      exitCode: number | null;
+      message: string;
+    }
+  | {
+      status: "not_found";
+      message: string;
+    };
+
 export interface AgentRuntime {
   canRunAgent: boolean;
   startRun(request: AgentRunRequest): Promise<string>;
   stopRun(runId: string): Promise<void>;
+  getRunStatus(runId: string): Promise<AgentRuntimeRunStatus>;
 }
 
 export const webAgentRuntime: AgentRuntime = {
@@ -24,4 +43,9 @@ export const webAgentRuntime: AgentRuntime = {
   startRun: () =>
     Promise.reject(new Error("Local agent execution is unavailable on web")),
   stopRun: () => Promise.resolve(),
+  getRunStatus: () =>
+    Promise.resolve({
+      status: "not_found",
+      message: "Local agent execution is unavailable on web",
+    }),
 };

--- a/src/runtime/desktopAgentRuntime.test.ts
+++ b/src/runtime/desktopAgentRuntime.test.ts
@@ -31,7 +31,7 @@ describe("desktop agent runtime", () => {
     await expect(getDesktopAgentCapability()).resolves.toBe(false);
   });
 
-  it("starts and stops runs through the native agent commands", async () => {
+  it("starts, stops, and reads runs through the native agent commands", async () => {
     const calls: {
       command: string;
       args: Record<string, unknown> | undefined;
@@ -45,6 +45,9 @@ describe("desktop agent runtime", () => {
           }
           if (command === "dragon_start_agent_run") {
             return Promise.resolve("native-run-1");
+          }
+          if (command === "dragon_get_agent_run_status") {
+            return Promise.resolve({ status: "completed", exitCode: 0 });
           }
           return Promise.resolve(null);
         },
@@ -64,6 +67,12 @@ describe("desktop agent runtime", () => {
       }),
     ).resolves.toBe("native-run-1");
     await desktopAgentRuntime.stopRun("native-run-1");
+    await expect(
+      desktopAgentRuntime.getRunStatus("native-run-1"),
+    ).resolves.toEqual({
+      status: "completed",
+      exitCode: 0,
+    });
 
     expect(calls).toEqual([
       {
@@ -90,6 +99,16 @@ describe("desktop agent runtime", () => {
       },
       {
         command: "dragon_stop_agent_run",
+        args: {
+          runId: "native-run-1",
+        },
+      },
+      {
+        command: "dragon_runtime_ping",
+        args: undefined,
+      },
+      {
+        command: "dragon_get_agent_run_status",
         args: {
           runId: "native-run-1",
         },

--- a/src/runtime/desktopAgentRuntime.ts
+++ b/src/runtime/desktopAgentRuntime.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntime } from "./agent";
 import {
   getTauriAgentRuntimeAvailable,
+  getTauriAgentRunStatus,
   hasTauriBridge,
   pingTauriRuntime,
   startTauriAgentRun,
@@ -29,5 +30,9 @@ export const desktopAgentRuntime: AgentRuntime = {
   stopRun: async (runId) => {
     await assertDesktopRuntimeAvailable();
     await stopTauriAgentRun(runId);
+  },
+  getRunStatus: async (runId) => {
+    await assertDesktopRuntimeAvailable();
+    return getTauriAgentRunStatus(runId);
   },
 };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -4,7 +4,11 @@ import type {
   WorkspaceFileTarget,
 } from "./workspace";
 
-export type { AgentRuntime, AgentRunRequest } from "./agent";
+export type {
+  AgentRuntime,
+  AgentRunRequest,
+  AgentRuntimeRunStatus,
+} from "./agent";
 export type { TerminalAttachment, TerminalRuntime } from "./terminal";
 export type {
   NativeWorkspaceDirectoryTarget,

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getTauriAgentRuntimeAvailable,
+  getTauriAgentRunStatus,
   hasTauriBridge,
   invokeTauriCommand,
   openTauriDirectory,
@@ -72,7 +73,7 @@ describe("tauri bridge", () => {
     );
   });
 
-  it("starts and stops native agent runs through Tauri commands", async () => {
+  it("starts, stops, and reads native agent runs through Tauri commands", async () => {
     const calls: {
       command: string;
       args: Record<string, unknown> | undefined;
@@ -81,6 +82,9 @@ describe("tauri bridge", () => {
       core: {
         invoke: (command, args) => {
           calls.push({ command, args });
+          if (command === "dragon_get_agent_run_status") {
+            return Promise.resolve({ status: "running" });
+          }
           return Promise.resolve("native-run-1");
         },
       },
@@ -97,6 +101,9 @@ describe("tauri bridge", () => {
 
     await expect(startTauriAgentRun(request)).resolves.toBe("native-run-1");
     await stopTauriAgentRun("native-run-1");
+    await expect(getTauriAgentRunStatus("native-run-1")).resolves.toEqual({
+      status: "running",
+    });
 
     expect(calls).toEqual([
       {
@@ -105,6 +112,10 @@ describe("tauri bridge", () => {
       },
       {
         command: "dragon_stop_agent_run",
+        args: { runId: "native-run-1" },
+      },
+      {
+        command: "dragon_get_agent_run_status",
         args: { runId: "native-run-1" },
       },
     ]);
@@ -128,6 +139,18 @@ describe("tauri bridge", () => {
         workspaceRootPath: null,
       }),
     ).rejects.toThrow("Unexpected native agent run response");
+  });
+
+  it("rejects malformed native agent run status responses", async () => {
+    window.__TAURI__ = {
+      core: {
+        invoke: () => Promise.resolve({ status: "completed", exitCode: "0" }),
+      },
+    };
+
+    await expect(getTauriAgentRunStatus("native-run-1")).rejects.toThrow(
+      "Unexpected native agent run exitCode field",
+    );
   });
 
   it("reads and writes native text files through Tauri commands", async () => {

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -1,4 +1,4 @@
-import type { AgentRunRequest } from "./agent";
+import type { AgentRunRequest, AgentRuntimeRunStatus } from "./agent";
 import type {
   NativeWorkspaceDirectoryTarget,
   NativeWorkspaceFileTarget,
@@ -13,7 +13,8 @@ export type TauriCommand =
   | "dragon_write_text_file"
   | "dragon_read_directory_tree"
   | "dragon_start_agent_run"
-  | "dragon_stop_agent_run";
+  | "dragon_stop_agent_run"
+  | "dragon_get_agent_run_status";
 
 export interface TauriNativeFileNode {
   kind: "file";
@@ -101,6 +102,56 @@ function readStringField(
   }
 
   throw new Error(`Unexpected native file tree ${fieldName} field`);
+}
+
+function readOptionalNumberField(
+  record: Record<string, unknown>,
+  fieldName: string,
+): number | null {
+  const value = record[fieldName];
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+
+  throw new Error(`Unexpected native agent run ${fieldName} field`);
+}
+
+function parseNativeAgentRunStatus(value: unknown): AgentRuntimeRunStatus {
+  if (!isRecord(value)) {
+    throw new Error("Unexpected native agent run status response");
+  }
+
+  const status = readStringField(value, "status");
+  if (status === "running") {
+    return { status };
+  }
+
+  if (status === "completed") {
+    return {
+      status,
+      exitCode: readOptionalNumberField(value, "exitCode"),
+    };
+  }
+
+  if (status === "failed") {
+    return {
+      status,
+      exitCode: readOptionalNumberField(value, "exitCode"),
+      message: readStringField(value, "message"),
+    };
+  }
+
+  if (status === "not_found") {
+    return {
+      status,
+      message: readStringField(value, "message"),
+    };
+  }
+
+  throw new Error("Unexpected native agent run status");
 }
 
 function parseNativeTreeNode(value: unknown): TauriNativeTreeNode {
@@ -239,4 +290,14 @@ export function stopTauriAgentRun(runId: string): Promise<unknown> {
     command: "dragon_stop_agent_run",
     args: { runId },
   });
+}
+
+export async function getTauriAgentRunStatus(
+  runId: string,
+): Promise<AgentRuntimeRunStatus> {
+  const result = await invokeTauriCommand({
+    command: "dragon_get_agent_run_status",
+    args: { runId },
+  });
+  return parseNativeAgentRunStatus(result);
 }

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -160,6 +160,9 @@ export function CommentPanel({ peerMode = false }: Props) {
     (state) => state.startQuestionThreadAgentRun,
   );
   const stopActiveAgentRun = useAppStore((state) => state.stopActiveAgentRun);
+  const syncActiveAgentRunStatus = useAppStore(
+    (state) => state.syncActiveAgentRunStatus,
+  );
   const clearAgentRun = useAppStore((state) => state.clearAgentRun);
   const activeAgentRun = useAppStore((state) =>
     tab?.id ? getActiveAgentRunForTab(state, tab.id) : null,
@@ -369,6 +372,33 @@ export function CommentPanel({ peerMode = false }: Props) {
       showToast(result.message);
     }
   }
+
+  useEffect(() => {
+    if (
+      peerMode ||
+      !canRunAgent ||
+      !activeAgentRun?.terminalAttachmentId ||
+      !ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status)
+    ) {
+      return;
+    }
+
+    function syncStatus() {
+      syncActiveAgentRunStatus().catch((error) => {
+        console.error("[CommentPanel] failed to sync agent run:", error);
+      });
+    }
+
+    syncStatus();
+    const intervalId = window.setInterval(syncStatus, 2000);
+    return () => window.clearInterval(intervalId);
+  }, [
+    activeAgentRun?.id,
+    activeAgentRun?.status,
+    activeAgentRun?.terminalAttachmentId,
+    peerMode,
+    syncActiveAgentRunStatus,
+  ]);
 
   useEffect(() => {
     const activePanelCommentId = peerMode


### PR DESCRIPTION
## Summary
- add a runtime/Tauri status API for native agent runs
- poll active desktop agent runs from the comment panel and reconcile completed/failed state into tab-scoped run metadata
- remove completed children from the native process map and document the lifecycle behavior

## Verification
- 
px tsc --noEmit
- 
px vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts src/runtime/webAgentRuntime.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx src/ui/agentActions.test.ts
- 
px eslint src/runtime/agent.ts src/runtime/index.ts src/runtime/desktopAgentRuntime.ts src/runtime/tauriBridge.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx (0 errors; existing CommentPanel warnings remain)
- 
px prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/runtime/agent.ts src/runtime/index.ts src/runtime/desktopAgentRuntime.ts src/runtime/tauriBridge.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx && git diff --check
- 
px vite build
- 
px vite build --mode desktop

## Not run
- cargo fmt --manifest-path src-tauri/Cargo.toml: blocked because cargo is not installed in this WSL image.
