### PR TITLE
Show agent run scope summary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,6 +127,7 @@ Owns serializable host-mode agent review run metadata:
 - active run per tab mapping
 - run lifecycle status
 - generated prompt snapshots for inspection/copying
+- target and comment scope metadata shown in the active run panel
 - active-file question-thread run request orchestration
 
 Mutable runner, process, socket, and terminal objects stay in runtime services,

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -234,6 +234,8 @@ outside this first desktop planning scope.
   reflected in the UI.
 - Agent run state keeps the generated prompt snapshot, and the active run panel
   can copy that exact prompt for inspection or manual recovery.
+- The active run panel shows the run task, target path summary, and selected
+  comment count.
 - Native runner stdout and stderr are captured into a bounded output tail shown
   on the active run panel for same-window observability.
 - Closing a tab with a queued, running, or attention-needed run is blocked until

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -153,6 +153,13 @@
   color: var(--text);
 }
 
+.comment-panel__agent-run-scope {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+
 .comment-panel__agent-run-error {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -325,6 +325,7 @@ describe("CommentPanel — agent prompt", () => {
       tabId: "test-tab",
       taskKind: "answer_questions",
       targetPaths: ["spec.md"],
+      selectedCommentIds: ["mr-question-1"],
       prompt: "Review spec.md and answer questions",
       runnerKind: "terminal",
     });
@@ -338,6 +339,9 @@ describe("CommentPanel — agent prompt", () => {
     render(<CommentPanel />);
 
     expect(screen.getByText("Agent Running")).toBeInTheDocument();
+    expect(
+      screen.getByText("Answer questions · spec.md · 1 comment"),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Working on questions/)).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Copy agent prompt" }),

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -56,6 +56,11 @@ const AGENT_RUN_STATUS_LABEL: Record<AgentRunStatus, string> = {
   failed: "Failed",
   stopped: "Stopped",
 };
+const AGENT_RUN_TASK_LABEL = {
+  address_comments: "Address comments",
+  answer_questions: "Answer questions",
+  review_peer_comments: "Review peer comments",
+};
 const EMPTY_COMMENTS: Comment[] = [];
 const EMPTY_FILE_TREE: TabState["fileTree"] = [];
 const EMPTY_ALL_FILE_COMMENTS: TabState["allFileComments"] = {};
@@ -89,6 +94,26 @@ function peerCommentToDisplay(comment: PeerComment): DisplayComment {
     text: comment.text,
     blockIndex: comment.blockRef.blockIndex,
   };
+}
+
+function formatAgentRunTargets(targetPaths: string[]): string {
+  if (targetPaths.length === 0) {
+    return "No target";
+  }
+  if (targetPaths.length === 1) {
+    return targetPaths[0];
+  }
+  return `${targetPaths[0]} +${targetPaths.length - 1} more`;
+}
+
+function formatAgentRunCommentCount(commentCount: number): string {
+  if (commentCount === 0) {
+    return "no comments";
+  }
+  if (commentCount === 1) {
+    return "1 comment";
+  }
+  return `${commentCount} comments`;
 }
 
 interface CrossFileEntry<C extends { type: CommentType }> {
@@ -405,6 +430,13 @@ export function CommentPanel({ peerMode = false }: Props) {
     activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
   );
   const showAgentRunStatus = !peerMode && activeAgentRun;
+  const activeAgentRunScope = activeAgentRun
+    ? `${AGENT_RUN_TASK_LABEL[activeAgentRun.taskKind]} · ${formatAgentRunTargets(
+        activeAgentRun.targetPaths,
+      )} · ${formatAgentRunCommentCount(
+        activeAgentRun.selectedCommentIds.length,
+      )}`
+    : null;
   const showAgentCapabilityWarning = Boolean(
     !peerMode &&
     canRunAgent &&
@@ -596,6 +628,11 @@ export function CommentPanel({ peerMode = false }: Props) {
             <span className="comment-panel__agent-run-label">
               Agent {AGENT_RUN_STATUS_LABEL[activeAgentRun.status]}
             </span>
+            {activeAgentRunScope && (
+              <span className="comment-panel__agent-run-scope">
+                {activeAgentRunScope}
+              </span>
+            )}
             {activeAgentRun.errorMessage && (
               <span className="comment-panel__agent-run-error">
                 {activeAgentRun.errorMessage}


### PR DESCRIPTION
## Summary
- Show each active agent run's task, target path summary, and selected comment count in the comment panel run strip.
- Keep the summary compact for single or multi-target runs.
- Document the same-window run scope metadata.

## Verification
- npx tsc --noEmit
- npx vitest run src/ui/components/CommentPanel/CommentPanel.test.tsx
- npx eslint src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.test.tsx (0 errors; 2 existing CommentPanel async-handler warnings remain)
- npx prettier --check ARCHITECTURE.md docs/features/desktop-agent-client.md src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.css src/ui/components/CommentPanel/CommentPanel.test.tsx && git diff --check
- npx vite build
- npx vite build --mode desktop