### PR TITLE
Add pending peer-comment agent runs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -170,6 +170,9 @@ tab is closed.
 The comment panel can start desktop runtime runs for active-file unresolved
 comments, bounded folder-level unresolved comments, and active-file threaded
 questions, while web builds keep copy-prompt fallbacks.
+The host shared-panel pending-comment review list follows the same pattern for
+selected peer comments: desktop starts a `review_peer_comments` run, and website
+builds copy the generated prompt.
 Agent start actions refuse to create a second active run for the same tab and
 cap v1 to three active runs app-wide.
 Desktop UI reads the runtime agent capability asynchronously, so an unconfigured

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -305,13 +305,14 @@ run first. Finished run metadata is removed when the owning tab is closed.
 
 Agent workflow implementation note: `src/modules/agent-workflow/` now owns
 serializable run metadata and controller actions for active-file unresolved
-comments, folder-level unresolved comments, and active-file threaded questions.
-Active-file actions build an `AgentRunRequest` with one tab, one target path,
-selected comment ids, and a generated prompt. Folder address-comments actions
-use the same tab-scoped run model with a sorted, bounded set of up to five files
-and twenty-five actionable comments from the active folder tab. The web runtime
-still reports `canRunAgent: false`, so the website keeps copy-prompt paths until
-a desktop runtime provides an executable `AgentRuntime`.
+comments, folder-level unresolved comments, active-file threaded questions, and
+pending peer comments selected from a host share. Active-file actions build an
+`AgentRunRequest` with one tab, one target path, selected comment ids, and a
+generated prompt. Folder address-comments and pending-peer-comment actions use
+the same tab-scoped run model with a sorted, bounded set of up to five files and
+twenty-five relevant comments from the active tab. The web runtime still reports
+`canRunAgent: false`, so the website keeps copy-prompt paths until a desktop
+runtime provides an executable `AgentRuntime`.
 The generated prompt is also stored on the serializable run record so the active
 run panel can copy the exact prompt that was sent to the runtime.
 

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -253,6 +253,10 @@ outside this first desktop planning scope.
 - Folder tabs with scanned actionable comments use the same address-comments
   action. Desktop starts a run with a sorted, bounded set of file/comment targets
   from the active tab; website builds copy the same folder-scoped prompt.
+- Pending peer comment review has an agent action in the host shared-panel
+  review list. Desktop starts a `review_peer_comments` run for the selected
+  share's pending comments; website builds copy the same prompt for manual
+  agent handoff.
 - Agent starts are guarded to one active run per tab and three active runs
   app-wide.
 - Desktop reads agent availability before showing run actions, so missing

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -18,6 +18,24 @@ interface FolderAddressCommentsPromptInput {
   targets: FolderAddressCommentsPromptTarget[];
 }
 
+interface PendingPeerCommentPromptComment {
+  id: string;
+  peerName: string;
+  commentType: string;
+  text: string;
+  blockIndex: number;
+  contentPreview: string;
+}
+
+interface PendingPeerCommentPromptTarget {
+  filePath: string;
+  comments: PendingPeerCommentPromptComment[];
+}
+
+interface PendingPeerCommentsPromptInput {
+  targets: PendingPeerCommentPromptTarget[];
+}
+
 export function buildAgentReplyPrompt(): string {
   return `Review this markdown file and answer MarkReview threaded questions inline.
 
@@ -81,4 +99,31 @@ ${targetList}
 - Remove each addressed MarkReview comment once its requested change is applied.
 - Do not answer threaded question comments in this run.
 - Do not edit unrelated files or unrelated comments.`;
+}
+
+export function buildPendingPeerCommentsAgentPrompt(
+  input: PendingPeerCommentsPromptInput,
+): string {
+  const targetList = input.targets
+    .map((target) => {
+      const commentList = target.comments
+        .map(
+          (comment) =>
+            `  - ${comment.id} (${comment.commentType}) from ${comment.peerName} at block ${comment.blockIndex + 1}: ${comment.text}\n    Preview: ${comment.contentPreview}`,
+        )
+        .join("\n");
+      return `- ${target.filePath}\n${commentList}`;
+    })
+    .join("\n");
+
+  return `Review these pending peer comments and apply the useful changes.
+
+Scope:
+- Work only in the listed markdown files.
+- Review only these pending peer comment ids:
+${targetList}
+- Apply accepted changes directly in the markdown.
+- Do not add new MarkReview comments unless a peer comment is a question that cannot be answered by editing the text.
+- Do not edit unrelated files or unrelated comments.
+- Do not dismiss or resolve pending comments in Dragon; the host will do that after reviewing your changes.`;
 }

