### PR TITLE
Guard agent run concurrency

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,6 +167,8 @@ attention-needed agent runs, then cleans finished run metadata when the owning
 tab is closed.
 The comment panel can start desktop runtime runs for active-file unresolved
 comments and threaded questions, while web builds keep copy-prompt fallbacks.
+Agent start actions refuse to create a second active run for the same tab and
+cap v1 to three active runs app-wide.
 
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -227,7 +227,7 @@ Rules:
 - Closing a tab with a queued/running/attention run is blocked until the run is
   stopped or finishes. A richer stop/detach/cancel decision can follow once
   detachable terminal sessions exist.
-- A small app-wide active-run limit should prevent accidental over-parallelism.
+- At most three queued/running/attention runs may exist app-wide in v1.
 
 ## Website Preservation
 

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -239,10 +239,11 @@ outside this first desktop planning scope.
 - Active-file unresolved comments now have a comment-panel action: desktop
   starts an address-comments run, while the website copies the same scoped
   review prompt.
+- Agent starts are guarded to one active run per tab and three active runs
+  app-wide.
 
 ## Open Questions
 
-- What is the exact global concurrency limit for active runs?
 - How should desktop handle agent authentication and first-run setup?
 - What is the minimum Windows backend for terminal/session support if `tmux` is
   not available?

--- a/src/modules/agent-workflow/README.md
+++ b/src/modules/agent-workflow/README.md
@@ -27,6 +27,8 @@ narrow agent run request.
 - Agent runs are host-mode concepts.
 - Runtime-owned objects stay outside Zustand.
 - A tab has at most one active run in the current model.
+- The app allows at most three queued, running, or attention-needed runs at a
+  time in v1.
 - Web runtime support can expose the same metadata while reporting that local
   execution is unavailable.
 - Executable actions are scoped to the active tab's active file.

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -68,6 +68,7 @@ const SYNCABLE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
   "running",
   "needs_attention",
 ]);
+const MAX_ACTIVE_AGENT_RUNS = 3;
 const ADDRESSABLE_COMMENT_TYPES = new Set<Comment["type"]>([
   "fix",
   "rewrite",
@@ -228,6 +229,43 @@ function failedRuntimeStatusMessage(status: AgentRuntimeRunStatus): string {
   return "Agent run failed";
 }
 
+function countActiveAgentRuns(state: AgentWorkflowState): number {
+  return Object.values(state.agentRuns).filter((run) =>
+    SYNCABLE_AGENT_RUN_STATUSES.has(run.status),
+  ).length;
+}
+
+function hasActiveAgentRunForTab(
+  state: AgentWorkflowState,
+  tabId: string,
+): boolean {
+  const runId = state.activeAgentRunIdByTabId[tabId];
+  const run = runId ? state.agentRuns[runId] : null;
+  return Boolean(run && SYNCABLE_AGENT_RUN_STATUSES.has(run.status));
+}
+
+function getRunStartGuardResult(
+  state: AgentWorkflowState,
+  tabId: string,
+): AgentRunStartResult | null {
+  if (hasActiveAgentRunForTab(state, tabId)) {
+    return unavailableResult({
+      reason: "tab_agent_run_active",
+      message: "Stop the active agent run in this tab before starting another.",
+    });
+  }
+
+  if (countActiveAgentRuns(state) >= MAX_ACTIVE_AGENT_RUNS) {
+    return unavailableResult({
+      reason: "active_run_limit_reached",
+      message:
+        "Too many agent runs are active. Stop or wait for one run before starting another.",
+    });
+  }
+
+  return null;
+}
+
 export function createAgentWorkflowControllerActions<
   StoreState extends AgentWorkflowControllerStoreState,
 >(
@@ -313,6 +351,11 @@ export function createAgentWorkflowControllerActions<
         });
       }
 
