### PR TITLE
Guard tab close with active agent run

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -162,6 +162,9 @@ agent-start actions while the tab has a queued/running/attention run and exposes
 a stop control that routes through the runtime before marking the run stopped.
 In desktop runtime mode, the same panel polls the native run status while an
 active runtime run id is attached and shows the latest bounded output tail.
+Workspace tab removal refuses to close tabs with queued, running, or
+attention-needed agent runs, then cleans finished run metadata when the owning
+tab is closed.
 
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -224,8 +224,9 @@ Rules:
 - No automatic run is started when a tab opens.
 - A run is bound to the tab that started it.
 - Switching tabs does not stop the run.
-- Closing a tab with an active run prompts the user to stop, detach, or cancel
-  the close.
+- Closing a tab with a queued/running/attention run is blocked until the run is
+  stopped or finishes. A richer stop/detach/cancel decision can follow once
+  detachable terminal sessions exist.
 - A small app-wide active-run limit should prevent accidental over-parallelism.
 
 ## Website Preservation
@@ -288,6 +289,11 @@ can show progress without depending on terminal text as the lifecycle protocol.
 The comment panel polls this status only when the active runtime can execute
 agents, then reconciles the tab-scoped serializable run state to `completed` or
 `failed`.
+
+Tab-close implementation note: the workspace close action now checks the
+tab-scoped active run map before removing a tab. Tabs with queued, running, or
+attention-needed runs remain open and show a toast asking the user to stop the
+run first. Finished run metadata is removed when the owning tab is closed.
 
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and a controller action for active-file threaded

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -234,6 +234,8 @@ outside this first desktop planning scope.
   reflected in the UI.
 - Native runner stdout and stderr are captured into a bounded output tail shown
   on the active run panel for same-window observability.
