### PR TITLE
Add folder-level agent comment runs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,8 @@ Workspace tab removal refuses to close tabs with queued, running, or
 attention-needed agent runs, then cleans finished run metadata when the owning
 tab is closed.
 The comment panel can start desktop runtime runs for active-file unresolved
-comments and threaded questions, while web builds keep copy-prompt fallbacks.
+comments, bounded folder-level unresolved comments, and active-file threaded
+questions, while web builds keep copy-prompt fallbacks.
 Agent start actions refuse to create a second active run for the same tab and
 cap v1 to three active runs app-wide.
 Desktop UI reads the runtime agent capability asynchronously, so an unconfigured

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed planning document. No implementation is included in this change.
+Implementation in progress. The shared runtime boundary, Tauri shell, native
+file/folder targets, configurable desktop agent runner, tab-scoped run state, and
+bounded comment-driven folder runs have landed incrementally.
 
 ## Summary
 
@@ -203,7 +205,8 @@ Each run receives an explicit context package at creation time. The default
 context should be narrow:
 
 - one tab
-- one active file
+- one active file, or a bounded set of files from the active folder tab for the
+  folder address-comments action
 - selected or unresolved comments
 - explicit target path
 - explicit instruction not to edit unrelated files
@@ -251,8 +254,10 @@ Suggested implementation phases:
    processes.
 4. Add desktop runtime shell and native filesystem adapter.
 5. Add a first desktop runner behind `AgentRuntime`.
-6. Add optional terminal attachment for supported runners.
-7. Add broader folder/workspace agent actions after active-file runs are proven.
+6. Add bounded folder-level comment actions on top of the same run model.
+7. Add optional terminal attachment for supported runners.
+8. Add broader workspace agent actions after comment-driven folder runs are
+   proven.
 
 Each phase should keep the website runnable.
 
@@ -300,10 +305,13 @@ run first. Finished run metadata is removed when the owning tab is closed.
 
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and controller actions for active-file unresolved
-comments and threaded questions. Each action builds an `AgentRunRequest` with
-one tab, one target path, selected comment ids, and a generated prompt. The web
-runtime still reports `canRunAgent: false`, so the website keeps copy-prompt
-paths until a desktop runtime provides an executable `AgentRuntime`.
+comments, folder-level unresolved comments, and active-file threaded questions.
+Active-file actions build an `AgentRunRequest` with one tab, one target path,
+selected comment ids, and a generated prompt. Folder address-comments actions
+use the same tab-scoped run model with a sorted, bounded set of up to five files
+and twenty-five actionable comments from the active folder tab. The web runtime
+still reports `canRunAgent: false`, so the website keeps copy-prompt paths until
+a desktop runtime provides an executable `AgentRuntime`.
 The generated prompt is also stored on the serializable run record so the active
 run panel can copy the exact prompt that was sent to the runtime.
 

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed planning document. No implementation is included in this change.
+Implementation in progress. The website remains available, and the desktop
+foundation now covers native file/folder targets plus UI-started agent runs for
+comment review tasks.
 
 ## Problem
 
@@ -193,8 +195,10 @@ Folder action:
 
 - active tab only
 - selected folder or workspace only
-- bounded list of files containing relevant comments
-- explicit confirmation before start
+- bounded list of files containing actionable comments
+- maximum five files and twenty-five comments per run in the first
+  implementation
+- no context from other open tabs
 
 The generated prompt should state the target path, task, included comments, and
 out-of-scope files.
@@ -204,11 +208,14 @@ out-of-scope files.
 Initial actions should be narrow:
 
 - Address unresolved comments in the active file.
+- Address unresolved comments across a bounded set of scanned files in the
+  active folder tab.
 - Answer threaded `question:` comments in the active file.
 - Review pending peer comments after they have been merged or selected by the
   host.
 