--- a/src/modules/agent-workflow/README.md
+++ b/src/modules/agent-workflow/README.md
@@ -13,6 +13,7 @@ narrow agent run request.
 - run lifecycle status metadata
 - active-file address-comments and question-thread run request construction
 - bounded folder-level address-comments run request construction
+- pending peer-comment run request construction for a selected host share
 
 ## Does not own
 
@@ -35,6 +36,8 @@ narrow agent run request.
 - Executable actions are scoped to the active tab.
 - Folder-level executable actions use a bounded set of scanned comments from the
   active folder tab.
+- Pending peer-comment executable actions use a bounded set of comments from the
+  selected share on the active host tab.
 
 ## Public API
 
@@ -48,3 +51,5 @@ narrow agent run request.
   tab.
 - `buildQuestionThreadAgentRunRequest` builds the narrow request passed to the
   runtime for answering active-file question threads.
+- `buildPendingPeerCommentsAgentRunRequest` builds the bounded request passed to
+  the runtime for reviewing pending peer comments from a selected host share.

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -4,6 +4,7 @@ import {
   buildAgentReplyPrompt,
   buildCommentThreadGroups,
   buildFolderAddressCommentsAgentPrompt,
+  buildPendingPeerCommentsAgentPrompt,
 } from "../../markup";
 import { agentRuntime } from "../../runtime";
 import type {
@@ -18,6 +19,7 @@ import {
 } from "../../types/fileTree";
 import type { FileCommentEntry } from "../../types/tab";
 import type { TabState } from "../../types/tab";
+import type { PeerComment } from "../../types/share";
 import type {
   AgentRunStartUnavailableReason,
   AgentRunStartResult,
@@ -76,6 +78,26 @@ interface FolderAddressCommentsRunContext {
   workspaceRootPath: string | null;
 }
 
+interface PeerCommentTarget {
+  id: string;
+  peerName: string;
+  commentType: string;
+  text: string;
+  blockIndex: number;
+  contentPreview: string;
+}
+
+interface PendingPeerCommentTarget {
+  filePath: string;
+  comments: PeerCommentTarget[];
+}
+
+interface PendingPeerCommentsRunContext {
+  tabId: string;
+  targets: PendingPeerCommentTarget[];
+  workspaceRootPath: string | null;
+}
+
 const SYNCABLE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
   "queued",
   "running",
@@ -84,6 +106,8 @@ const SYNCABLE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
 const MAX_ACTIVE_AGENT_RUNS = 3;
 const MAX_FOLDER_AGENT_TARGET_FILES = 5;
 const MAX_FOLDER_AGENT_COMMENTS = 25;
+const MAX_PEER_AGENT_TARGET_FILES = 5;
+const MAX_PEER_AGENT_COMMENTS = 25;
 const ADDRESSABLE_COMMENT_TYPES = new Set<Comment["type"]>([
   "fix",
   "rewrite",
@@ -155,6 +179,66 @@ export function getFolderAddressableCommentTargets(
       comments,
     });
     selectedCommentCount += comments.length;
+  }
+
+  return targets;
+}
+
+export function getPendingPeerCommentTargets(
+  comments: PeerComment[],
+): PendingPeerCommentTarget[] {
+  const byPath: Record<string, PeerComment[]> = {};
+  for (const comment of comments) {
+    if (!byPath[comment.path]) {
+      byPath[comment.path] = [];
+    }
+    byPath[comment.path].push(comment);
+  }
+
+  const targets: PendingPeerCommentTarget[] = [];
+  let selectedCommentCount = 0;
+  const sortedPaths = Object.keys(byPath).sort((pathA, pathB) =>
+    pathA.localeCompare(pathB),
+  );
+
+  for (const filePath of sortedPaths) {
+    if (targets.length >= MAX_PEER_AGENT_TARGET_FILES) {
+      break;
+    }
+    if (selectedCommentCount >= MAX_PEER_AGENT_COMMENTS) {
+      break;
+    }
+
+    const remainingCommentCount =
+      MAX_PEER_AGENT_COMMENTS - selectedCommentCount;
+    const pathComments = byPath[filePath] ?? [];
+    const commentsForPath = pathComments
+      .slice()
+      .sort((commentA, commentB) => {
+        if (commentA.blockRef.blockIndex !== commentB.blockRef.blockIndex) {
+          return commentA.blockRef.blockIndex - commentB.blockRef.blockIndex;
+        }
+        return commentA.id.localeCompare(commentB.id);
+      })
+      .slice(0, remainingCommentCount)
+      .map((comment) => ({
+        id: comment.id,
+        peerName: comment.peerName,
+        commentType: comment.commentType,
+        text: comment.text,
+        blockIndex: comment.blockRef.blockIndex,
+        contentPreview: comment.blockRef.contentPreview,
+      }));
+
+    if (commentsForPath.length === 0) {
+      continue;
+    }
+
+    targets.push({
+      filePath,
+      comments: commentsForPath,
+    });
+    selectedCommentCount += commentsForPath.length;
   }
 
   return targets;
@@ -241,6 +325,24 @@ export function buildFolderAddressCommentsAgentRunRequest(
     runnerKind: "terminal",
     workspaceRootPath: context.workspaceRootPath,
     prompt: buildFolderAddressCommentsAgentPrompt({
+      targets: context.targets,
+    }),
+  };
+}
+
+export function buildPendingPeerCommentsAgentRunRequest(
+  context: PendingPeerCommentsRunContext,
+): AgentRunRequest {
+  return {
+    tabId: context.tabId,
+    taskKind: "review_peer_comments",
+    targetPaths: context.targets.map((target) => target.filePath),
+    selectedCommentIds: context.targets.flatMap((target) =>
+      target.comments.map((comment) => `${target.filePath}#${comment.id}`),
+    ),
+    runnerKind: "terminal",
+    workspaceRootPath: context.workspaceRootPath,
+    prompt: buildPendingPeerCommentsAgentPrompt({
       targets: context.targets,
     }),
   };
@@ -515,6 +617,45 @@ export function createAgentWorkflowControllerActions<
           targetPath: activeTab.targetPath,
           questionCommentIds,
           workspaceRootPath: getAgentWorkspaceRootPath(activeTab.tab),
+        }),
+      );
+    },
+
+    startPeerCommentsAgentRun: async (docId) => {
+      if (!runtime.canRunAgent) {
+        return unavailableResult({
+          reason: "agent_unavailable",
+          message: "Local agent execution is unavailable in this runtime.",
+        });
+      }
+
+      const tab = deps.getActiveTab(deps.get);
+      if (!tab) {
+        return unavailableResult({
+          reason: "no_active_tab",
+          message: "Open a file or folder before starting an agent run.",
+        });
+      }
+
+      const guardResult = getRunStartGuardResult(deps.get(), tab.id);
+      if (guardResult) {
+        return guardResult;
+      }
+
+      const pendingComments = tab.pendingComments[docId] ?? [];
+      const pendingTargets = getPendingPeerCommentTargets(pendingComments);
+      if (pendingTargets.length === 0) {
+        return unavailableResult({
+          reason: "no_peer_comments",
+          message: "No pending peer comments are available for this share.",
+        });
+      }
+
+      return startRuntimeAgentRun(
+        buildPendingPeerCommentsAgentRunRequest({
+          tabId: tab.id,
+          targets: pendingTargets,
+          workspaceRootPath: getAgentWorkspaceRootPath(tab),
         }),
       );
     },

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -3,6 +3,7 @@ import { useAppStore } from "../../../store";
 import { getActiveTab } from "../../../store/selectors";
 import {
   makeComment,
+  makePeerComment,
   resetTestStore,
   setTestState,
 } from "../../../testing/testHelpers";
