### PR TITLE
Persist native workspace targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -188,9 +188,9 @@ commands. The desktop workspace runtime uses those dialogs for host open flows
 and returns native path targets.
 
 Host tab state can store either browser handles or native path targets for live
-file and directory access. Browser handles remain the only targets persisted in
-IndexedDB restore storage; native target persistence is a separate desktop
-runtime concern.
+file and directory access. Browser handles use IndexedDB restore storage, while
+serializable native path targets are persisted with tab state and restored
+through the active workspace runtime.
 
 ### `workspace`
 

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -359,8 +359,8 @@ on browser handles until tab state is widened to store native sessions.
 
 Native tab target note: host tab state now accepts browser handles or native path
 targets for live file and directory access. Existing browser handle restore logic
-is preserved; native restore/session persistence will be handled in a later
-desktop runtime slice.
+is preserved; serializable native file and folder path targets are persisted
+with tab state and restored through the active workspace runtime.
 
 ## Risks
 

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -243,13 +243,15 @@ outside this first desktop planning scope.
   app-wide.
 - Desktop reads agent availability before showing run actions, so missing
   `DRAGON_AGENT_COMMAND` falls back to prompt copying with a setup message.
+- Native file and folder targets are persisted by path, so desktop tabs can
+  restore live access after reload without browser handle storage.
 
 ## Open Questions
 
 - How should desktop handle agent authentication and first-run setup?
 - What is the minimum Windows backend for terminal/session support if `tmux` is
   not available?
