### PR TITLE
Show desktop agent availability

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,6 +169,8 @@ The comment panel can start desktop runtime runs for active-file unresolved
 comments and threaded questions, while web builds keep copy-prompt fallbacks.
 Agent start actions refuse to create a second active run for the same tab and
 cap v1 to three active runs app-wide.
+Desktop UI reads the runtime agent capability asynchronously, so an unconfigured
+`DRAGON_AGENT_COMMAND` falls back to prompt copying with an inline setup message.
 
 Workspace runtime file operations accept runtime targets. Browser targets are
 the current `FileSystem*Handle` values, while native targets are path-based

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -273,6 +273,9 @@ Native runner implementation note: desktop agent runs now call Tauri
 and stores only the returned runtime run id in app state. This keeps tmux, Codex
 CLI, and other runner choices behind the native runtime boundary instead of
 hard-coding one backend into the UI/store contract.
+The comment panel checks the native availability command before presenting
+run-agent actions, so an unconfigured command falls back to prompt copying with
+an inline setup message.
 
 Run-control implementation note: the comment panel now shows the active run for
 the current tab and exposes a stop action while the run is queued, running, or

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -241,6 +241,8 @@ outside this first desktop planning scope.
   review prompt.
 - Agent starts are guarded to one active run per tab and three active runs
   app-wide.