@@ -10,10 +11,12 @@ import type { AgentRuntime, AgentRunRequest } from "../../../runtime";
 import {
   buildAddressCommentsAgentRunRequest,
   buildFolderAddressCommentsAgentRunRequest,
+  buildPendingPeerCommentsAgentRunRequest,
   buildQuestionThreadAgentRunRequest,
   createAgentWorkflowControllerActions,
   getAddressableCommentTargets,
   getFolderAddressableCommentTargets,
+  getPendingPeerCommentTargets,
   getQuestionThreadCommentIds,
 } from "../controller";
 
@@ -243,6 +246,82 @@ describe("question thread agent run context", () => {
     expect(request.prompt).toContain("- mr-question-1");
     expect(request.prompt).toContain("- mr-question-2");
     expect(request.prompt).toContain("Do not edit unrelated files");
+  });
+});
+
+describe("pending peer comments agent run context", () => {
+  it("groups and bounds pending peer comments by path", () => {
+    const comments = Array.from({ length: 6 }, (_unusedValue, index) => {
+      const fileIndex = index + 1;
+      return makePeerComment({
+        id: `peer-${fileIndex}`,
+        peerName: "Alice",
+        path: `docs/file-${fileIndex}.md`,
+        blockRef: {
+          blockIndex: fileIndex,
+          contentPreview: `Preview ${fileIndex}`,
+        },
+        commentType: "note",
+        text: `Check file ${fileIndex}`,
+      });
+    });
+
+    const targets = getPendingPeerCommentTargets(comments);
+
+    expect(targets).toHaveLength(5);
+    expect(targets.map((target) => target.filePath)).toEqual([
+      "docs/file-1.md",
+      "docs/file-2.md",
+      "docs/file-3.md",
+      "docs/file-4.md",
+      "docs/file-5.md",
+    ]);
+    expect(targets[0]?.comments).toEqual([
+      {
+        id: "peer-1",
+        peerName: "Alice",
+        commentType: "note",
+        text: "Check file 1",
+        blockIndex: 1,
+        contentPreview: "Preview 1",
+      },
+    ]);
+  });
+
+  it("builds a pending peer comments request", () => {
+    const request = buildPendingPeerCommentsAgentRunRequest({
+      tabId: "tab-1",
+      workspaceRootPath: "/tmp/project",
+      targets: [
+        {
+          filePath: "docs/spec.md",
+          comments: [
+            {
+              id: "peer-1",
+              peerName: "Alice",
+              commentType: "fix",
+              text: "Fix the intro",
+              blockIndex: 0,
+              contentPreview: "Intro paragraph",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(request).toMatchObject({
+      tabId: "tab-1",
+      taskKind: "review_peer_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["docs/spec.md#peer-1"],
+      runnerKind: "terminal",
+      workspaceRootPath: "/tmp/project",
+    });
+    expect(request.prompt).toContain("Review these pending peer comments");
+    expect(request.prompt).toContain("- docs/spec.md");
+    expect(request.prompt).toContain(
+      "  - peer-1 (fix) from Alice at block 1: Fix the intro",
+    );
   });
 });
 
@@ -524,6 +603,106 @@ describe("address comments agent run controller", () => {
     });
     expect(requests[0]?.prompt).toContain("- docs/spec.md");
     expect(requests[0]?.prompt).toContain("  - fix-root (fix): Fix the intro");
+  });
+});
+
+describe("pending peer comments agent run controller", () => {
+  it("creates a run and starts the injected runtime", async () => {
+    const requests: AgentRunRequest[] = [];
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
+      startRun: (request) => {
+        requests.push(request);
+        return Promise.resolve("terminal-session-1");
+      },
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
+    };
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: () => {},
+      runtime,
+    });
+
+    setTestState({
+      directoryHandle: {
+        kind: "native_directory",
+        path: "/tmp/project",
+        name: "project",
+      },
+      pendingComments: {
+        "doc-1": [
+          makePeerComment({
+            id: "peer-1",
+            peerName: "Alice",
+            path: "docs/spec.md",
+            blockRef: {
+              blockIndex: 0,
+              contentPreview: "Intro paragraph",
+            },
+            commentType: "fix",
+            text: "Fix the intro",
+          }),
+        ],
+      },
+    });
+
+    const result = await actions.startPeerCommentsAgentRun("doc-1");
+
+    expect(result.status).toBe("started");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      tabId: "test-tab",
+      taskKind: "review_peer_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["docs/spec.md#peer-1"],
+      workspaceRootPath: "/tmp/project",
+    });
+    const state = useAppStore.getState();
+    const runId = state.activeAgentRunIdByTabId["test-tab"];
+    const run = runId ? state.agentRuns[runId] : null;
+    expect(run).toMatchObject({
+      tabId: "test-tab",
+      status: "running",
+      taskKind: "review_peer_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["docs/spec.md#peer-1"],
+      prompt: requests[0]?.prompt,
+      runnerKind: "terminal",
+      terminalAttachmentId: "terminal-session-1",
+    });
+  });
+
+  it("returns unavailable when no pending peer comments exist", async () => {
+    const runtime: AgentRuntime = {
+      canRunAgent: true,
+      getCapability: () =>
+        Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
+      startRun: () => Promise.resolve("terminal-session-1"),
+      stopRun: () => Promise.resolve(),
+      getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
+    };
+    const actions = createAgentWorkflowControllerActions({
+      get: useAppStore.getState,
+      getActiveTab: (get) => getActiveTab(get()),
+      showToast: () => {},
+      runtime,
+    });
+
+    setTestState({
+      pendingComments: {},
+    });
+
+    const result = await actions.startPeerCommentsAgentRun("doc-1");
+
+    expect(result).toEqual({
+      status: "unavailable",
+      reason: "no_peer_comments",
+      message: "No pending peer comments are available for this share.",
+    });
   });
 });
 

