### PR TITLE
Show native agent output preview

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,13 +154,14 @@ review prompt to stdin, and tracks the child process by runtime run id. Runner
 processes remain outside Zustand; the store keeps only serializable run
 metadata. The frontend can poll a runtime run id through the Tauri bridge to
 move the tab-scoped run from `running` to `completed` or `failed` when the child
-process exits.
+process exits. Native stdout and stderr are captured into a bounded output tail
+that is returned with status polling and stored as serializable run metadata.
 
 Host UI surfaces active agent run state per tab. The comment panel hides new
 agent-start actions while the tab has a queued/running/attention run and exposes
 a stop control that routes through the runtime before marking the run stopped.
 In desktop runtime mode, the same panel polls the native run status while an
-active runtime run id is attached.
+active runtime run id is attached and shows the latest bounded output tail.
 
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -282,9 +282,12 @@ Run-status implementation note: desktop agent runs now expose
 `dragon_get_agent_run_status` through the Tauri bridge. The native command polls
 the tracked child process with `try_wait`, removes completed children from the
 native process map, and returns `running`, `completed`, `failed`, or `not_found`
-to the shared runtime boundary. The comment panel polls this status only when
-the active runtime can execute agents, then reconciles the tab-scoped
-serializable run state to `completed` or `failed`.
+to the shared runtime boundary. Native stdout and stderr are captured into a
+bounded output tail and returned with each status response, so the comment panel
+can show progress without depending on terminal text as the lifecycle protocol.
+The comment panel polls this status only when the active runtime can execute
+agents, then reconciles the tab-scoped serializable run state to `completed` or
+`failed`.
 
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and a controller action for active-file threaded

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -232,6 +232,8 @@ outside this first desktop planning scope.
 - Agent run state is tab-scoped and serializable. The comment panel can stop an
   active run and polls native run status so completed or failed processes are
   reflected in the UI.
+- Native runner stdout and stderr are captured into a bounded output tail shown
+  on the active run panel for same-window observability.
 
 ## Open Questions
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,20 +2,22 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri_plugin_dialog::DialogExt;
 
 const IGNORED_NAMES: [&str; 3] = ["node_modules", ".git", ".markreview"];
 const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
 const AGENT_COMMAND_ENV: &str = "DRAGON_AGENT_COMMAND";
+const AGENT_OUTPUT_LIMIT: usize = 20_000;
 
 static AGENT_RUN_COUNTER: AtomicU64 = AtomicU64::new(1);
-static AGENT_RUNS: OnceLock<Mutex<HashMap<String, Child>>> = OnceLock::new();
+static AGENT_RUNS: OnceLock<Mutex<HashMap<String, AgentRunProcess>>> = OnceLock::new();
 
 #[derive(Serialize)]
 #[serde(tag = "kind")]
@@ -49,6 +51,13 @@ struct AgentRunStatusPayload {
     status: String,
     exit_code: Option<i32>,
     message: Option<String>,
+    output: String,
+}
+
+struct AgentRunProcess {
+    child: Child,
+    output: Arc<Mutex<String>>,
+    output_threads: Vec<JoinHandle<()>>,
 }
 
 fn path_target_from_path(path: PathBuf) -> NativePathTarget {
@@ -63,8 +72,68 @@ fn path_target_from_path(path: PathBuf) -> NativePathTarget {
     }
 }
 