-Broader folder/workspace actions can follow after the run model is proven.
+Broader workspace actions that are not directly tied to existing comments can
+follow after the run model is proven.
 
 ## Website Behavior
 
@@ -243,6 +250,9 @@ outside this first desktop planning scope.
 - Active-file unresolved comments now have a comment-panel action: desktop
   starts an address-comments run, while the website copies the same scoped
   review prompt.
+- Folder tabs with scanned actionable comments use the same address-comments
+  action. Desktop starts a run with a sorted, bounded set of file/comment targets
+  from the active tab; website builds copy the same folder-scoped prompt.
 - Agent starts are guarded to one active run per tab and three active runs
   app-wide.
 - Desktop reads agent availability before showing run actions, so missing

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -9,6 +9,15 @@ interface AddressCommentsPromptInput {
   comments: AddressCommentsPromptComment[];
 }
 
+interface FolderAddressCommentsPromptTarget {
+  filePath: string;
+  comments: AddressCommentsPromptComment[];
+}
+
+interface FolderAddressCommentsPromptInput {
+  targets: FolderAddressCommentsPromptTarget[];
+}
+
 export function buildAgentReplyPrompt(): string {
   return `Review this markdown file and answer MarkReview threaded questions inline.
 
@@ -43,6 +52,32 @@ Scope:
 - Address only these unresolved comment ids:
 ${commentList}
 - Apply the requested edits directly in the markdown.
+- Remove each addressed MarkReview comment once its requested change is applied.
+- Do not answer threaded question comments in this run.
+- Do not edit unrelated files or unrelated comments.`;
+}
+
+export function buildFolderAddressCommentsAgentPrompt(
+  input: FolderAddressCommentsPromptInput,
+): string {
+  const targetList = input.targets
+    .map((target) => {
+      const commentList = target.comments
+        .map(
+          (comment) => `  - ${comment.id} (${comment.type}): ${comment.text}`,
+        )
+        .join("\n");
+      return `- ${target.filePath}\n${commentList}`;
+    })
+    .join("\n");
+
+  return `Review this markdown folder and address the listed MarkReview comments.
+
+Scope:
+- Work only in the listed markdown files.
+- Address only these unresolved comment ids:
+${targetList}
+- Apply the requested edits directly in the markdown files.
 - Remove each addressed MarkReview comment once its requested change is applied.
 - Do not answer threaded question comments in this run.
 - Do not edit unrelated files or unrelated comments.`;

--- a/src/modules/agent-workflow/README.md
+++ b/src/modules/agent-workflow/README.md
@@ -12,6 +12,7 @@ narrow agent run request.
 - active run per tab mapping
 - run lifecycle status metadata
 - active-file address-comments and question-thread run request construction
+- bounded folder-level address-comments run request construction
 
 ## Does not own
 
@@ -20,7 +21,7 @@ narrow agent run request.
 - sockets
 - agent CLI configuration
 - peer-mode review state
-- broad folder/workspace agent prompting
+- broad workspace agent prompting that is not tied to existing comments
 
 ## Invariants
 
@@ -31,7 +32,9 @@ narrow agent run request.
   time in v1.
 - Web runtime support can expose the same metadata while reporting that local
   execution is unavailable.
-- Executable actions are scoped to the active tab's active file.
+- Executable actions are scoped to the active tab.
+- Folder-level executable actions use a bounded set of scanned comments from the
+  active folder tab.
 
 ## Public API
 
@@ -40,5 +43,8 @@ narrow agent run request.
   actions backed by the active `AgentRuntime`.
 - `buildAddressCommentsAgentRunRequest` builds the narrow request passed to the
   runtime for addressing active-file unresolved comments.
+- `buildFolderAddressCommentsAgentRunRequest` builds the bounded request passed
+  to the runtime for addressing unresolved comments across the active folder
+  tab.
 - `buildQuestionThreadAgentRunRequest` builds the narrow request passed to the
   runtime for answering active-file question threads.

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -3,6 +3,7 @@ import {
   buildAddressCommentsAgentPrompt,
   buildAgentReplyPrompt,
   buildCommentThreadGroups,
+  buildFolderAddressCommentsAgentPrompt,
 } from "../../markup";
 import { agentRuntime } from "../../runtime";
 import type {
@@ -15,6 +16,7 @@ import {
   isNativeDirectoryTarget,
   isNativeFileTarget,
 } from "../../types/fileTree";
+import type { FileCommentEntry } from "../../types/tab";
 import type { TabState } from "../../types/tab";
 import type {
   AgentRunStartUnavailableReason,
@@ -63,12 +65,25 @@ interface AddressCommentsRunContext {
   workspaceRootPath: string | null;
 }
 
+interface FolderAddressableCommentTarget {
+  filePath: string;
+  comments: AddressableCommentTarget[];
+}
+
+interface FolderAddressCommentsRunContext {
+  tabId: string;
+  targets: FolderAddressableCommentTarget[];
+  workspaceRootPath: string | null;
+}
+
 const SYNCABLE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
   "queued",
   "running",
   "needs_attention",
 ]);
 const MAX_ACTIVE_AGENT_RUNS = 3;
+const MAX_FOLDER_AGENT_TARGET_FILES = 5;
+const MAX_FOLDER_AGENT_COMMENTS = 25;
 const ADDRESSABLE_COMMENT_TYPES = new Set<Comment["type"]>([
   "fix",
   "rewrite",
@@ -105,6 +120,44 @@ export function getAddressableCommentTargets(
       type: comment.type,
       text: commentPromptText(comment),
     }));
+}
+
+export function getFolderAddressableCommentTargets(
+  entries: FileCommentEntry[],
+): FolderAddressableCommentTarget[] {
+  const targets: FolderAddressableCommentTarget[] = [];
+  let selectedCommentCount = 0;
+
+  const sortedEntries = [...entries].sort((entryA, entryB) =>
+    entryA.filePath.localeCompare(entryB.filePath),
+  );
+
+  for (const entry of sortedEntries) {
+    if (targets.length >= MAX_FOLDER_AGENT_TARGET_FILES) {
+      break;
+    }
+    if (selectedCommentCount >= MAX_FOLDER_AGENT_COMMENTS) {
+      break;
+    }
+
+    const remainingCommentCount =
+      MAX_FOLDER_AGENT_COMMENTS - selectedCommentCount;
+    const comments = getAddressableCommentTargets(entry.comments).slice(
+      0,
+      remainingCommentCount,
+    );
+    if (comments.length === 0) {
+      continue;
+    }
+
+    targets.push({
+      filePath: entry.filePath,
+      comments,
+    });
+    selectedCommentCount += comments.length;
+  }
+
+  return targets;
 }
 
 function getAgentTargetPath(tab: TabState): string | null {
@@ -173,6 +226,28 @@ export function buildAddressCommentsAgentRunRequest(
       comments: context.comments,
     }),
   };