--- a/src/modules/agent-workflow/types.ts
+++ b/src/modules/agent-workflow/types.ts
@@ -64,6 +64,7 @@ export type AgentRunStartUnavailableReason =
   | "no_active_tab"
   | "no_active_file"
   | "no_addressable_comments"
+  | "no_peer_comments"
   | "no_question_threads"
   | "tab_agent_run_active";
 
@@ -122,6 +123,7 @@ export type AgentRunSyncStatusResult =
 export interface AgentWorkflowControllerActions {
   startAddressCommentsAgentRun: () => Promise<AgentRunStartResult>;
   startQuestionThreadAgentRun: () => Promise<AgentRunStartResult>;
+  startPeerCommentsAgentRun: (docId: string) => Promise<AgentRunStartResult>;
   stopActiveAgentRun: () => Promise<AgentRunStopResult>;
   syncActiveAgentRunStatus: () => Promise<AgentRunSyncStatusResult>;
 }

--- a/src/ui/agentActions.test.ts
+++ b/src/ui/agentActions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getAddressCommentsAgentAction,
+  getPeerCommentsAgentAction,
   getQuestionThreadAgentAction,
 } from "./agentActions";
 
@@ -74,6 +75,43 @@ describe("getQuestionThreadAgentAction", () => {
       kind: "run_agent",
       label: "Ask agent",
       title: "Ask the local agent to answer threaded questions",
+    });
+  });
+});
+
+describe("getPeerCommentsAgentAction", () => {
+  it("uses copy-prompt mode when local agent execution is unavailable", () => {
+    expect(
+      getPeerCommentsAgentAction({
+        canRunAgent: false,
+        canStartPeerCommentsRun: true,
+      }),
+    ).toEqual({
+      kind: "copy_prompt",
+      label: "Copy agent prompt",
+      title: "Copy instructions for reviewing pending peer comments",
+    });
+  });
+
+  it("uses copy-prompt mode when peer comment runs are unavailable", () => {
+    expect(
+      getPeerCommentsAgentAction({
+        canRunAgent: true,
+        canStartPeerCommentsRun: false,
+      }).kind,
+    ).toBe("copy_prompt");
+  });
+
+  it("uses run-agent mode when both capabilities are available", () => {
+    expect(
+      getPeerCommentsAgentAction({
+        canRunAgent: true,
+        canStartPeerCommentsRun: true,
+      }),
+    ).toEqual({
+      kind: "run_agent",
+      label: "Ask agent",
+      title: "Ask the local agent to review pending peer comments",
     });
   });
 });

