### PR TITLE
Add address-comments agent action

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,6 +165,8 @@ active runtime run id is attached and shows the latest bounded output tail.
 Workspace tab removal refuses to close tabs with queued, running, or
 attention-needed agent runs, then cleans finished run metadata when the owning
 tab is closed.
+The comment panel can start desktop runtime runs for active-file unresolved
+comments and threaded questions, while web builds keep copy-prompt fallbacks.
 
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -296,11 +296,11 @@ attention-needed runs remain open and show a toast asking the user to stop the
 run first. Finished run metadata is removed when the owning tab is closed.
 
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
-serializable run metadata and a controller action for active-file threaded
-questions. The action builds an `AgentRunRequest` with one tab, one target path,
-and explicit question thread ids. The web runtime still reports
-`canRunAgent: false`, so the website keeps the copy-prompt path until a desktop
-runtime provides an executable `AgentRuntime`.
+serializable run metadata and controller actions for active-file unresolved
+comments and threaded questions. Each action builds an `AgentRunRequest` with
+one tab, one target path, selected comment ids, and a generated prompt. The web
+runtime still reports `canRunAgent: false`, so the website keeps copy-prompt
+paths until a desktop runtime provides an executable `AgentRuntime`.
 
 Second implementation note: the next foundation slice adds serializable
 `agent-workflow` run metadata plus web runtime agent and terminal capabilities
@@ -313,6 +313,9 @@ an agent action capability helper. In the web runtime it remains the existing
 "Copy agent prompt" action. When a desktop runtime reports local agent
 execution, the same surface becomes "Ask agent" and calls the
 question-thread run controller action.
+The active-file unresolved-comments action follows the same capability path:
+website builds copy a review prompt, while desktop builds call the address
+comments run controller action.
 
 Desktop shell implementation note: `src-tauri/` now contains the first Tauri v2
 native shell. It loads the existing Vite app in a native window and adds

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -236,6 +236,9 @@ outside this first desktop planning scope.
   on the active run panel for same-window observability.
 - Closing a tab with a queued, running, or attention-needed run is blocked until
   the user stops the run or it finishes.
+- Active-file unresolved comments now have a comment-panel action: desktop
+  starts an address-comments run, while the website copies the same scoped
+  review prompt.
 
 ## Open Questions
 

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -1,3 +1,14 @@
+interface AddressCommentsPromptComment {
+  id: string;
+  type: string;
+  text: string;
+}
+
+interface AddressCommentsPromptInput {
+  targetPath: string;
+  comments: AddressCommentsPromptComment[];
+}
+
 export function buildAgentReplyPrompt(): string {
   return `Review this markdown file and answer MarkReview threaded questions inline.
 
@@ -16,4 +27,23 @@ Example question:
 
 Example answer:
 {>>answer: This section explains the reconnect fallback path after a missed live event. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}`;
+}
+
+export function buildAddressCommentsAgentPrompt(
+  input: AddressCommentsPromptInput,
+): string {
+  const commentList = input.comments
+    .map((comment) => `- ${comment.id} (${comment.type}): ${comment.text}`)
+    .join("\n");
+
+  return `Review this markdown file and address the listed MarkReview comments.
+
+Scope:
+- Work only in ${input.targetPath}.
+- Address only these unresolved comment ids:
+${commentList}
+- Apply the requested edits directly in the markdown.
+- Remove each addressed MarkReview comment once its requested change is applied.
+- Do not answer threaded question comments in this run.
+- Do not edit unrelated files or unrelated comments.`;
 }

--- a/src/modules/agent-workflow/README.md
+++ b/src/modules/agent-workflow/README.md
@@ -11,7 +11,7 @@ narrow agent run request.
 - agent run records
 - active run per tab mapping
 - run lifecycle status metadata
-- active-file question-thread run request construction
+- active-file address-comments and question-thread run request construction
 
 ## Does not own
 