+}
+
+export function buildFolderAddressCommentsAgentRunRequest(
+  context: FolderAddressCommentsRunContext,
+): AgentRunRequest {
+  return {
+    tabId: context.tabId,
+    taskKind: "address_comments",
+    targetPaths: context.targets.map((target) => target.filePath),
+    selectedCommentIds: context.targets.flatMap((target) =>
+      target.comments.map((comment) => `${target.filePath}#${comment.id}`),
+    ),
+    runnerKind: "terminal",
+    workspaceRootPath: context.workspaceRootPath,
+    prompt: buildFolderAddressCommentsAgentPrompt({
+      targets: context.targets,
+    }),
+  };
+}
+
+function isFolderAgentRunTab(tab: TabState): boolean {
+  return tab.fileTree.length > 0;
 }
 
 function unavailableResult(input: {
@@ -341,25 +416,48 @@ export function createAgentWorkflowControllerActions<
         });
       }
 
-      const activeTab = getRunnableActiveTab();
-      if (!activeTab) {
-        const tab = deps.getActiveTab(deps.get);
+      const tab = deps.getActiveTab(deps.get);
+      if (!tab) {
         return unavailableResult({
-          reason: tab ? "no_active_file" : "no_active_tab",
-          message: tab
-            ? "Select a markdown file before starting an agent run."
-            : "Open a file or folder before starting an agent run.",
+          reason: "no_active_tab",
+          message: "Open a file or folder before starting an agent run.",
         });
       }
 
-      const guardResult = getRunStartGuardResult(deps.get(), activeTab.tab.id);
+      const guardResult = getRunStartGuardResult(deps.get(), tab.id);
       if (guardResult) {
         return guardResult;
       }
 
-      const addressableComments = getAddressableCommentTargets(
-        activeTab.tab.comments,
-      );
+      if (isFolderAgentRunTab(tab)) {
+        const folderTargets = getFolderAddressableCommentTargets(
+          Object.values(tab.allFileComments),
+        );
+        if (folderTargets.length === 0) {
+          return unavailableResult({
+            reason: "no_addressable_comments",
+            message: "No unresolved actionable comments are available.",
+          });
+        }
+
+        return startRuntimeAgentRun(
+          buildFolderAddressCommentsAgentRunRequest({
+            tabId: tab.id,
+            targets: folderTargets,
+            workspaceRootPath: getAgentWorkspaceRootPath(tab),
+          }),
+        );
+      }
+
+      const targetPath = getAgentTargetPath(tab);
+      if (!targetPath) {
+        return unavailableResult({
+          reason: "no_active_file",
+          message: "Select a markdown file before starting an agent run.",
+        });
+      }
+
+      const addressableComments = getAddressableCommentTargets(tab.comments);
       if (addressableComments.length === 0) {
         return unavailableResult({
           reason: "no_addressable_comments",
@@ -369,10 +467,10 @@ export function createAgentWorkflowControllerActions<
 
       return startRuntimeAgentRun(
         buildAddressCommentsAgentRunRequest({
-          tabId: activeTab.tab.id,
-          targetPath: activeTab.targetPath,
+          tabId: tab.id,
+          targetPath,
           comments: addressableComments,
-          workspaceRootPath: getAgentWorkspaceRootPath(activeTab.tab),
+          workspaceRootPath: getAgentWorkspaceRootPath(tab),
         }),
       );
     },

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -9,9 +9,11 @@ import {
 import type { AgentRuntime, AgentRunRequest } from "../../../runtime";
 import {
   buildAddressCommentsAgentRunRequest,
+  buildFolderAddressCommentsAgentRunRequest,
   buildQuestionThreadAgentRunRequest,
   createAgentWorkflowControllerActions,
   getAddressableCommentTargets,
+  getFolderAddressableCommentTargets,
   getQuestionThreadCommentIds,
 } from "../controller";
 
@@ -102,6 +104,93 @@ describe("address comments agent run context", () => {
     expect(request.prompt).toContain(
       "Do not answer threaded question comments",
     );
+  });
+
+  it("selects a bounded set of folder comment targets", () => {
+    const entries = Array.from({ length: 6 }, (_, index) => {
+      const fileIndex = index + 1;
+      return {
+        filePath: `docs/file-${fileIndex}.md`,
+        fileName: `file-${fileIndex}.md`,
+        comments: [
+          makeComment({
+            id: `fix-${fileIndex}`,
+            type: "fix",
+            text: `Fix file ${fileIndex}`,
+          }),
+          makeComment({
+            id: `question-${fileIndex}`,
+            type: "question",
+            text: `Question ${fileIndex}`,
+            thread: {
+              commentId: `mr-question-${fileIndex}`,
+              threadId: `mr-question-${fileIndex}`,
+            },
+          }),
+        ],
+      };
+    });
+
+    const targets = getFolderAddressableCommentTargets(entries);
+
+    expect(targets).toHaveLength(5);
+    expect(targets.map((target) => target.filePath)).toEqual([
+      "docs/file-1.md",
+      "docs/file-2.md",
+      "docs/file-3.md",
+      "docs/file-4.md",
+      "docs/file-5.md",
+    ]);
+    expect(targets[0]?.comments).toEqual([
+      {
+        id: "fix-1",
+        type: "fix",
+        text: "Fix file 1",
+      },
+    ]);
+  });
+
+  it("builds a bounded folder request for addressing comments", () => {
+    const request = buildFolderAddressCommentsAgentRunRequest({
+      tabId: "tab-1",
+      workspaceRootPath: "/tmp/project",
+      targets: [
+        {
+          filePath: "docs/a.md",
+          comments: [
+            {
+              id: "fix-a",
+              type: "fix",
+              text: "Fix A",
+            },
+          ],
+        },
+        {
+          filePath: "docs/b.md",
+          comments: [
+            {
+              id: "note-b",
+              type: "note",
+              text: "Check B",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(request).toMatchObject({
+      tabId: "tab-1",
+      taskKind: "address_comments",
+      targetPaths: ["docs/a.md", "docs/b.md"],
+      selectedCommentIds: ["docs/a.md#fix-a", "docs/b.md#note-b"],
+      runnerKind: "terminal",
+      workspaceRootPath: "/tmp/project",
+    });
+    expect(request.prompt).toContain("Work only in the listed markdown files");
+    expect(request.prompt).toContain("- docs/a.md");
+    expect(request.prompt).toContain("  - fix-a (fix): Fix A");
+    expect(request.prompt).toContain("- docs/b.md");
+    expect(request.prompt).toContain("  - note-b (note): Check B");
   });
 });
 
@@ -372,6 +461,69 @@ describe("address comments agent run controller", () => {
       message: "No unresolved actionable comments are available.",
     });
     expect(useAppStore.getState().agentRuns).toEqual({});
+  });
+
+  it("creates a folder run from scanned file comments", async () => {
+    const requests: AgentRunRequest[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
+      startRun: (request) => {
+        requests.push(request);
+        return Promise.resolve("terminal-session-1");
+      },
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
+    };
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: () => {},
+      runtime,
+    });
+
+    setTestState({
+      directoryHandle: {
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      },
+      fileTree: [
+        {
+          kind: "file",
+          name: "spec.md",
+          path: "docs/spec.md",
+        },
+      ],
+      allFileComments: {
+        "docs/spec.md": {
+          filePath: "docs/spec.md",
+          fileName: "spec.md",
+          comments: [
+            makeComment({
+              id: "fix-root",
+              type: "fix",
+              text: "Fix the intro",
+            }),
+          ],
+        },
+      },
+    });
+
+    const result = await actions.startAddressCommentsAgentRun();
+
+    expect(result.status).toBe("started");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      tabId: "test-tab",
+      taskKind: "address_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["docs/spec.md#fix-root"],
+      workspaceRootPath: "/tmp/project",
+    });
+    expect(requests[0]?.prompt).toContain("- docs/spec.md");
+    expect(requests[0]?.prompt).toContain("  - fix-root (fix): Fix the intro");
   });
 });
 

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -254,6 +254,66 @@ describe("CommentPanel — agent prompt", () => {
     expect(useAppStore.getState().toast).toBe("Agent review prompt copied");
   });
 