+- Closing a tab with a queued, running, or attention-needed run is blocked until
+  the user stops the run or it finishes.
 
 ## Open Questions
 

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -49,6 +49,16 @@ type GetState<StoreState> = StoreApi<StoreState>["getState"];
 const HISTORY_KEY = "markreview-history";
 const HISTORY_LIMIT = 20;
 const HISTORY_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const BLOCKING_AGENT_RUN_STATUSES = new Set([
+  "queued",
+  "running",
+  "needs_attention",
+]);
+
+interface AgentRunCloseGuardState {
+  agentRuns: Record<string, { status: string }>;
+  activeAgentRunIdByTabId: Record<string, string>;
+}
 
 async function saveBrowserHandle(
   key: string,
@@ -309,10 +319,38 @@ export async function findTabByHandle(
 }
 
 interface WorkspaceControllerActionDeps<
-  StoreState extends WorkspaceState,
+  StoreState extends WorkspaceState & AgentRunCloseGuardState,
 > extends WorkspaceControllerDeps {
   set: SetState<StoreState>;
   get: GetState<StoreState>;
+}
+
+function hasBlockingAgentRunForTab(
+  state: AgentRunCloseGuardState,
+  tabId: string,
+): boolean {
+  const runId = state.activeAgentRunIdByTabId[tabId];
+  const run = runId ? state.agentRuns[runId] : null;
+  return Boolean(run && BLOCKING_AGENT_RUN_STATUSES.has(run.status));
+}
+
+function removeTabAgentRunState(
+  state: AgentRunCloseGuardState,
+  tabId: string,
+): Partial<AgentRunCloseGuardState> {
+  const runId = state.activeAgentRunIdByTabId[tabId];
+  if (!runId) {
+    return {};
+  }
+
+  const nextRuns = { ...state.agentRuns };
+  delete nextRuns[runId];
+  const nextActiveByTab = { ...state.activeAgentRunIdByTabId };
+  delete nextActiveByTab[tabId];
+  return {
+    agentRuns: nextRuns,
+    activeAgentRunIdByTabId: nextActiveByTab,
+  };
 }
 
 function createHistoryEntry(tab: TabState): HistoryEntry | null {
@@ -454,7 +492,7 @@ async function restoreActiveFileFromTree(input: {
 }
 
 export function createWorkspaceControllerActions<
-  StoreState extends WorkspaceControllerStoreState,
+  StoreState extends WorkspaceState & AgentRunCloseGuardState,
 >(
   deps: WorkspaceControllerActionDeps<StoreState>,
 ): Pick<
@@ -644,9 +682,15 @@ export function createWorkspaceControllerActions<
     },
 
     removeTab: (tabId) => {
-      const { activeTabId, tabs } = get();
+      const state = get();
+      const { activeTabId, tabs } = state;
       const tabIndex = tabs.findIndex((tab) => tab.id === tabId);
       if (tabIndex === -1) {
+        return;
+      }
+
+      if (hasBlockingAgentRunForTab(state, tabId)) {
+        showToast("Stop the active agent run before closing this tab.");
         return;
       }
 
@@ -655,6 +699,7 @@ export function createWorkspaceControllerActions<
       if (!nextTabState) {
         return;
       }
+      const nextAgentRunState = removeTabAgentRunState(state, tabId);
 
       const docIdsToUnsubscribe: string[] = [];
       for (const share of tab.shares) {
@@ -696,6 +741,7 @@ export function createWorkspaceControllerActions<
           tabs: nextTabState.updatedTabs,
           activeTabId: nextTabState.nextActiveTabId,
           history: nextHistory,
+          ...nextAgentRunState,
         });
       } else {
         removeHandle(`tab:${tabId}:directory`).catch((error) =>
@@ -707,6 +753,7 @@ export function createWorkspaceControllerActions<
         set({
           tabs: nextTabState.updatedTabs,
           activeTabId: nextTabState.nextActiveTabId,
+          ...nextAgentRunState,
         });
       }
 

--- a/src/modules/workspace/test/history.test.ts
+++ b/src/modules/workspace/test/history.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { useAppStore } from "../../../store";
-import { setTestState, resetTestStore, makeShare } from "../../../testing/testHelpers";
+import {
+  setTestState,
+  resetTestStore,
+  makeShare,
+} from "../../../testing/testHelpers";
 import type { HistoryEntry } from "../../../types/history";
 import { getActiveTab } from "../selectors";
 import { resetHandleStore } from "../storage";
@@ -115,6 +119,58 @@ describe("store.removeTab — history archival", () => {
     useAppStore.getState().removeTab(tabId);
 
     expect(useAppStore.getState().history).toHaveLength(0);
+  });
+
+  it("does not close a tab with an active agent run", () => {
+    setTestState({ fileName: "agent.md" });
+    const tabId = getActiveTab(useAppStore.getState())!.id;
+    const run = useAppStore.getState().createAgentRun({
+      tabId,
+      taskKind: "answer_questions",
+      targetPaths: ["agent.md"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+    });
+
+    useAppStore.getState().removeTab(tabId);
+
+    expect(useAppStore.getState().tabs.some((tab) => tab.id === tabId)).toBe(
+      true,
+    );
+    expect(useAppStore.getState().history).toHaveLength(0);
+    expect(useAppStore.getState().agentRuns[run.id]?.status).toBe("running");
+    expect(useAppStore.getState().toast).toBe(
+      "Stop the active agent run before closing this tab.",
+    );
+  });
+
+  it("removes finished agent run metadata when closing its tab", () => {
+    setTestState({ fileName: "agent.md" });
+    const tabId = getActiveTab(useAppStore.getState())!.id;
+    const run = useAppStore.getState().createAgentRun({
+      tabId,
+      taskKind: "answer_questions",
+      targetPaths: ["agent.md"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "completed",
+    });
+
+    useAppStore.getState().removeTab(tabId);
+
+    expect(useAppStore.getState().tabs.some((tab) => tab.id === tabId)).toBe(
+      false,
+    );
+    expect(useAppStore.getState().agentRuns[run.id]).toBeUndefined();
+    expect(
+      useAppStore.getState().activeAgentRunIdByTabId[tabId],
+    ).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Block closing a workspace tab while its agent run is queued, running, or waiting for attention.
- Remove completed, failed, or stopped agent run metadata when the owning tab closes.
- Document the v1 tab-close behavior for desktop agent runs.

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/workspace/test/history.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts
- npx eslint src/modules/workspace/controller.ts src/modules/workspace/test/history.test.ts (0 errors; existing warnings remain)
- npx prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/modules/workspace/controller.ts src/modules/workspace/test/history.test.ts && git diff --check
- npx vite build
- npx vite build --mode desktop