+- Desktop reads agent availability before showing run actions, so missing
+  `DRAGON_AGENT_COMMAND` falls back to prompt copying with a setup message.
 
 ## Open Questions
 

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -162,6 +162,8 @@ describe("address comments agent run controller", () => {
     const requests: AgentRunRequest[] = [];
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: (request) => {
         requests.push(request);
         return Promise.resolve("terminal-session-1");
@@ -226,6 +228,8 @@ describe("address comments agent run controller", () => {
     const requests: AgentRunRequest[] = [];
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: (request) => {
         requests.push(request);
         return Promise.resolve("terminal-session-1");
@@ -279,6 +283,8 @@ describe("address comments agent run controller", () => {
     const requests: AgentRunRequest[] = [];
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: (request) => {
         requests.push(request);
         return Promise.resolve("terminal-session-1");
@@ -331,6 +337,8 @@ describe("address comments agent run controller", () => {
   it("returns unavailable when no actionable comments exist", async () => {
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: () => Promise.resolve("terminal-session-1"),
       stopRun: () => Promise.resolve(),
       getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
@@ -395,6 +403,8 @@ describe("question thread agent run controller", () => {
     const requests: AgentRunRequest[] = [];
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: (request) => {
         requests.push(request);
         return Promise.resolve("terminal-session-1");
@@ -461,6 +471,8 @@ describe("question thread agent run controller", () => {
     const stoppedRuntimeRunIds: string[] = [];
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: () => Promise.resolve("terminal-session-1"),
       stopRun: (runId) => {
         stoppedRuntimeRunIds.push(runId);
@@ -508,6 +520,8 @@ describe("question thread agent run controller", () => {
     const checkedRuntimeRunIds: string[] = [];
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: () => Promise.resolve("terminal-session-1"),
       stopRun: () => Promise.resolve(),
       getRunStatus: (runId) => {
@@ -560,6 +574,8 @@ describe("question thread agent run controller", () => {
   it("syncs a failed native runtime run into the active tab run", async () => {
     const runtime: AgentRuntime = {
       canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
       startRun: () => Promise.resolve("terminal-session-1"),
       stopRun: () => Promise.resolve(),
       getRunStatus: () =>

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -35,8 +35,14 @@ export type AgentRuntimeRunStatus =
       output: string;
     };
 
+export interface AgentRuntimeCapability {
+  canRunAgent: boolean;
+  unavailableMessage: string | null;
+}
+
 export interface AgentRuntime {
   canRunAgent: boolean;
+  getCapability(): Promise<AgentRuntimeCapability>;
   startRun(request: AgentRunRequest): Promise<string>;
   stopRun(runId: string): Promise<void>;
   getRunStatus(runId: string): Promise<AgentRuntimeRunStatus>;
@@ -44,6 +50,11 @@ export interface AgentRuntime {
 
 export const webAgentRuntime: AgentRuntime = {
   canRunAgent: false,
+  getCapability: () =>
+    Promise.resolve({
+      canRunAgent: false,
+      unavailableMessage: "Local agent execution is unavailable on web.",
+    }),
   startRun: () =>
     Promise.reject(new Error("Local agent execution is unavailable on web")),
   stopRun: () => Promise.resolve(),

--- a/src/runtime/desktop.ts
+++ b/src/runtime/desktop.ts
@@ -12,6 +12,7 @@ export {
   assertDesktopRuntimeAvailable,
   desktopAgentRuntime,
   getDesktopAgentCapability,
+  getDesktopAgentCapabilityStatus,
 } from "./desktopAgentRuntime";
 export { desktopTerminalRuntime } from "./desktopTerminalRuntime";
 export { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";

--- a/src/runtime/desktopAgentRuntime.test.ts
+++ b/src/runtime/desktopAgentRuntime.test.ts
@@ -3,6 +3,7 @@ import {
   assertDesktopRuntimeAvailable,
   desktopAgentRuntime,
   getDesktopAgentCapability,
+  getDesktopAgentCapabilityStatus,
 } from "./desktopAgentRuntime";
 
 beforeEach(() => {
@@ -29,6 +30,11 @@ describe("desktop agent runtime", () => {
     };
 
     await expect(getDesktopAgentCapability()).resolves.toBe(false);
+    await expect(getDesktopAgentCapabilityStatus()).resolves.toEqual({
+      canRunAgent: false,
+      unavailableMessage:
+        "Configure DRAGON_AGENT_COMMAND before starting local agent runs.",
+    });
   });
 
   it("starts, stops, and reads runs through the native agent commands", async () => {

--- a/src/runtime/desktopAgentRuntime.ts
+++ b/src/runtime/desktopAgentRuntime.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntime } from "./agent";
+import type { AgentRuntime, AgentRuntimeCapability } from "./agent";
 import {
   getTauriAgentRuntimeAvailable,
   getTauriAgentRunStatus,
@@ -17,12 +17,41 @@ export async function assertDesktopRuntimeAvailable(): Promise<void> {
 }
 
 export async function getDesktopAgentCapability(): Promise<boolean> {
-  await assertDesktopRuntimeAvailable();
-  return getTauriAgentRuntimeAvailable();
+  const capability = await getDesktopAgentCapabilityStatus();
+  return capability.canRunAgent;
+}
+
+export async function getDesktopAgentCapabilityStatus(): Promise<AgentRuntimeCapability> {
+  try {
+    await assertDesktopRuntimeAvailable();
+    const canRunAgent = await getTauriAgentRuntimeAvailable();
+    if (canRunAgent) {
+      return {
+        canRunAgent: true,
+        unavailableMessage: null,
+      };
+    }
+
+    return {
+      canRunAgent: false,
+      unavailableMessage:
+        "Configure DRAGON_AGENT_COMMAND before starting local agent runs.",
+    };
+  } catch (error) {
+    const unavailableMessage =
+      error instanceof Error
+        ? error.message
+        : "Desktop agent runtime is unavailable.";
+    return {
+      canRunAgent: false,
+      unavailableMessage,
+    };
+  }
 }
 
 export const desktopAgentRuntime: AgentRuntime = {
   canRunAgent: true,
+  getCapability: getDesktopAgentCapabilityStatus,
   startRun: async (request) => {
     await assertDesktopRuntimeAvailable();
     return startTauriAgentRun(request);

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -6,6 +6,7 @@ import type {
 
 export type {
   AgentRuntime,
+  AgentRuntimeCapability,
   AgentRunRequest,
   AgentRuntimeRunStatus,
 } from "./agent";
@@ -30,6 +31,10 @@ export const terminalRuntime = activeRuntime.terminalRuntime;
 
 export const canRunAgent = agentRuntime.canRunAgent;
 export const canShowTerminal = terminalRuntime.canShowTerminal;
+
+export function getAgentRuntimeCapability() {
+  return agentRuntime.getCapability();
+}
 
 export function openFile() {
   return workspaceRuntime.openFile();

--- a/src/runtime/webAgentRuntime.test.ts
+++ b/src/runtime/webAgentRuntime.test.ts
@@ -5,6 +5,10 @@ describe("web agent runtime capabilities", () => {
   it("reports that local agent execution is unavailable on web", async () => {
     expect(canRunAgent).toBe(false);
     expect(agentRuntime.canRunAgent).toBe(false);
+    await expect(agentRuntime.getCapability()).resolves.toEqual({
+      canRunAgent: false,
+      unavailableMessage: "Local agent execution is unavailable on web.",
+    });
 
     await expect(
       agentRuntime.startRun({

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -192,6 +192,16 @@
   color: var(--accent);
 }
 
+.comment-panel__agent-capability {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--c-orange) 35%, var(--border));
+  background: color-mix(in srgb, var(--surface) 86%, var(--c-orange) 14%);
+  color: var(--text-secondary);
+  font-size: 0.74rem;
+  line-height: 1.35;
+}
+
 .comment-panel__close {
   background: none;
   border: none;

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -10,7 +10,8 @@ import {
   getAddressableCommentTargets,
 } from "../../../modules/agent-workflow";
 import type { AgentRunStatus } from "../../../modules/agent-workflow";
-import { canRunAgent } from "../../../runtime";
+import { canRunAgent, getAgentRuntimeCapability } from "../../../runtime";
+import type { AgentRuntimeCapability } from "../../../runtime";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
@@ -58,6 +59,12 @@ const AGENT_RUN_STATUS_LABEL: Record<AgentRunStatus, string> = {
 const EMPTY_COMMENTS: Comment[] = [];
 const EMPTY_FILE_TREE: TabState["fileTree"] = [];
 const EMPTY_ALL_FILE_COMMENTS: TabState["allFileComments"] = {};
+const INITIAL_AGENT_CAPABILITY: AgentRuntimeCapability = {
+  canRunAgent: false,
+  unavailableMessage: canRunAgent
+    ? null
+    : "Local agent execution is unavailable on web.",
+};
 
 function scrollToBlock(blockIndex: number | undefined) {
   if (blockIndex === undefined) {
@@ -183,6 +190,9 @@ export function CommentPanel({ peerMode = false }: Props) {
   );
   const sharedContent = useAppStore((state) => state.sharedContent);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+  const [agentCapability, setAgentCapability] = useState(
+    INITIAL_AGENT_CAPABILITY,
+  );
 
   const isFolderMode = fileTree.length > 0 && !peerMode;
   const isPeerMultiFile =
@@ -384,17 +394,23 @@ export function CommentPanel({ peerMode = false }: Props) {
   }
 
   const addressCommentsAgentAction = getAddressCommentsAgentAction({
-    canRunAgent,
+    canRunAgent: agentCapability.canRunAgent,
     canStartAddressCommentsRun: hasAddressableComments,
   });
   const questionThreadAgentAction = getQuestionThreadAgentAction({
-    canRunAgent,
+    canRunAgent: agentCapability.canRunAgent,
     canStartQuestionThreadRun: hasQuestionThreads,
   });
   const canStopAgentRun = Boolean(
     activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
   );
   const showAgentRunStatus = !peerMode && activeAgentRun;
+  const showAgentCapabilityWarning = Boolean(
+    !peerMode &&
+    canRunAgent &&
+    !agentCapability.canRunAgent &&
+    agentCapability.unavailableMessage,
+  );
 
   async function handleQuestionThreadAgentAction() {
     if (questionThreadAgentAction.kind === "copy_prompt") {
@@ -430,7 +446,7 @@ export function CommentPanel({ peerMode = false }: Props) {
   useEffect(() => {
     if (
       peerMode ||
-      !canRunAgent ||
+      !agentCapability.canRunAgent ||
       !activeAgentRun?.terminalAttachmentId ||
       !ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status)
     ) {
@@ -450,9 +466,42 @@ export function CommentPanel({ peerMode = false }: Props) {
     activeAgentRun?.id,
     activeAgentRun?.status,
     activeAgentRun?.terminalAttachmentId,
+    agentCapability.canRunAgent,
     peerMode,
     syncActiveAgentRunStatus,
   ]);
+
+  useEffect(() => {
+    if (peerMode) {
+      return;
+    }
+
+    let cancelled = false;
+    getAgentRuntimeCapability()
+      .then((capability) => {
+        if (
+          !cancelled &&
+          (capability.canRunAgent !== INITIAL_AGENT_CAPABILITY.canRunAgent ||
+            capability.unavailableMessage !==
+              INITIAL_AGENT_CAPABILITY.unavailableMessage)
+        ) {
+          setAgentCapability(capability);
+        }
+      })
+      .catch((error) => {
+        console.error("[CommentPanel] failed to read agent capability:", error);
+        if (!cancelled) {
+          setAgentCapability({
+            canRunAgent: false,
+            unavailableMessage: "Agent runtime availability check failed.",
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [peerMode]);
 
   useEffect(() => {
     const activePanelCommentId = peerMode
@@ -561,6 +610,12 @@ export function CommentPanel({ peerMode = false }: Props) {
               Dismiss
             </button>
           )}
+        </div>
+      )}
+
+      {showAgentCapabilityWarning && (
+        <div className="comment-panel__agent-capability" role="status">
+          {agentCapability.unavailableMessage}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Add an async agent runtime capability check shared by web and desktop runtimes.
- Map missing desktop `DRAGON_AGENT_COMMAND` to an inline setup message and prompt-copy fallback instead of showing run actions too early.
- Document the availability behavior in the desktop-agent architecture and feature notes.

## Verification
- npx tsc --noEmit
- npx vitest run src/runtime/webAgentRuntime.test.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/tauriBridge.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/agentActions.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx
- npx eslint src/runtime/agent.ts src/runtime/desktopAgentRuntime.ts src/runtime/desktop.ts src/runtime/index.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/webAgentRuntime.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx (0 errors; 2 existing CommentPanel async-handler warnings remain)
- npx prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/runtime/agent.ts src/runtime/desktopAgentRuntime.ts src/runtime/desktop.ts src/runtime/index.ts src/runtime/desktopAgentRuntime.test.ts src/runtime/webAgentRuntime.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.css && git diff --check
- npx vite build
- npx vite build --mode desktop