+  it("copies a folder address-comments prompt from scanned file comments", async () => {
+    const user = userEvent.setup();
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
+    setTestState({
+      fileTree: [
+        {
+          kind: "file",
+          name: "spec.md",
+          path: "docs/spec.md",
+        },
+      ],
+      allFileComments: {
+        "docs/spec.md": {
+          filePath: "docs/spec.md",
+          fileName: "spec.md",
+          comments: [
+            makeCommentBase({
+              id: "fix-root",
+              type: "fix",
+              text: "Fix the intro",
+            }),
+          ],
+        },
+        "docs/notes.md": {
+          filePath: "docs/notes.md",
+          fileName: "notes.md",
+          comments: [
+            makeCommentBase({
+              id: "note-root",
+              type: "note",
+              text: "Check this claim",
+            }),
+          ],
+        },
+      },
+    });
+
+    render(<CommentPanel />);
+    await user.click(
+      screen.getByRole("button", { name: "Copy review prompt" }),
+    );
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "Work only in the listed markdown files",
+    );
+    expect(writeText.mock.calls[0]?.[0]).toContain("- docs/notes.md");
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "  - note-root (note): Check this claim",
+    );
+    expect(writeText.mock.calls[0]?.[0]).toContain("- docs/spec.md");
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "  - fix-root (fix): Fix the intro",
+    );
+    expect(useAppStore.getState().toast).toBe("Agent review prompt copied");
+  });
+
   it("shows a copy prompt button when question threads exist", () => {
     setTestState({
       comments: [

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -4,10 +4,12 @@ import {
   buildAddressCommentsAgentPrompt,
   buildAgentReplyPrompt,
   buildCommentThreadGroups,
+  buildFolderAddressCommentsAgentPrompt,
 } from "../../../markup";
 import {
   getActiveAgentRunForTab,
   getAddressableCommentTargets,
+  getFolderAddressableCommentTargets,
 } from "../../../modules/agent-workflow";
 import type { AgentRunStatus } from "../../../modules/agent-workflow";
 import { canRunAgent, getAgentRuntimeCapability } from "../../../runtime";
@@ -317,7 +319,15 @@ export function CommentPanel({ peerMode = false }: Props) {
     }
     return getAddressableCommentTargets(comments);
   }, [comments, isFolderMode, peerMode]);
-  const hasAddressableComments = addressableCommentTargets.length > 0;
+  const folderAddressableCommentTargets = useMemo(() => {
+    if (peerMode || !isFolderMode) {
+      return [];
+    }
+    return getFolderAddressableCommentTargets(crossFileComments);
+  }, [crossFileComments, isFolderMode, peerMode]);
+  const hasAddressableComments = isFolderMode
+    ? folderAddressableCommentTargets.length > 0
+    : addressableCommentTargets.length > 0;
 
   const isResolved = !peerMode && commentFilter === "resolved";
 
@@ -404,13 +414,16 @@ export function CommentPanel({ peerMode = false }: Props) {
   async function handleCopyAddressCommentsPrompt() {
     const targetPath =
       activeFilePath ?? tab?.fileName ?? "the active markdown file";
-    try {
-      await navigator.clipboard.writeText(
-        buildAddressCommentsAgentPrompt({
+    const prompt = isFolderMode
+      ? buildFolderAddressCommentsAgentPrompt({
+          targets: folderAddressableCommentTargets,
+        })
+      : buildAddressCommentsAgentPrompt({
           targetPath,
           comments: addressableCommentTargets,
-        }),
-      );
+        });
+    try {
+      await navigator.clipboard.writeText(prompt);
       showToast("Agent review prompt copied");
     } catch (error) {
       console.error("[CommentPanel] failed to copy agent prompt:", error);


### PR DESCRIPTION
## Summary
- add folder-scoped address-comments prompt generation and run request construction
- route folder-mode comment panel address action through bounded scanned file/comment context
- update desktop agent docs and agent-workflow ownership notes

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx
- npx eslint on touched TypeScript files
- npx prettier --check on touched docs and code files, plus git diff --check
- npx vite build
- npx vite build --mode desktop

## Notes
- ESLint still reports the two existing CommentPanel async-handler warnings.
- Vite builds still report the existing large-chunk warning.