--- a/src/ui/agentActions.ts
+++ b/src/ui/agentActions.ts
@@ -1,5 +1,6 @@
 export type QuestionThreadAgentActionKind = "copy_prompt" | "run_agent";
 export type AddressCommentsAgentActionKind = "copy_prompt" | "run_agent";
+export type PeerCommentsAgentActionKind = "copy_prompt" | "run_agent";
 
 export interface QuestionThreadAgentAction {
   kind: QuestionThreadAgentActionKind;
@@ -13,6 +14,12 @@ export interface AddressCommentsAgentAction {
   title: string;
 }
 
+export interface PeerCommentsAgentAction {
+  kind: PeerCommentsAgentActionKind;
+  label: string;
+  title: string;
+}
+
 export interface AgentActionCapabilities {
   canRunAgent: boolean;
   canStartQuestionThreadRun: boolean;
@@ -21,6 +28,11 @@ export interface AgentActionCapabilities {
 export interface AddressCommentsAgentActionCapabilities {
   canRunAgent: boolean;
   canStartAddressCommentsRun: boolean;
+}
+
+export interface PeerCommentsAgentActionCapabilities {
+  canRunAgent: boolean;
+  canStartPeerCommentsRun: boolean;
 }
 
 export function getAddressCommentsAgentAction(
@@ -56,5 +68,23 @@ export function getQuestionThreadAgentAction(
     kind: "copy_prompt",
     label: "Copy agent prompt",
     title: "Copy instructions for answering threaded questions",
+  };
+}
+
+export function getPeerCommentsAgentAction(
+  capabilities: PeerCommentsAgentActionCapabilities,
+): PeerCommentsAgentAction {
+  if (capabilities.canRunAgent && capabilities.canStartPeerCommentsRun) {
+    return {
+      kind: "run_agent",
+      label: "Ask agent",
+      title: "Ask the local agent to review pending peer comments",
+    };
+  }
+
+  return {
+    kind: "copy_prompt",
+    label: "Copy agent prompt",
+    title: "Copy instructions for reviewing pending peer comments",
   };
 }

--- a/src/ui/components/PendingCommentReview/PendingCommentReview.test.tsx
+++ b/src/ui/components/PendingCommentReview/PendingCommentReview.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  makePeerComment,
+  resetTestStore,
+  setTestState,
+} from "../../../testing/testHelpers";
+import { useAppStore } from "../../../store";
+import { PendingCommentReview } from "./PendingCommentReview";
+
+beforeEach(() => {
+  resetTestStore();
+  setTestState({
+    pendingComments: {
+      "doc-1": [
+        makePeerComment({
+          id: "peer-1",
+          peerName: "Alice",
+          path: "docs/spec.md",
+          blockRef: {
+            blockIndex: 0,
+            contentPreview: "Intro paragraph",
+          },
+          commentType: "fix",
+          text: "Fix the intro",
+        }),
+      ],
+    },
+  });
+  vi.restoreAllMocks();
+});
+
+describe("PendingCommentReview", () => {
+  it("copies a pending peer comments prompt when local agent execution is unavailable", async () => {
+    const user = userEvent.setup();
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
+    render(<PendingCommentReview docId="doc-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Copy agent prompt" }));
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "Review these pending peer comments",
+    );
+    expect(writeText.mock.calls[0]?.[0]).toContain("- docs/spec.md");
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "  - peer-1 (fix) from Alice at block 1: Fix the intro",
+    );
+    expect(useAppStore.getState().toast).toBe("Agent prompt copied");
+  });
+
+  it("hides the agent action while the tab has an active run", async () => {
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "test-tab",
+      taskKind: "review_peer_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["docs/spec.md#peer-1"],
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+    });
+
+    render(<PendingCommentReview docId="doc-1" />);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Copy agent prompt" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/ui/components/PendingCommentReview/PendingCommentReview.tsx
+++ b/src/ui/components/PendingCommentReview/PendingCommentReview.tsx
@@ -1,40 +1,157 @@
-import './PendingCommentReview.css'
-import { useAppStore } from '../../../store'
-import { useActiveTab } from '../../../store/selectors'
-import { PeerCommentCard } from '../PeerCommentCard'
+import "./PendingCommentReview.css";
+import { useEffect, useMemo, useState } from "react";
+import { buildPendingPeerCommentsAgentPrompt } from "../../../markup";
+import {
+  getActiveAgentRunForTab,
+  getPendingPeerCommentTargets,
+} from "../../../modules/agent-workflow";
+import type { AgentRunStatus } from "../../../modules/agent-workflow";
+import { canRunAgent, getAgentRuntimeCapability } from "../../../runtime";
+import type { AgentRuntimeCapability } from "../../../runtime";
+import { useAppStore } from "../../../store";
+import { useActiveTab } from "../../../store/selectors";
+import type { PeerComment } from "../../../types/share";
+import { getPeerCommentsAgentAction } from "../../agentActions";
+import { PeerCommentCard } from "../PeerCommentCard";
 
 interface Props {
-  docId: string
+  docId: string;
 }
 