-- How much native file/session persistence should desktop restore across app
+- How much agent terminal/session persistence should desktop restore across app
   restarts?
 - Which structured runner should follow the first configurable terminal-command
   runner?

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -171,8 +171,14 @@ export async function restoreDirectoryTabState<
   }
 
   try {
-    const handle = await getHandle(`tab:${tab.id}:directory`);
-    if (!handle || handle.kind !== "directory") {
+    const handle =
+      tab.directoryHandle && isNativeDirectoryTarget(tab.directoryHandle)
+        ? tab.directoryHandle
+        : await getHandle(`tab:${tab.id}:directory`);
+    if (
+      !handle ||
+      (!isBrowserDirectoryHandle(handle) && !isNativeDirectoryTarget(handle))
+    ) {
       console.debug(
         "[restoreDirectoryTabState] no saved directory handle:",
         tab.id,
@@ -191,30 +197,32 @@ export async function restoreDirectoryTabState<
       return;
     }
 
-    let readPermission = await handle.queryPermission({ mode: "read" });
-    if (readPermission !== "granted" && requestPermissionOnPrompt) {
-      readPermission = await handle.requestPermission({ mode: "read" });
-    }
-    if (readPermission !== "granted") {
-      console.debug(
-        "[restoreDirectoryTabState] directory permission not granted:",
-        {
-          tabId: tab.id,
-          directoryName: tab.directoryName,
-          readPermission,
-        },
-      );
-      set((state) => ({
-        tabs: buildUpdatedTabs(state.tabs, tab.id, () => ({
-          ...buildRestoreAccessState(
-            buildFolderRestoreMessage({
-              directoryName: tab.directoryName,
-              fileName: tab.fileName,
-            }),
-          ),
-        })),
-      }));
-      return;
+    if (isBrowserDirectoryHandle(handle)) {
+      let readPermission = await handle.queryPermission({ mode: "read" });
+      if (readPermission !== "granted" && requestPermissionOnPrompt) {
+        readPermission = await handle.requestPermission({ mode: "read" });
+      }
+      if (readPermission !== "granted") {
+        console.debug(
+          "[restoreDirectoryTabState] directory permission not granted:",
+          {
+            tabId: tab.id,
+            directoryName: tab.directoryName,
+            readPermission,
+          },
+        );
+        set((state) => ({
+          tabs: buildUpdatedTabs(state.tabs, tab.id, () => ({
+            ...buildRestoreAccessState(
+              buildFolderRestoreMessage({
+                directoryName: tab.directoryName,
+                fileName: tab.fileName,
+              }),
+            ),
+          })),
+        }));
+        return;
+      }
     }
 
     const tree = await buildFileTree(handle);
@@ -1096,6 +1104,18 @@ export function createWorkspaceControllerActions<
           }
         } else if (tab.fileName) {
           try {
+            if (tab.fileHandle && isNativeFileTarget(tab.fileHandle)) {
+              const restoredRawContent = await readFile(tab.fileHandle);
+              set((state) => ({
+                tabs: buildUpdatedTabs(state.tabs, tab.id, () => ({
+                  rawContent: restoredRawContent,
+                  writeAllowed: true,
+                  restoreError: null,
+                })),
+              }));
+              continue;
+            }
+
             const handle = await getHandle(`tab:${tab.id}:file`);
             if (!handle || handle.kind !== "file") {
               console.warn(

--- a/src/modules/workspace/test/tabRestore.test.ts
+++ b/src/modules/workspace/test/tabRestore.test.ts
@@ -15,7 +15,11 @@ vi.mock("../storage", async (importOriginal) => {
 
 import { useAppStore } from "../../../store";
 import { createDefaultTab } from "../../../types/tab";
-import type { FileTreeNode } from "../../../types/fileTree";
+import type {
+  FileTreeNode,
+  NativeDirectoryTarget,
+  NativeFileTarget,
+} from "../../../types/fileTree";
 import { resetTestStore, setTestState } from "../../../testing/testHelpers";
 import { getActiveTab } from "../selectors";
 import {
@@ -30,6 +34,40 @@ beforeEach(() => {
   resetTestStore();
   vi.clearAllMocks();
 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function getPersistedStoreState(): Record<string, unknown> {
+  const raw = localStorage.getItem("markreview-store");
+  if (!raw) {
+    throw new Error("Expected markreview-store to be persisted");
+  }
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!isRecord(parsed) || !isRecord(parsed["state"])) {
+    throw new Error("Expected persisted store state object");
+  }
+
+  return parsed["state"];
+}
+
+function findRecordById(
+  values: unknown[],
+  id: string,
+): Record<string, unknown> {
+  const record = values.find((value) => isRecord(value) && value["id"] === id);
+  if (!isRecord(record)) {
+    throw new Error(`Expected persisted record ${id}`);
+  }
+
+  return record;
+}
 
 describe("store.switchTab", () => {
   it("restores a persisted folder tab when it becomes active", async () => {
@@ -144,6 +182,152 @@ describe("store.switchTab", () => {
 });
 
 describe("store.restoreTabs", () => {
+  it("restores a native file tab from its persisted path target", async () => {
+    const nativeFileHandle: NativeFileTarget = {
+      kind: "native_file",
+      path: "/tmp/project/notes.md",
+      name: "notes.md",
+    };
+    const fileTab = createDefaultTab({
+      id: "file-tab",
+      label: "notes.md",
+      fileHandle: nativeFileHandle,
+      fileName: "notes.md",
+      rawContent: "# Stale content",
+      restoreError: "Previous error",
+      writeAllowed: false,
+    });
+
+    useAppStore.setState({
+      tabs: [fileTab],
+      activeTabId: fileTab.id,
+    });
+
+    vi.mocked(readFile).mockResolvedValue("# Native restored content");
+
+    await useAppStore.getState().restoreTabs();
+
+    const tab = useAppStore.getState().tabs.find((t) => t.id === "file-tab");
+    expect(getHandle).not.toHaveBeenCalledWith("tab:file-tab:file");
+    expect(readFile).toHaveBeenCalledWith(nativeFileHandle);
+    expect(tab?.fileHandle).toBe(nativeFileHandle);
+    expect(tab?.rawContent).toBe("# Native restored content");
+    expect(tab?.restoreError).toBeNull();
+    expect(tab?.writeAllowed).toBe(true);
+  });
+
+  it("restores a native folder tab from its persisted path target", async () => {
+    const nativeDirectoryHandle: NativeDirectoryTarget = {
+      kind: "native_directory",
+      path: "/tmp/project",
+      name: "project",
+    };
+    const nativeFileHandle: NativeFileTarget = {
+      kind: "native_file",
+      path: "/tmp/project/docs/readme.md",
+      name: "readme.md",
+    };
+    const directoryTab = createDefaultTab({
+      id: "folder-tab",
+      label: "project",
+      directoryHandle: nativeDirectoryHandle,
+      directoryName: "project",
+      fileName: "readme.md",
+      rawContent: "# Stale content",
+      activeFilePath: "docs/readme.md",
+      restoreError: "Previous error",
+      writeAllowed: false,
+    });
+    const tree: FileTreeNode[] = [
+      {
+        kind: "directory",
+        name: "docs",
+        path: "docs",
+        children: [
+          {
+            kind: "file",
+            name: "readme.md",
+            path: "docs/readme.md",
+            handle: nativeFileHandle,
+          },
+        ],
+      },
+    ];
+
+    useAppStore.setState({
+      tabs: [directoryTab],
+      activeTabId: directoryTab.id,
+    });
+
+    vi.mocked(buildFileTree).mockResolvedValue(tree);
+    vi.mocked(readFile).mockResolvedValue("# Native folder content");
+
+    await useAppStore.getState().restoreTabs();
+
+    const tab = useAppStore.getState().tabs.find((t) => t.id === "folder-tab");
+    expect(getHandle).not.toHaveBeenCalledWith("tab:folder-tab:directory");
+    expect(buildFileTree).toHaveBeenCalledWith(nativeDirectoryHandle);
+    expect(readFile).toHaveBeenCalledWith(nativeFileHandle);
+    expect(tab?.directoryHandle).toBe(nativeDirectoryHandle);
+    expect(tab?.fileTree).toEqual(tree);
+    expect(tab?.fileHandle).toBe(nativeFileHandle);
+    expect(tab?.rawContent).toBe("# Native folder content");
+    expect(tab?.restoreError).toBeNull();
+    expect(tab?.writeAllowed).toBe(true);
+  });
+
+  it("persists native path targets while omitting browser handles", () => {
+    localStorage.removeItem("markreview-store");
+    const nativeFileHandle: NativeFileTarget = {
+      kind: "native_file",
+      path: "/tmp/project/notes.md",
+      name: "notes.md",
+    };
+    const nativeDirectoryHandle: NativeDirectoryTarget = {
+      kind: "native_directory",
+      path: "/tmp/project",
+      name: "project",
+    };
+    const nativeTab = createDefaultTab({
+      id: "native-tab",
+      label: "project",
+      fileHandle: nativeFileHandle,
+      fileName: "notes.md",
+      directoryHandle: nativeDirectoryHandle,
+      directoryName: "project",
+    });
+    const browserTab = createDefaultTab({
+      id: "browser-tab",
+      label: "browser.md",
+      fileHandle: {
+        kind: "file",
+        name: "browser.md",
+      },
+      fileName: "browser.md",
+    });
+
+    useAppStore.setState({
+      tabs: [nativeTab, browserTab],
+      activeTabId: nativeTab.id,
+    });
+
+    const persistedState = getPersistedStoreState();
+    const persistedTabs = persistedState["tabs"];
+    if (!isUnknownArray(persistedTabs)) {
+      throw new Error("Expected persisted tabs array");
+    }
+
+    const persistedNativeTab = findRecordById(persistedTabs, "native-tab");
+    const persistedBrowserTab = findRecordById(persistedTabs, "browser-tab");
+
+    expect(persistedNativeTab["fileHandle"]).toEqual(nativeFileHandle);
+    expect(persistedNativeTab["directoryHandle"]).toEqual(
+      nativeDirectoryHandle,
+    );
+    expect(persistedBrowserTab["fileHandle"]).toBeNull();
+    expect(persistedBrowserTab["directoryHandle"]).toBeNull();
+  });
+
   it("sets restoreError on file tab when handle is missing from IndexedDB", async () => {
     const fileTab = createDefaultTab({
       id: "file-tab",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -54,8 +54,11 @@ import {
 } from "../modules/workspace";
 import type { WorkspaceActions, WorkspaceState } from "../modules/workspace";
 import { toPersistedTree } from "../types/fileTree";
+import { isNativeDirectoryTarget, isNativeFileTarget } from "../types/fileTree";
 import type {
   HydratedSidebarTreeNode,
+  NativeDirectoryTarget,
+  NativeFileTarget,
   SidebarTreeNode,
 } from "../types/fileTree";
 import type { CommentType } from "../types/criticmarkup";
@@ -118,6 +121,20 @@ interface OldPersistedState {
   activeFilePath?: string | null;
   directoryName?: string | null;
   peerName?: string | null;
+}
+
+function getPersistedNativeFileTarget(tab: TabState): NativeFileTarget | null {
+  return tab.fileHandle && isNativeFileTarget(tab.fileHandle)
+    ? tab.fileHandle
+    : null;
+}
+
+function getPersistedNativeDirectoryTarget(
+  tab: TabState,
+): NativeDirectoryTarget | null {
+  return tab.directoryHandle && isNativeDirectoryTarget(tab.directoryHandle)
+    ? tab.directoryHandle
+    : null;
 }
 
 function isOldFormat(p: unknown): p is OldPersistedState {
@@ -318,8 +335,10 @@ export const useAppStore = create<AppState>()(
         tabs: s.tabs.map((t) => ({
           id: t.id,
           label: t.label,
+          fileHandle: getPersistedNativeFileTarget(t),
           fileName: t.fileName,
           rawContent: t.rawContent,
+          directoryHandle: getPersistedNativeDirectoryTarget(t),
           directoryName: t.directoryName,
           activeFilePath: t.activeFilePath,
           fileTree: toPersistedTree(t.fileTree),


### PR DESCRIPTION
## Summary
- Persist serializable native file and folder targets with tab state while continuing to omit browser handles from localStorage.
- Restore native file tabs by reading their saved path target, and restore native folder tabs by rebuilding the tree from the saved folder path.
- Update desktop docs now that native file/folder tab persistence is implemented.

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/workspace/test/tabRestore.test.ts src/modules/workspace/test/nativeTargets.test.ts src/runtime/desktopWorkspaceRuntime.test.ts src/runtime/webWorkspaceRuntime.test.ts
- npx eslint src/modules/workspace/controller.ts src/modules/workspace/test/tabRestore.test.ts src/store/index.ts (0 errors; existing workspace/store warnings remain)
- npx prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/modules/workspace/controller.ts src/modules/workspace/test/tabRestore.test.ts src/store/index.ts && git diff --check
- npx vite build
- npx vite build --mode desktop