### PR TITLE
Snapshot agent run prompts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,7 @@ Owns serializable host-mode agent review run metadata:
 - run records
 - active run per tab mapping
 - run lifecycle status
+- generated prompt snapshots for inspection/copying
 - active-file question-thread run request orchestration
 
 Mutable runner, process, socket, and terminal objects stay in runtime services,

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -304,6 +304,8 @@ comments and threaded questions. Each action builds an `AgentRunRequest` with
 one tab, one target path, selected comment ids, and a generated prompt. The web
 runtime still reports `canRunAgent: false`, so the website keeps copy-prompt
 paths until a desktop runtime provides an executable `AgentRuntime`.
+The generated prompt is also stored on the serializable run record so the active
+run panel can copy the exact prompt that was sent to the runtime.
 
 Second implementation note: the next foundation slice adds serializable
 `agent-workflow` run metadata plus web runtime agent and terminal capabilities

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -232,6 +232,8 @@ outside this first desktop planning scope.
 - Agent run state is tab-scoped and serializable. The comment panel can stop an
   active run and polls native run status so completed or failed processes are
   reflected in the UI.
+- Agent run state keeps the generated prompt snapshot, and the active run panel
+  can copy that exact prompt for inspection or manual recovery.
 - Native runner stdout and stderr are captured into a bounded output tail shown
   on the active run panel for same-window observability.
 - Closing a tab with a queued, running, or attention-needed run is blocked until

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -281,6 +281,7 @@ export function createAgentWorkflowControllerActions<
       taskKind: request.taskKind,
       targetPaths: request.targetPaths,
       selectedCommentIds: request.selectedCommentIds,
+      prompt: request.prompt,
       runnerKind: request.runnerKind,
     });
 