+const ACTIVE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
+  "queued",
+  "running",
+  "needs_attention",
+]);
+const INITIAL_AGENT_CAPABILITY: AgentRuntimeCapability = {
+  canRunAgent: false,
+  unavailableMessage: canRunAgent
+    ? null
+    : "Local agent execution is unavailable on web.",
+};
+const EMPTY_PEER_COMMENTS: PeerComment[] = [];
+
 export function PendingCommentReview({ docId }: Props) {
-  const tab = useActiveTab()
-  const pendingComments = tab?.pendingComments ?? {}
-  const mergeComment = useAppStore((s) => s.mergeComment)
-  const clearPendingComments = useAppStore((s) => s.clearPendingComments)
-  const activeFilePath = tab?.activeFilePath ?? null
-  const fileName = tab?.fileName ?? null
+  const tab = useActiveTab();
+  const pendingComments = tab?.pendingComments ?? {};
+  const mergeComment = useAppStore((state) => state.mergeComment);
+  const clearPendingComments = useAppStore(
+    (state) => state.clearPendingComments,
+  );
+  const showToast = useAppStore((state) => state.showToast);
+  const startPeerCommentsAgentRun = useAppStore(
+    (state) => state.startPeerCommentsAgentRun,
+  );
+  const activeAgentRun = useAppStore((state) =>
+    tab?.id ? getActiveAgentRunForTab(state, tab.id) : null,
+  );
+  const activeFilePath = tab?.activeFilePath ?? null;
+  const fileName = tab?.fileName ?? null;
+  const [agentCapability, setAgentCapability] = useState(
+    INITIAL_AGENT_CAPABILITY,
+  );
 
-  const comments = pendingComments[docId] ?? []
-  const currentPath = activeFilePath ?? fileName ?? ''
-
-  if (comments.length === 0) {
-    return <p className="pending-review__empty">No pending comments.</p>
-  }
+  const comments = pendingComments[docId] ?? EMPTY_PEER_COMMENTS;
+  const currentPath = activeFilePath ?? fileName ?? "";
+  const pendingTargets = useMemo(
+    () => getPendingPeerCommentTargets(comments),
+    [comments],
+  );
+  const canStopAgentRun = Boolean(
+    activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
+  );
+  const peerCommentsAgentAction = getPeerCommentsAgentAction({
+    canRunAgent: agentCapability.canRunAgent,
+    canStartPeerCommentsRun: comments.length > 0 && !canStopAgentRun,
+  });
 
   async function handleMergeAll() {
-    for (const c of comments) {
-      await mergeComment(docId, c)
+    for (const comment of comments) {
+      await mergeComment(docId, comment);
     }
+  }
+
+  async function handleCopyPeerCommentsPrompt() {
+    try {
+      await navigator.clipboard.writeText(
+        buildPendingPeerCommentsAgentPrompt({
+          targets: pendingTargets,
+        }),
+      );
+      showToast("Agent prompt copied");
+    } catch (error) {
+      console.error(
+        "[PendingCommentReview] failed to copy agent prompt:",
+        error,
+      );
+      showToast("Couldn't copy agent prompt");
+    }
+  }
+
+  async function handlePeerCommentsAgentAction() {
+    if (peerCommentsAgentAction.kind === "copy_prompt") {
+      await handleCopyPeerCommentsPrompt();
+      return;
+    }
+
+    const result = await startPeerCommentsAgentRun(docId);
+    if (result.status === "unavailable") {
+      showToast(result.message);
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    getAgentRuntimeCapability()
+      .then((capability) => {
+        if (!cancelled) {
+          setAgentCapability(capability);
+        }
+      })
+      .catch((error) => {
+        console.error(
+          "[PendingCommentReview] failed to read agent capability:",
+          error,
+        );
+        if (!cancelled) {
+          setAgentCapability({
+            canRunAgent: false,
+            unavailableMessage: "Agent runtime availability check failed.",
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (comments.length === 0) {
+    return <p className="pending-review__empty">No pending comments.</p>;
   }
 
   return (
     <div className="pending-review">
       <div className="pending-review__toolbar">
-        <span className="pending-review__count">{comments.length} comment{comments.length !== 1 ? 's' : ''}</span>
+        <span className="pending-review__count">
+          {comments.length} comment{comments.length !== 1 ? "s" : ""}
+        </span>
+        {!canStopAgentRun && (
+          <button
+            className="pending-review__btn"
+            onClick={() => {
+              void handlePeerCommentsAgentAction();
+            }}
+            title={peerCommentsAgentAction.title}
+          >
+            {peerCommentsAgentAction.label}
+          </button>
+        )}
         <button
           className="pending-review__btn pending-review__btn--merge-all"
-          onClick={handleMergeAll}
+          onClick={() => {
+            void handleMergeAll();
+          }}
         >
           Merge all
         </button>
@@ -47,10 +164,15 @@ export function PendingCommentReview({ docId }: Props) {
       </div>
 
       <div className="pending-review__list">
-        {comments.map((c) => (
-          <PeerCommentCard key={c.id} docId={docId} comment={c} currentPath={currentPath} />
+        {comments.map((comment) => (
+          <PeerCommentCard
+            key={comment.id}
+            docId={docId}
+            comment={comment}
+            currentPath={currentPath}
+          />
         ))}
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add pending peer-comment prompt generation and review_peer_comments run requests
- wire PendingCommentReview to copy prompts on web and start desktop agent runs when available
- update desktop agent architecture docs and focused tests

## Verification
- npx tsc --noEmit
- npx vitest run src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/agent-workflow/test/agentWorkflowState.test.ts src/ui/agentActions.test.ts src/ui/components/PendingCommentReview/PendingCommentReview.test.tsx src/ui/components/SharedPanel/SharedPanel.test.tsx
- npx eslint on touched TypeScript files
- npx prettier --check on touched docs and code files, plus git diff --check
- npx vite build
- npx vite build --mode desktop

## Notes
- Vite builds still report the existing large-chunk warning.