@@ -29,13 +29,14 @@ narrow agent run request.
 - A tab has at most one active run in the current model.
 - Web runtime support can expose the same metadata while reporting that local
   execution is unavailable.
-- The first executable action is scoped to the active tab's active file and
-  threaded `question:` comments only.
+- Executable actions are scoped to the active tab's active file.
 
 ## Public API
 
 - `createAgentWorkflowActions` creates serializable run metadata actions.
 - `createAgentWorkflowControllerActions` creates side-effecting run start
   actions backed by the active `AgentRuntime`.
+- `buildAddressCommentsAgentRunRequest` builds the narrow request passed to the
+  runtime for addressing active-file unresolved comments.
 - `buildQuestionThreadAgentRunRequest` builds the narrow request passed to the
   runtime for answering active-file question threads.

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -1,5 +1,9 @@
 import type { StoreApi } from "zustand";
-import { buildAgentReplyPrompt, buildCommentThreadGroups } from "../../markup";
+import {
+  buildAddressCommentsAgentPrompt,
+  buildAgentReplyPrompt,
+  buildCommentThreadGroups,
+} from "../../markup";
 import { agentRuntime } from "../../runtime";
 import type {
   AgentRuntime,
@@ -46,16 +50,60 @@ interface QuestionThreadRunContext {
   workspaceRootPath: string | null;
 }
 
+interface AddressableCommentTarget {
+  id: string;
+  type: string;
+  text: string;
+}
+
+interface AddressCommentsRunContext {
+  tabId: string;
+  targetPath: string;
+  comments: AddressableCommentTarget[];
+  workspaceRootPath: string | null;
+}
+
 const SYNCABLE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
   "queued",
   "running",
   "needs_attention",
+]);
+const ADDRESSABLE_COMMENT_TYPES = new Set<Comment["type"]>([
+  "fix",
+  "rewrite",
+  "expand",
+  "clarify",
+  "remove",
+  "note",
 ]);
 
 export function getQuestionThreadCommentIds(comments: Comment[]): string[] {
   return buildCommentThreadGroups(comments)
     .filter((group) => group.root.type === "question" && !!group.root.thread)
     .map((group) => group.root.thread?.commentId ?? group.root.id);
+}
+
+function commentPromptText(comment: Comment): string {
+  return (
+    comment.text ||
+    comment.highlightedText ||
+    comment.from ||
+    comment.to ||
+    comment.raw
+  );
+}
+
+export function getAddressableCommentTargets(
+  comments: Comment[],
+): AddressableCommentTarget[] {
+  return buildCommentThreadGroups(comments)
+    .map((group) => group.root)
+    .filter((comment) => ADDRESSABLE_COMMENT_TYPES.has(comment.type))
+    .map((comment) => ({
+      id: comment.thread?.commentId ?? comment.id,
+      type: comment.type,
+      text: commentPromptText(comment),
+    }));
 }
 
 function getAgentTargetPath(tab: TabState): string | null {
@@ -106,6 +154,23 @@ Scope:
 - Answer only these MarkReview question thread ids:
 ${questionList}
 - Do not edit unrelated files or unrelated comments.`,
+  };
+}
+
+export function buildAddressCommentsAgentRunRequest(
+  context: AddressCommentsRunContext,
+): AgentRunRequest {
+  return {
+    tabId: context.tabId,
+    taskKind: "address_comments",
+    targetPaths: [context.targetPath],
+    selectedCommentIds: context.comments.map((comment) => comment.id),
+    runnerKind: "terminal",
+    workspaceRootPath: context.workspaceRootPath,
+    prompt: buildAddressCommentsAgentPrompt({
+      targetPath: context.targetPath,
+      comments: context.comments,
+    }),
   };
 }
 
@@ -170,7 +235,104 @@ export function createAgentWorkflowControllerActions<
 ): AgentWorkflowControllerActions {
   const runtime = deps.runtime ?? agentRuntime;
 
+  async function startRuntimeAgentRun(
+    request: AgentRunRequest,
+  ): Promise<AgentRunStartResult> {
+    const run = deps.get().createAgentRun({
+      tabId: request.tabId,
+      taskKind: request.taskKind,
+      targetPaths: request.targetPaths,
+      selectedCommentIds: request.selectedCommentIds,
+      runnerKind: request.runnerKind,
+    });
+
+    try {
+      const runtimeRunId = await runtime.startRun(request);
+      deps.get().updateAgentRunStatus({
+        runId: run.id,
+        status: "running",
+        terminalAttachmentId: runtimeRunId,
+      });
+      deps.showToast("Agent run started");
+      return {
+        status: "started",
+        run,
+        runtimeRunId,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Agent run failed to start";
+      console.error("[agent-workflow] failed to start agent run:", error);
+      deps.get().updateAgentRunStatus({
+        runId: run.id,
+        status: "failed",
+        errorMessage: message,
+      });
+      deps.showToast("Agent run failed to start");
+      return unavailableResult({
+        reason: "agent_unavailable",
+        message,
+      });
+    }
+  }
+
+  function getRunnableActiveTab(): {
+    tab: TabState;
+    targetPath: string;
+  } | null {
+    const tab = deps.getActiveTab(deps.get);
+    if (!tab) {
+      return null;
+    }
+
+    const targetPath = getAgentTargetPath(tab);
+    if (!targetPath) {
+      return null;
+    }
+
+    return { tab, targetPath };
+  }
+
   return {
+    startAddressCommentsAgentRun: async () => {
+      if (!runtime.canRunAgent) {
+        return unavailableResult({
+          reason: "agent_unavailable",
+          message: "Local agent execution is unavailable in this runtime.",
+        });
+      }
+
+      const activeTab = getRunnableActiveTab();
+      if (!activeTab) {
+        const tab = deps.getActiveTab(deps.get);
+        return unavailableResult({
+          reason: tab ? "no_active_file" : "no_active_tab",
+          message: tab
+            ? "Select a markdown file before starting an agent run."
+            : "Open a file or folder before starting an agent run.",
+        });
+      }
+
+      const addressableComments = getAddressableCommentTargets(
+        activeTab.tab.comments,
+      );
+      if (addressableComments.length === 0) {
+        return unavailableResult({
+          reason: "no_addressable_comments",
+          message: "No unresolved actionable comments are available.",
+        });
+      }
+
+      return startRuntimeAgentRun(
+        buildAddressCommentsAgentRunRequest({
+          tabId: activeTab.tab.id,
+          targetPath: activeTab.targetPath,
+          comments: addressableComments,
+          workspaceRootPath: getAgentWorkspaceRootPath(activeTab.tab),
+        }),
+      );
+    },
+
     startQuestionThreadAgentRun: async () => {
       if (!runtime.canRunAgent) {
         return unavailableResult({
@@ -179,23 +341,20 @@ export function createAgentWorkflowControllerActions<
         });
       }
 
-      const tab = deps.getActiveTab(deps.get);
-      if (!tab) {
+      const activeTab = getRunnableActiveTab();
+      if (!activeTab) {
+        const tab = deps.getActiveTab(deps.get);
         return unavailableResult({
-          reason: "no_active_tab",
-          message: "Open a file or folder before starting an agent run.",
+          reason: tab ? "no_active_file" : "no_active_tab",
+          message: tab
+            ? "Select a markdown file before starting an agent run."
+            : "Open a file or folder before starting an agent run.",
         });
       }
 
-      const targetPath = getAgentTargetPath(tab);
-      if (!targetPath) {
-        return unavailableResult({
-          reason: "no_active_file",
-          message: "Select a markdown file before starting an agent run.",
-        });
-      }
-
-      const questionCommentIds = getQuestionThreadCommentIds(tab.comments);
+      const questionCommentIds = getQuestionThreadCommentIds(
+        activeTab.tab.comments,
+      );
       if (questionCommentIds.length === 0) {
         return unavailableResult({
           reason: "no_question_threads",
@@ -203,48 +362,14 @@ export function createAgentWorkflowControllerActions<
         });
       }
 
-      const request = buildQuestionThreadAgentRunRequest({
-        tabId: tab.id,
-        targetPath,
-        questionCommentIds,
-        workspaceRootPath: getAgentWorkspaceRootPath(tab),
-      });
-      const run = deps.get().createAgentRun({
-        tabId: request.tabId,
-        taskKind: request.taskKind,
-        targetPaths: request.targetPaths,
-        selectedCommentIds: request.selectedCommentIds,
-        runnerKind: request.runnerKind,
-      });
-
-      try {
-        const runtimeRunId = await runtime.startRun(request);
-        deps.get().updateAgentRunStatus({
-          runId: run.id,
-          status: "running",
-          terminalAttachmentId: runtimeRunId,
-        });
-        deps.showToast("Agent run started");
-        return {
-          status: "started",
-          run,
-          runtimeRunId,
-        };
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Agent run failed to start";
-        console.error("[agent-workflow] failed to start agent run:", error);
-        deps.get().updateAgentRunStatus({
-          runId: run.id,
-          status: "failed",
-          errorMessage: message,
-        });
-        deps.showToast("Agent run failed to start");
-        return unavailableResult({
-          reason: "agent_unavailable",
-          message,
-        });
-      }
+      return startRuntimeAgentRun(
+        buildQuestionThreadAgentRunRequest({
+          tabId: activeTab.tab.id,
+          targetPath: activeTab.targetPath,
+          questionCommentIds,
+          workspaceRootPath: getAgentWorkspaceRootPath(activeTab.tab),
+        }),
+      );
     },
 
     stopActiveAgentRun: async () => {

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -8,13 +8,101 @@ import {
 } from "../../../testing/testHelpers";
 import type { AgentRuntime, AgentRunRequest } from "../../../runtime";
 import {
+  buildAddressCommentsAgentRunRequest,
   buildQuestionThreadAgentRunRequest,
   createAgentWorkflowControllerActions,
+  getAddressableCommentTargets,
   getQuestionThreadCommentIds,
 } from "../controller";
 
 beforeEach(() => {
   resetTestStore();
+});
+
+describe("address comments agent run context", () => {
+  it("selects unresolved actionable root comments", () => {
+    const commentTargets = getAddressableCommentTargets([
+      makeComment({
+        id: "fix-root",
+        type: "fix",
+        text: "Fix the intro",
+      }),
+      makeComment({
+        id: "question-root",
+        type: "question",
+        text: "Why is this here?",
+        thread: {
+          commentId: "mr-question-1",
+          threadId: "mr-question-1",
+        },
+      }),
+      makeComment({
+        id: "answer-reply",
+        type: "answer",
+        text: "Because it explains reconnect fallback.",
+        thread: {
+          commentId: "mr-answer-1",
+          threadId: "mr-question-1",
+          replyTo: "mr-question-1",
+        },
+      }),
+      makeComment({
+        id: "note-root",
+        type: "note",
+        text: "Check this claim",
+      }),
+    ]);
+
+    expect(commentTargets).toEqual([
+      {
+        id: "fix-root",
+        type: "fix",
+        text: "Fix the intro",
+      },
+      {
+        id: "note-root",
+        type: "note",
+        text: "Check this claim",
+      },
+    ]);
+  });
+
+  it("builds a narrow active-file request for addressing comments", () => {
+    const request = buildAddressCommentsAgentRunRequest({
+      tabId: "tab-1",
+      targetPath: "docs/spec.md",
+      comments: [
+        {
+          id: "comment-1",
+          type: "fix",
+          text: "Fix the intro",
+        },
+        {
+          id: "comment-2",
+          type: "rewrite",
+          text: "Rewrite this paragraph",
+        },
+      ],
+      workspaceRootPath: "/tmp/project",
+    });
+
+    expect(request).toMatchObject({
+      tabId: "tab-1",
+      taskKind: "address_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["comment-1", "comment-2"],
+      runnerKind: "terminal",
+      workspaceRootPath: "/tmp/project",
+    });
+    expect(request.prompt).toContain("Work only in docs/spec.md");
+    expect(request.prompt).toContain("- comment-1 (fix): Fix the intro");
+    expect(request.prompt).toContain(
+      "- comment-2 (rewrite): Rewrite this paragraph",
+    );
+    expect(request.prompt).toContain(
+      "Do not answer threaded question comments",
+    );
+  });
 });
 
 describe("question thread agent run context", () => {
@@ -66,6 +154,109 @@ describe("question thread agent run context", () => {
     expect(request.prompt).toContain("- mr-question-1");
     expect(request.prompt).toContain("- mr-question-2");
     expect(request.prompt).toContain("Do not edit unrelated files");
+  });
+});
+
+describe("address comments agent run controller", () => {
+  it("creates a run and starts the injected runtime", async () => {
+    const requests: AgentRunRequest[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: (request) => {
+        requests.push(request);
+        return Promise.resolve("terminal-session-1");
+      },
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
+    };
+    const showToastMessages: string[] = [];
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: (message) => {
+        showToastMessages.push(message);
+      },
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+      activeFilePath: "docs/spec.md",
+      directoryHandle: {
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      },
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix the intro",
+        }),
+      ],
+    });
+
+    const result = await actions.startAddressCommentsAgentRun();
+
+    expect(result.status).toBe("started");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      tabId: "test-tab",
+      taskKind: "address_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["fix-root"],
+      workspaceRootPath: "/tmp/project",
+    });
+    const state = useAppStore.getState();
+    const runId = state.activeAgentRunIdByTabId["test-tab"];
+    const run = runId ? state.agentRuns[runId] : null;
+    expect(run).toMatchObject({
+      tabId: "test-tab",
+      status: "running",
+      taskKind: "address_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["fix-root"],
+      runnerKind: "terminal",
+      terminalAttachmentId: "terminal-session-1",
+    });
+    expect(showToastMessages).toEqual(["Agent run started"]);
+  });
+
+  it("returns unavailable when no actionable comments exist", async () => {
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: () => Promise.resolve("terminal-session-1"),
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
+    };
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: () => {},
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+      comments: [
+        makeComment({
+          type: "question",
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+      ],
+    });
+
+    const result = await actions.startAddressCommentsAgentRun();
+
+    expect(result).toEqual({
+      status: "unavailable",
+      reason: "no_addressable_comments",
+      message: "No unresolved actionable comments are available.",
+    });
+    expect(useAppStore.getState().agentRuns).toEqual({});
   });
 });
 

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -60,6 +60,7 @@ export type AgentRunStartUnavailableReason =
   | "agent_unavailable"
   | "no_active_tab"
   | "no_active_file"
+  | "no_addressable_comments"
   | "no_question_threads";
 
 export type AgentRunStartResult =
@@ -115,6 +116,7 @@ export type AgentRunSyncStatusResult =
     };
 
 export interface AgentWorkflowControllerActions {
+  startAddressCommentsAgentRun: () => Promise<AgentRunStartResult>;
   startQuestionThreadAgentRun: () => Promise<AgentRunStartResult>;
   stopActiveAgentRun: () => Promise<AgentRunStopResult>;
   syncActiveAgentRunStatus: () => Promise<AgentRunSyncStatusResult>;

--- a/src/ui/agentActions.test.ts
+++ b/src/ui/agentActions.test.ts
@@ -1,5 +1,45 @@
 import { describe, expect, it } from "vitest";
-import { getQuestionThreadAgentAction } from "./agentActions";
+import {
+  getAddressCommentsAgentAction,
+  getQuestionThreadAgentAction,
+} from "./agentActions";
+
+describe("getAddressCommentsAgentAction", () => {
+  it("uses copy-prompt mode when local agent execution is unavailable", () => {
+    expect(
+      getAddressCommentsAgentAction({
+        canRunAgent: false,
+        canStartAddressCommentsRun: false,
+      }),
+    ).toEqual({
+      kind: "copy_prompt",
+      label: "Copy review prompt",
+      title: "Copy instructions for addressing unresolved comments",
+    });
+  });
+
+  it("uses copy-prompt mode when address-comment runs are unavailable", () => {
+    expect(
+      getAddressCommentsAgentAction({
+        canRunAgent: true,
+        canStartAddressCommentsRun: false,
+      }).kind,
+    ).toBe("copy_prompt");
+  });
+
+  it("uses run-agent mode when both capabilities are available", () => {
+    expect(
+      getAddressCommentsAgentAction({
+        canRunAgent: true,
+        canStartAddressCommentsRun: true,
+      }),
+    ).toEqual({
+      kind: "run_agent",
+      label: "Address comments",
+      title: "Ask the local agent to address unresolved comments",
+    });
+  });
+});
 
 describe("getQuestionThreadAgentAction", () => {
   it("uses copy-prompt mode when local agent execution is unavailable", () => {

--- a/src/ui/agentActions.ts
+++ b/src/ui/agentActions.ts
@@ -1,4 +1,5 @@
 export type QuestionThreadAgentActionKind = "copy_prompt" | "run_agent";
+export type AddressCommentsAgentActionKind = "copy_prompt" | "run_agent";
 
 export interface QuestionThreadAgentAction {
   kind: QuestionThreadAgentActionKind;
@@ -6,9 +7,38 @@ export interface QuestionThreadAgentAction {
   title: string;
 }
 
+export interface AddressCommentsAgentAction {
+  kind: AddressCommentsAgentActionKind;
+  label: string;
+  title: string;
+}
+
 export interface AgentActionCapabilities {
   canRunAgent: boolean;
   canStartQuestionThreadRun: boolean;
+}
+
+export interface AddressCommentsAgentActionCapabilities {
+  canRunAgent: boolean;
+  canStartAddressCommentsRun: boolean;
+}
+
+export function getAddressCommentsAgentAction(
+  capabilities: AddressCommentsAgentActionCapabilities,
+): AddressCommentsAgentAction {
+  if (capabilities.canRunAgent && capabilities.canStartAddressCommentsRun) {
+    return {
+      kind: "run_agent",
+      label: "Address comments",
+      title: "Ask the local agent to address unresolved comments",
+    };
+  }
+
+  return {
+    kind: "copy_prompt",
+    label: "Copy review prompt",
+    title: "Copy instructions for addressing unresolved comments",
+  };
 }
 
 export function getQuestionThreadAgentAction(

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -206,6 +206,54 @@ describe("CommentPanel — close", () => {
 });
 
 describe("CommentPanel — agent prompt", () => {
+  it("shows a copy review prompt button when actionable comments exist", () => {
+    setTestState({
+      activeFilePath: "docs/spec.md",
+      comments: [
+        makeCommentBase({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix the intro",
+        }),
+      ],
+    });
+
+    render(<CommentPanel />);
+    expect(
+      screen.getByRole("button", { name: "Copy review prompt" }),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the address-comments prompt to the clipboard", async () => {
+    const user = userEvent.setup();
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
+    setTestState({
+      activeFilePath: "docs/spec.md",
+      comments: [
+        makeCommentBase({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix the intro",
+        }),
+      ],
+    });
+
+    render(<CommentPanel />);
+    await user.click(
+      screen.getByRole("button", { name: "Copy review prompt" }),
+    );
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText.mock.calls[0]?.[0]).toContain("Work only in docs/spec.md");
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "- fix-root (fix): Fix the intro",
+    );
+    expect(useAppStore.getState().toast).toBe("Agent review prompt copied");
+  });
+
   it("shows a copy prompt button when question threads exist", () => {
     setTestState({
       comments: [

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -1,10 +1,14 @@
 import "./CommentPanel.css";
 import { useEffect, useMemo, useState } from "react";
 import {
+  buildAddressCommentsAgentPrompt,
   buildAgentReplyPrompt,
   buildCommentThreadGroups,
 } from "../../../markup";
-import { getActiveAgentRunForTab } from "../../../modules/agent-workflow";
+import {
+  getActiveAgentRunForTab,
+  getAddressableCommentTargets,
+} from "../../../modules/agent-workflow";
 import type { AgentRunStatus } from "../../../modules/agent-workflow";
 import { canRunAgent } from "../../../runtime";
 import { useAppStore } from "../../../store";
@@ -12,7 +16,11 @@ import { useActiveTab } from "../../../store/selectors";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
 import type { Comment, CommentType } from "../../../types/criticmarkup";
 import type { PeerComment } from "../../../types/share";
-import { getQuestionThreadAgentAction } from "../../agentActions";
+import type { TabState } from "../../../types/tab";
+import {
+  getAddressCommentsAgentAction,
+  getQuestionThreadAgentAction,
+} from "../../agentActions";
 
 const ALL_TYPES: CommentType[] = [
   "fix",
@@ -47,6 +55,9 @@ const AGENT_RUN_STATUS_LABEL: Record<AgentRunStatus, string> = {
   failed: "Failed",
   stopped: "Stopped",
 };
+const EMPTY_COMMENTS: Comment[] = [];
+const EMPTY_FILE_TREE: TabState["fileTree"] = [];
+const EMPTY_ALL_FILE_COMMENTS: TabState["allFileComments"] = {};
 
 function scrollToBlock(blockIndex: number | undefined) {
   if (blockIndex === undefined) {
@@ -126,12 +137,12 @@ interface Props {
 
 export function CommentPanel({ peerMode = false }: Props) {
   const tab = useActiveTab();
-  const comments = tab?.comments ?? [];
+  const comments = tab?.comments ?? EMPTY_COMMENTS;
   const hostRootComments = useMemo(
     () => getRootOnlyComments(comments),
     [comments],
   );
-  const resolvedComments = tab?.resolvedComments ?? [];
+  const resolvedComments = tab?.resolvedComments ?? EMPTY_COMMENTS;
   const activeCommentId = tab?.activeCommentId ?? null;
   const activeRootCommentId = useMemo(
     () => getActiveRootCommentId(comments, activeCommentId),
@@ -147,8 +158,8 @@ export function CommentPanel({ peerMode = false }: Props) {
   const activeFilePath = peerMode
     ? peerActiveFilePath
     : (tab?.activeFilePath ?? null);
-  const fileTree = tab?.fileTree ?? [];
-  const allFileComments = tab?.allFileComments ?? {};
+  const fileTree = tab?.fileTree ?? EMPTY_FILE_TREE;
+  const allFileComments = tab?.allFileComments ?? EMPTY_ALL_FILE_COMMENTS;
   const navigateToComment = useAppStore((state) => state.navigateToComment);
   const editComment = useAppStore((state) => state.editComment);
   const deleteComment = useAppStore((state) => state.deleteComment);
@@ -158,6 +169,9 @@ export function CommentPanel({ peerMode = false }: Props) {
   const selectPeerFile = useAppStore((state) => state.selectPeerFile);
   const startQuestionThreadAgentRun = useAppStore(
     (state) => state.startQuestionThreadAgentRun,
+  );
+  const startAddressCommentsAgentRun = useAppStore(
+    (state) => state.startAddressCommentsAgentRun,
   );
   const stopActiveAgentRun = useAppStore((state) => state.stopActiveAgentRun);
   const syncActiveAgentRunStatus = useAppStore(
@@ -262,6 +276,13 @@ export function CommentPanel({ peerMode = false }: Props) {
       (comment) => comment.type === "question" && !!comment.thread,
     );
   }, [crossFileComments, hostRootComments, isFolderMode, peerMode]);
+  const addressableCommentTargets = useMemo(() => {
+    if (peerMode || isFolderMode) {
+      return [];
+    }
+    return getAddressableCommentTargets(comments);
+  }, [comments, isFolderMode, peerMode]);
+  const hasAddressableComments = addressableCommentTargets.length > 0;
 
   const isResolved = !peerMode && commentFilter === "resolved";
 
@@ -345,9 +366,30 @@ export function CommentPanel({ peerMode = false }: Props) {
     }
   }
 
+  async function handleCopyAddressCommentsPrompt() {
+    const targetPath =
+      activeFilePath ?? tab?.fileName ?? "the active markdown file";
+    try {
+      await navigator.clipboard.writeText(
+        buildAddressCommentsAgentPrompt({
+          targetPath,
+          comments: addressableCommentTargets,
+        }),
+      );
+      showToast("Agent review prompt copied");
+    } catch (error) {
+      console.error("[CommentPanel] failed to copy agent prompt:", error);
+      showToast("Couldn't copy agent prompt");
+    }
+  }
+
+  const addressCommentsAgentAction = getAddressCommentsAgentAction({
+    canRunAgent,
+    canStartAddressCommentsRun: hasAddressableComments,
+  });
   const questionThreadAgentAction = getQuestionThreadAgentAction({
     canRunAgent,
-    canStartQuestionThreadRun: true,
+    canStartQuestionThreadRun: hasQuestionThreads,
   });
   const canStopAgentRun = Boolean(
     activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
@@ -361,6 +403,18 @@ export function CommentPanel({ peerMode = false }: Props) {
     }
 
     const result = await startQuestionThreadAgentRun();
+    if (result.status === "unavailable") {
+      showToast(result.message);
+    }
+  }
+
+  async function handleAddressCommentsAgentAction() {
+    if (addressCommentsAgentAction.kind === "copy_prompt") {
+      await handleCopyAddressCommentsPrompt();
+      return;
+    }
+
+    const result = await startAddressCommentsAgentRun();
     if (result.status === "unavailable") {
       showToast(result.message);
     }
@@ -433,6 +487,17 @@ export function CommentPanel({ peerMode = false }: Props) {
         </span>
         {!peerMode && displayCount > 0 && (
           <>
+            {hasAddressableComments && !canStopAgentRun && (
+              <button
+                className="comment-panel__secondary-action"
+                onClick={() => {
+                  void handleAddressCommentsAgentAction();
+                }}
+                title={addressCommentsAgentAction.title}
+              >
+                {addressCommentsAgentAction.label}
+              </button>
+            )}
             {hasQuestionThreads && !canStopAgentRun && (
               <button
                 className="comment-panel__secondary-action"


### PR DESCRIPTION
## Summary
- Add an active-file address-comments agent request and controller action for unresolved actionable comments.
- Show a comment-panel action that runs the local desktop agent when available, or copies the scoped review prompt on the website.
- Keep question-thread agent runs separate and update docs/tests for both narrow active-file actions.

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx src/runtime/webAgentRuntime.test.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts
- npx eslint src/markup/agentPrompt.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/agentActions.ts src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.test.tsx (0 errors; 2 existing CommentPanel async-handler warnings remain)
- npx prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/markup/agentPrompt.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/README.md src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/agentActions.ts src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.test.tsx && git diff --check
- npx vite build
- npx vite build --mode desktop