--- a/src/modules/agent-workflow/state.ts
+++ b/src/modules/agent-workflow/state.ts
@@ -35,6 +35,7 @@ function createRun(input: {
   taskKind: AgentRun["taskKind"];
   targetPaths: string[];
   selectedCommentIds: string[];
+  prompt: string;
   runnerKind: AgentRun["runnerKind"];
   createdAt: string;
 }): AgentRun {
@@ -45,6 +46,7 @@ function createRun(input: {
     taskKind: input.taskKind,
     targetPaths: input.targetPaths,
     selectedCommentIds: input.selectedCommentIds,
+    prompt: input.prompt,
     createdAt: input.createdAt,
     completedAt: null,
     runnerKind: input.runnerKind,
@@ -65,6 +67,7 @@ export function createAgentWorkflowActions<
         taskKind: input.taskKind,
         targetPaths: [...input.targetPaths],
         selectedCommentIds: [...(input.selectedCommentIds ?? [])],
+        prompt: input.prompt ?? "",
         runnerKind: input.runnerKind ?? null,
         createdAt: new Date().toISOString(),
       });

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -218,6 +218,7 @@ describe("address comments agent run controller", () => {
       taskKind: "address_comments",
       targetPaths: ["docs/spec.md"],
       selectedCommentIds: ["fix-root"],
+      prompt: requests[0]?.prompt,
       runnerKind: "terminal",
       terminalAttachmentId: "terminal-session-1",
     });
@@ -461,6 +462,7 @@ describe("question thread agent run controller", () => {
       taskKind: "answer_questions",
       targetPaths: ["docs/spec.md"],
       selectedCommentIds: ["mr-question-1"],
+      prompt: requests[0]?.prompt,
       runnerKind: "terminal",
       terminalAttachmentId: "terminal-session-1",
     });

--- a/src/modules/agent-workflow/test/agentWorkflowState.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowState.test.ts
@@ -30,6 +30,7 @@ describe("agent workflow state", () => {
       taskKind: "address_comments",
       targetPaths: ["docs/spec.md"],
       selectedCommentIds: ["comment-1"],
+      prompt: "",
       createdAt: "2026-06-12T18:00:00.000Z",
       completedAt: null,
       runnerKind: "terminal",

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -20,6 +20,7 @@ export interface AgentRun {
   taskKind: AgentRunTaskKind;
   targetPaths: string[];
   selectedCommentIds: string[];
+  prompt: string;
   createdAt: string;
   completedAt: string | null;
   runnerKind: AgentRunnerKind | null;
@@ -33,6 +34,7 @@ export interface CreateAgentRunInput {
   taskKind: AgentRunTaskKind;
   targetPaths: string[];
   selectedCommentIds?: string[];
+  prompt?: string;
   runnerKind?: AgentRunnerKind | null;
 }
 

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -175,8 +175,14 @@
   white-space: pre-wrap;
 }
 
-.comment-panel__agent-run-action {
+.comment-panel__agent-run-actions {
   flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.comment-panel__agent-run-action {
   border: 1px solid var(--border);
   border-radius: 4px;
   background: var(--surface);

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -304,6 +304,9 @@ describe("CommentPanel — agent prompt", () => {
 
   it("shows and stops an active agent run for the current tab", async () => {
     const user = userEvent.setup();
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
 
     setTestState({
       comments: [
@@ -322,6 +325,7 @@ describe("CommentPanel — agent prompt", () => {
       tabId: "test-tab",
       taskKind: "answer_questions",
       targetPaths: ["spec.md"],
+      prompt: "Review spec.md and answer questions",
       runnerKind: "terminal",
     });
     useAppStore.getState().updateAgentRunStatus({
@@ -338,6 +342,12 @@ describe("CommentPanel — agent prompt", () => {
     expect(
       screen.queryByRole("button", { name: "Copy agent prompt" }),
     ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Copy prompt" }));
+    expect(writeText).toHaveBeenCalledWith(
+      "Review spec.md and answer questions",
+    );
+    expect(useAppStore.getState().toast).toBe("Agent run prompt copied");
 
     await user.click(screen.getByRole("button", { name: "Stop" }));
 

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -443,6 +443,20 @@ export function CommentPanel({ peerMode = false }: Props) {
     }
   }
 
+  async function handleCopyActiveRunPrompt() {
+    if (!activeAgentRun?.prompt) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(activeAgentRun.prompt);
+      showToast("Agent run prompt copied");
+    } catch (error) {
+      console.error("[CommentPanel] failed to copy run prompt:", error);
+      showToast("Couldn't copy agent prompt");
+    }
+  }
+
   useEffect(() => {
     if (
       peerMode ||
@@ -593,23 +607,35 @@ export function CommentPanel({ peerMode = false }: Props) {
               </pre>
             )}
           </div>
-          {canStopAgentRun ? (
-            <button
-              className="comment-panel__agent-run-action"
-              onClick={() => {
-                void handleStopAgentRun();
-              }}
-            >
-              Stop
-            </button>
-          ) : (
-            <button
-              className="comment-panel__agent-run-action"
-              onClick={() => clearAgentRun(activeAgentRun.id)}
-            >
-              Dismiss
-            </button>
-          )}
+          <div className="comment-panel__agent-run-actions">
+            {activeAgentRun.prompt && (
+              <button
+                className="comment-panel__agent-run-action"
+                onClick={() => {
+                  void handleCopyActiveRunPrompt();
+                }}
+              >
+                Copy prompt
+              </button>
+            )}
+            {canStopAgentRun ? (
+              <button
+                className="comment-panel__agent-run-action"
+                onClick={() => {
+                  void handleStopAgentRun();
+                }}
+              >
+                Stop
+              </button>
+            ) : (
+              <button
+                className="comment-panel__agent-run-action"
+                onClick={() => clearAgentRun(activeAgentRun.id)}
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Store the generated prompt snapshot on each agent run record.
- Pass the exact runtime request prompt into run metadata for address-comments and question-thread runs.
- Add a same-window "Copy prompt" action on the active run strip for inspection/manual recovery.

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/agent-workflow/test/agentWorkflowState.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx
- npx eslint src/modules/agent-workflow/types.ts src/modules/agent-workflow/state.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.test.tsx (0 errors; 2 existing CommentPanel async-handler warnings remain)
- npx prettier --check ARCHITECTURE.md docs/design/desktop-runtime-agent-architecture.md docs/features/desktop-agent-client.md src/modules/agent-workflow/types.ts src/modules/agent-workflow/state.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.css src/ui/components/CommentPanel/CommentPanel.test.tsx && git diff --check
- npx vite build
- npx vite build --mode desktop