-fn active_agent_runs() -> &'static Mutex<HashMap<String, Child>> {
+fn active_agent_runs() -> &'static Mutex<HashMap<String, AgentRunProcess>> {
     AGENT_RUNS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn append_agent_output(output: &Arc<Mutex<String>>, chunk: &str) {
+    if chunk.is_empty() {
+        return;
+    }
+
+    if let Ok(mut locked_output) = output.lock() {
+        locked_output.push_str(chunk);
+        if locked_output.len() > AGENT_OUTPUT_LIMIT {
+            let keep_from = locked_output.len() - AGENT_OUTPUT_LIMIT;
+            let trimmed = locked_output
+                .char_indices()
+                .find(|(index, _character)| *index >= keep_from)
+                .map(|(index, _character)| index)
+                .unwrap_or(keep_from);
+            locked_output.drain(..trimmed);
+        }
+    }
+}
+
+fn read_agent_output(output: &Arc<Mutex<String>>) -> String {
+    output
+        .lock()
+        .map(|locked_output| locked_output.clone())
+        .unwrap_or_else(|error| format!("Failed to read agent output: {error}"))
+}
+
+fn spawn_agent_output_reader<R>(mut reader: R, output: Arc<Mutex<String>>) -> JoinHandle<()>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut buffer = [0; 4096];
+        loop {
+            let bytes_read = match reader.read(&mut buffer) {
+                Ok(0) => return,
+                Ok(bytes_read) => bytes_read,
+                Err(error) => {
+                    append_agent_output(
+                        &output,
+                        &format!("\n[agent output read failed: {error}]\n"),
+                    );
+                    return;
+                }
+            };
+            let chunk = String::from_utf8_lossy(&buffer[..bytes_read]);
+            append_agent_output(&output, &chunk);
+        }
+    })
+}
+
+fn join_agent_output_threads(process: AgentRunProcess) -> String {
+    for output_thread in process.output_threads {
+        if output_thread.join().is_err() {
+            append_agent_output(&process.output, "\n[agent output reader panicked]\n");
+        }
+    }
+
+    read_agent_output(&process.output)
 }
 
 fn configured_agent_command() -> Result<String, String> {
@@ -217,8 +286,8 @@ fn dragon_start_agent_run(request: AgentRunRequestPayload) -> Result<String, Str
     let run_id = create_agent_run_id();
     let mut process = shell_command(&command);
     process.stdin(Stdio::piped());
-    process.stdout(Stdio::null());
-    process.stderr(Stdio::null());
+    process.stdout(Stdio::piped());
+    process.stderr(Stdio::piped());
 
     if let Some(workspace_root_path) = request.workspace_root_path {
         if !workspace_root_path.trim().is_empty() {
@@ -227,6 +296,14 @@ fn dragon_start_agent_run(request: AgentRunRequestPayload) -> Result<String, Str
     }
 
     let mut child = process.spawn().map_err(|error| error.to_string())?;
+    let output = Arc::new(Mutex::new(String::new()));
+    let mut output_threads = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        output_threads.push(spawn_agent_output_reader(stdout, Arc::clone(&output)));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        output_threads.push(spawn_agent_output_reader(stderr, Arc::clone(&output)));
+    }
     if let Some(mut stdin) = child.stdin.take() {
         stdin
             .write_all(request.prompt.as_bytes())
@@ -236,7 +313,14 @@ fn dragon_start_agent_run(request: AgentRunRequestPayload) -> Result<String, Str
 
     let runs = active_agent_runs();
     let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
-    locked_runs.insert(run_id.clone(), child);
+    locked_runs.insert(
+        run_id.clone(),
+        AgentRunProcess {
+            child,
+            output,
+            output_threads,
+        },
+    );
 
     Ok(run_id)
 }
@@ -245,11 +329,17 @@ fn dragon_start_agent_run(request: AgentRunRequestPayload) -> Result<String, Str
 fn dragon_stop_agent_run(run_id: String) -> Result<(), String> {
     let runs = active_agent_runs();
     let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
-    if let Some(mut child) = locked_runs.remove(&run_id) {
-        if child.try_wait().map_err(|error| error.to_string())?.is_none() {
-            child.kill().map_err(|error| error.to_string())?;
+    if let Some(mut process) = locked_runs.remove(&run_id) {
+        if process
+            .child
+            .try_wait()
+            .map_err(|error| error.to_string())?
+            .is_none()
+        {
+            process.child.kill().map_err(|error| error.to_string())?;
         }
-        let _status = child.wait().map_err(|error| error.to_string())?;
+        let _status = process.child.wait().map_err(|error| error.to_string())?;
+        let _output = join_agent_output_threads(process);
     }
 
     Ok(())
@@ -259,30 +349,43 @@ fn dragon_stop_agent_run(run_id: String) -> Result<(), String> {
 fn dragon_get_agent_run_status(run_id: String) -> Result<AgentRunStatusPayload, String> {
     let runs = active_agent_runs();
     let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
-    let wait_status = if let Some(child) = locked_runs.get_mut(&run_id) {
-        child.try_wait().map_err(|error| error.to_string())?
+    let wait_status = if let Some(process) = locked_runs.get_mut(&run_id) {
+        process
+            .child
+            .try_wait()
+            .map_err(|error| error.to_string())?
     } else {
         return Ok(AgentRunStatusPayload {
             status: "not_found".to_string(),
             exit_code: None,
             message: Some("Agent run is no longer available".to_string()),
+            output: String::new(),
         });
     };
+    let output = locked_runs
+        .get(&run_id)
+        .map(|process| read_agent_output(&process.output))
+        .unwrap_or_default();
 
     let Some(exit_status) = wait_status else {
         return Ok(AgentRunStatusPayload {
             status: "running".to_string(),
             exit_code: None,
             message: None,
+            output,
         });
     };
 
-    locked_runs.remove(&run_id);
+    let process = locked_runs
+        .remove(&run_id)
+        .ok_or_else(|| "Agent run is no longer available".to_string())?;
+    let output = join_agent_output_threads(process);
     if exit_status.success() {
         return Ok(AgentRunStatusPayload {
             status: "completed".to_string(),
             exit_code: exit_status.code(),
             message: None,
+            output,
         });
     }
 
@@ -294,6 +397,7 @@ fn dragon_get_agent_run_status(run_id: String) -> Result<AgentRunStatusPayload, 
         status: "failed".to_string(),
         exit_code,
         message: Some(message),
+        output,
     })
 }
 

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -332,6 +332,11 @@ export function createAgentWorkflowControllerActions<
           run.terminalAttachmentId,
         );
         if (runtimeStatus.status === "running") {
+          deps.get().updateAgentRunStatus({
+            runId: run.id,
+            status: "running",
+            output: runtimeStatus.output,
+          });
           return {
             status: "synced",
             runId: run.id,
@@ -343,6 +348,7 @@ export function createAgentWorkflowControllerActions<
           deps.get().updateAgentRunStatus({
             runId: run.id,
             status: "completed",
+            output: runtimeStatus.output,
           });
           deps.showToast("Agent run completed");
           return {
@@ -357,6 +363,7 @@ export function createAgentWorkflowControllerActions<
           runId: run.id,
           status: "failed",
           errorMessage: message,
+          output: runtimeStatus.output,
         });
         deps.showToast("Agent run failed");
         return {

--- a/src/modules/agent-workflow/state.ts
+++ b/src/modules/agent-workflow/state.ts
@@ -50,6 +50,7 @@ function createRun(input: {
     runnerKind: input.runnerKind,
     terminalAttachmentId: null,
     errorMessage: null,
+    output: "",
   };
 }
 
@@ -109,6 +110,8 @@ export function createAgentWorkflowActions<
             input.terminalAttachmentId !== undefined
               ? input.terminalAttachmentId
               : run.terminalAttachmentId,
+          output:
+            input.output !== undefined ? input.output : (run.output ?? ""),
         };
 
         return {

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -103,7 +103,7 @@ describe("question thread agent run controller", () => {
         return Promise.resolve("terminal-session-1");
       },
       stopRun: () => Promise.resolve(),
-      getRunStatus: () => Promise.resolve({ status: "running" }),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
     };
     const showToastMessages: string[] = [];
     const actions = createAgentWorkflowControllerActions({
@@ -169,7 +169,7 @@ describe("question thread agent run controller", () => {
         stoppedRuntimeRunIds.push(runId);
         return Promise.resolve();
       },
-      getRunStatus: () => Promise.resolve({ status: "running" }),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
     };
     const showToastMessages: string[] = [];
     const actions = createAgentWorkflowControllerActions({
@@ -218,6 +218,7 @@ describe("question thread agent run controller", () => {
         return Promise.resolve({
           status: "completed",
           exitCode: 0,
+          output: "Done\n",
         });
       },
     };
@@ -255,6 +256,7 @@ describe("question thread agent run controller", () => {
     });
     expect(checkedRuntimeRunIds).toEqual(["native-run-1"]);
     expect(useAppStore.getState().agentRuns[run.id]?.status).toBe("completed");
+    expect(useAppStore.getState().agentRuns[run.id]?.output).toBe("Done\n");
     expect(showToastMessages).toEqual(["Agent run completed"]);
   });
 
@@ -268,6 +270,7 @@ describe("question thread agent run controller", () => {
           status: "failed",
           exitCode: 7,
           message: "Agent exited with code 7",
+          output: "Command failed\n",
         }),
     };
     const showToastMessages: string[] = [];
@@ -305,6 +308,7 @@ describe("question thread agent run controller", () => {
     expect(useAppStore.getState().agentRuns[run.id]).toMatchObject({
       status: "failed",
       errorMessage: "Agent exited with code 7",
+      output: "Command failed\n",
     });
     expect(showToastMessages).toEqual(["Agent run failed"]);
   });

--- a/src/modules/agent-workflow/test/agentWorkflowState.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowState.test.ts
@@ -35,6 +35,7 @@ describe("agent workflow state", () => {
       runnerKind: "terminal",
       terminalAttachmentId: null,
       errorMessage: null,
+      output: "",
     });
     expect(state.agentRuns[run.id]).toEqual(run);
     expect(state.activeAgentRunIdByTabId["tab-1"]).toBe(run.id);
@@ -54,12 +55,14 @@ describe("agent workflow state", () => {
       runId: run.id,
       status: "failed",
       errorMessage: "Agent unavailable",
+      output: "Failure log",
     });
 
     const updatedRun = useAppStore.getState().agentRuns[run.id];
     expect(updatedRun?.status).toBe("failed");
     expect(updatedRun?.completedAt).toBe("2026-06-12T18:01:00.000Z");
     expect(updatedRun?.errorMessage).toBe("Agent unavailable");
+    expect(updatedRun?.output).toBe("Failure log");
     expect(hasActiveAgentRunForTab(useAppStore.getState(), "tab-1")).toBe(
       false,
     );

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -25,6 +25,7 @@ export interface AgentRun {
   runnerKind: AgentRunnerKind | null;
   terminalAttachmentId: string | null;
   errorMessage: string | null;
+  output: string;
 }
 
 export interface CreateAgentRunInput {
@@ -40,6 +41,7 @@ export interface UpdateAgentRunStatusInput {
   status: AgentRunStatus;
   errorMessage?: string | null;
   terminalAttachmentId?: string | null;
+  output?: string;
 }
 
 export interface AgentWorkflowState {

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -16,19 +16,23 @@ export interface AgentRunRequest {
 export type AgentRuntimeRunStatus =
   | {
       status: "running";
+      output: string;
     }
   | {
       status: "completed";
       exitCode: number | null;
+      output: string;
     }
   | {
       status: "failed";
       exitCode: number | null;
       message: string;
+      output: string;
     }
   | {
       status: "not_found";
       message: string;
+      output: string;
     };
 
 export interface AgentRuntime {
@@ -47,5 +51,6 @@ export const webAgentRuntime: AgentRuntime = {
     Promise.resolve({
       status: "not_found",
       message: "Local agent execution is unavailable on web",
+      output: "",
     }),
 };

--- a/src/runtime/desktopAgentRuntime.test.ts
+++ b/src/runtime/desktopAgentRuntime.test.ts
@@ -47,7 +47,11 @@ describe("desktop agent runtime", () => {
             return Promise.resolve("native-run-1");
           }
           if (command === "dragon_get_agent_run_status") {
-            return Promise.resolve({ status: "completed", exitCode: 0 });
+            return Promise.resolve({
+              status: "completed",
+              exitCode: 0,
+              output: "Done\n",
+            });
           }
           return Promise.resolve(null);
         },
@@ -72,6 +76,7 @@ describe("desktop agent runtime", () => {
     ).resolves.toEqual({
       status: "completed",
       exitCode: 0,
+      output: "Done\n",
     });
 
     expect(calls).toEqual([

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -83,7 +83,7 @@ describe("tauri bridge", () => {
         invoke: (command, args) => {
           calls.push({ command, args });
           if (command === "dragon_get_agent_run_status") {
-            return Promise.resolve({ status: "running" });
+            return Promise.resolve({ status: "running", output: "Working\n" });
           }
           return Promise.resolve("native-run-1");
         },
@@ -103,6 +103,7 @@ describe("tauri bridge", () => {
     await stopTauriAgentRun("native-run-1");
     await expect(getTauriAgentRunStatus("native-run-1")).resolves.toEqual({
       status: "running",
+      output: "Working\n",
     });
 
     expect(calls).toEqual([
@@ -144,7 +145,12 @@ describe("tauri bridge", () => {
   it("rejects malformed native agent run status responses", async () => {
     window.__TAURI__ = {
       core: {
-        invoke: () => Promise.resolve({ status: "completed", exitCode: "0" }),
+        invoke: () =>
+          Promise.resolve({
+            status: "completed",
+            exitCode: "0",
+            output: "",
+          }),
       },
     };
 

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -125,14 +125,16 @@ function parseNativeAgentRunStatus(value: unknown): AgentRuntimeRunStatus {
   }
 
   const status = readStringField(value, "status");
+  const output = readStringField(value, "output");
   if (status === "running") {
-    return { status };
+    return { status, output };
   }
 
   if (status === "completed") {
     return {
       status,
       exitCode: readOptionalNumberField(value, "exitCode"),
+      output,
     };
   }
 
@@ -141,6 +143,7 @@ function parseNativeAgentRunStatus(value: unknown): AgentRuntimeRunStatus {
       status,
       exitCode: readOptionalNumberField(value, "exitCode"),
       message: readStringField(value, "message"),
+      output,
     };
   }
 
@@ -148,6 +151,7 @@ function parseNativeAgentRunStatus(value: unknown): AgentRuntimeRunStatus {
     return {
       status,
       message: readStringField(value, "message"),
+      output,
     };
   }
 

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -160,6 +160,21 @@
   color: var(--c-red);
 }
 
+.comment-panel__agent-run-output {
+  max-height: 9rem;
+  overflow: auto;
+  margin: 0.25rem 0 0;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
 .comment-panel__agent-run-action {
   flex-shrink: 0;
   border: 1px solid var(--border);

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -280,11 +280,13 @@ describe("CommentPanel — agent prompt", () => {
       runId: run.id,
       status: "running",
       terminalAttachmentId: "native-run-1",
+      output: "Working on questions\n",
     });
 
     render(<CommentPanel />);
 
     expect(screen.getByText("Agent Running")).toBeInTheDocument();
+    expect(screen.getByText(/Working on questions/)).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Copy agent prompt" }),
     ).not.toBeInTheDocument();

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -473,6 +473,11 @@ export function CommentPanel({ peerMode = false }: Props) {
                 {activeAgentRun.errorMessage}
               </span>
             )}
+            {activeAgentRun.output && (
+              <pre className="comment-panel__agent-run-output">
+                {activeAgentRun.output}
+              </pre>
+            )}
           </div>
           {canStopAgentRun ? (
             <button


### PR DESCRIPTION
## Summary
- capture native runner stdout/stderr into a bounded output tail
- return output with native agent status polling and store it as serializable run metadata
- render the active run output preview in the comment panel for same-window observability

## Verification
- 
px tsc --noEmit
- 
px vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts src/runtime/webAgentRuntime.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx
- 
px eslint src/runtime/agent.ts src/runtime/tauriBridge.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/state.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.test.tsx (0 errors; existing CommentPanel warnings remain)
- 
px prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/runtime/agent.ts src/runtime/tauriBridge.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/state.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.css src/ui/components/CommentPanel/CommentPanel.test.tsx && git diff --check
- 
px vite build
- 
px vite build --mode desktop

## Not run
- cargo fmt --manifest-path src-tauri/Cargo.toml: blocked because cargo is not installed in this WSL image.
- Native Rust compile: blocked by the same missing Rust toolchain in this WSL image.