+      const guardResult = getRunStartGuardResult(deps.get(), activeTab.tab.id);
+      if (guardResult) {
+        return guardResult;
+      }
+
       const addressableComments = getAddressableCommentTargets(
         activeTab.tab.comments,
       );
@@ -350,6 +393,11 @@ export function createAgentWorkflowControllerActions<
             ? "Select a markdown file before starting an agent run."
             : "Open a file or folder before starting an agent run.",
         });
+      }
+
+      const guardResult = getRunStartGuardResult(deps.get(), activeTab.tab.id);
+      if (guardResult) {
+        return guardResult;
       }
 
       const questionCommentIds = getQuestionThreadCommentIds(

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -222,6 +222,112 @@ describe("address comments agent run controller", () => {
     expect(showToastMessages).toEqual(["Agent run started"]);
   });
 
+  it("does not start a second run for the active tab", async () => {
+    const requests: AgentRunRequest[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: (request) => {
+        requests.push(request);
+        return Promise.resolve("terminal-session-1");
+      },
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
+    };
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: () => {},
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix the intro",
+        }),
+      ],
+    });
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "test-tab",
+      taskKind: "address_comments",
+      targetPaths: ["spec.md"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+    });
+
+    const result = await actions.startAddressCommentsAgentRun();
+
+    expect(result).toEqual({
+      status: "unavailable",
+      reason: "tab_agent_run_active",
+      message: "Stop the active agent run in this tab before starting another.",
+    });
+    expect(requests).toEqual([]);
+    expect(useAppStore.getState().activeAgentRunIdByTabId["test-tab"]).toBe(
+      run.id,
+    );
+  });
+
+  it("does not start a run when the app-wide active run limit is reached", async () => {
+    const requests: AgentRunRequest[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      startRun: (request) => {
+        requests.push(request);
+        return Promise.resolve("terminal-session-1");
+      },
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
+    };
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: () => {},
+      runtime,
+    });
+
+    setTestState({
+      fileName: "spec.md",
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix the intro",
+        }),
+      ],
+    });
+    for (const tabId of ["tab-1", "tab-2", "tab-3"]) {
+      const run = useAppStore.getState().createAgentRun({
+        tabId,
+        taskKind: "address_comments",
+        targetPaths: [`${tabId}.md`],
+        runnerKind: "terminal",
+      });
+      useAppStore.getState().updateAgentRunStatus({
+        runId: run.id,
+        status: "running",
+        terminalAttachmentId: `native-${tabId}`,
+      });
+    }
+
+    const result = await actions.startAddressCommentsAgentRun();
+
+    expect(result).toEqual({
+      status: "unavailable",
+      reason: "active_run_limit_reached",
+      message:
+        "Too many agent runs are active. Stop or wait for one run before starting another.",
+    });
+    expect(requests).toEqual([]);
+  });
+
   it("returns unavailable when no actionable comments exist", async () => {
     const runtime: AgentRuntime = {
       canRunAgent: true,

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -57,11 +57,13 @@ export interface AgentWorkflowActions {
 }
 
 export type AgentRunStartUnavailableReason =
+  | "active_run_limit_reached"
   | "agent_unavailable"
   | "no_active_tab"
   | "no_active_file"
   | "no_addressable_comments"
-  | "no_question_threads";
+  | "no_question_threads"
+  | "tab_agent_run_active";
 
 export type AgentRunStartResult =
   | {


### PR DESCRIPTION
## Summary
- Refuse to start a second queued/running/attention-needed agent run for the same tab.
- Cap v1 to three queued/running/attention-needed agent runs across the app.
- Document the concrete concurrency guard and remove the resolved open question.

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx
- npx eslint src/modules/agent-workflow/controller.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx (0 errors; 2 existing CommentPanel async-handler warnings remain)
- npx prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/modules/agent-workflow/README.md src/modules/agent-workflow/controller.ts src/modules/agent-workflow/types.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts && git diff --check
- npx vite build
- npx vite build --mode desktop