### PR TITLE
fix: gate browser filesystem by runtime

### DIFF
--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -103,6 +103,8 @@ Acceptance criteria:
 
 - Desktop can open and edit local markdown files and folders.
 - Desktop uses native path-based file access.
+- Desktop does not render the website-only File System Access API unsupported
+  screen when the browser API is unavailable.
 - Website continues using its browser filesystem implementation.
 
 As a desktop user, I want to click a Dragon UI action to ask an agent to address

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'src-tauri/target']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/runtime/desktopWorkspaceRuntime.test.ts
+++ b/src/runtime/desktopWorkspaceRuntime.test.ts
@@ -55,6 +55,10 @@ beforeEach(() => {
 });
 
 describe("desktopWorkspaceRuntime", () => {
+  it("does not require the browser File System Access API", () => {
+    expect(desktopWorkspaceRuntime.requiresBrowserFileSystemAccess).toBe(false);
+  });
+
   it("delegates native file and directory opens to Tauri dialogs", async () => {
     const fileTarget: NativeWorkspaceFileTarget = {
       kind: "native_file",

--- a/src/runtime/desktopWorkspaceRuntime.ts
+++ b/src/runtime/desktopWorkspaceRuntime.ts
@@ -42,6 +42,7 @@ function nativeTreeNodeToFileTreeNode(
 }
 
 export const desktopWorkspaceRuntime: WorkspaceRuntime = {
+  requiresBrowserFileSystemAccess: false,
   openFile: async () => {
     const target = await openTauriTextFile();
     if (!target) {

--- a/src/runtime/webWorkspaceRuntime.test.ts
+++ b/src/runtime/webWorkspaceRuntime.test.ts
@@ -51,6 +51,10 @@ beforeEach(() => {
 });
 
 describe("workspaceRuntime", () => {
+  it("requires the browser File System Access API", () => {
+    expect(workspaceRuntime.requiresBrowserFileSystemAccess).toBe(true);
+  });
+
   it("delegates file operations to the web filesystem implementation", async () => {
     const fileHandle = createFileHandle("notes.md");
     vi.mocked(openFile).mockResolvedValue({

--- a/src/runtime/webWorkspaceRuntime.ts
+++ b/src/runtime/webWorkspaceRuntime.ts
@@ -38,6 +38,7 @@ function requireBrowserDirectoryHandle(
 }
 
 export const webWorkspaceRuntime: WorkspaceRuntime = {
+  requiresBrowserFileSystemAccess: true,
   openFile,
   openDirectory,
   readFile: async (target) => readFile(requireBrowserFileHandle(target)),

--- a/src/runtime/workspace.ts
+++ b/src/runtime/workspace.ts
@@ -23,6 +23,7 @@ export interface OpenedWorkspaceDirectory {
 }
 
 export interface WorkspaceRuntime {
+  requiresBrowserFileSystemAccess: boolean;
   openFile(): Promise<OpenedWorkspaceFile | null>;
   openDirectory(): Promise<OpenedWorkspaceDirectory | null>;
   readFile(target: WorkspaceFileTarget): Promise<string>;

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../config", () => ({
 }));
 
 import App from "./App";
+import { shouldShowBrowserUnsupported } from "./browserSupport";
 import { useAppStore } from "../store";
 import { setTestState, resetTestStore } from "../testing/testHelpers";
 import type { FileTreeNode } from "../types/fileTree";
@@ -92,6 +93,26 @@ beforeEach(() => {
   document.documentElement.classList.remove("dark");
   resetStore();
   vi.restoreAllMocks();
+});
+
+describe("App — host browser support gate", () => {
+  it("blocks web host mode when browser file access is required but unavailable", () => {
+    expect(
+      shouldShowBrowserUnsupported(
+        { requiresBrowserFileSystemAccess: true },
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it("does not block desktop host mode when browser file access is unavailable", () => {
+    expect(
+      shouldShowBrowserUnsupported(
+        { requiresBrowserFileSystemAccess: false },
+        {},
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("App — no file open", () => {
@@ -232,7 +253,9 @@ describe("App — folder open", () => {
     expect(
       screen.getByText(/Choose a Markdown file from the sidebar/),
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "my-docs" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "my-docs" }),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("markdown-renderer")).not.toBeInTheDocument();
   });
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -27,6 +27,8 @@ import {
 } from "../types/tab";
 import { WORKER_URL } from "../config";
 import { stopRelay } from "../modules/relay";
+import { workspaceRuntime } from "../runtime";
+import { shouldShowBrowserUnsupported } from "./browserSupport";
 import {
   useThemeSync,
   useHashRouter,
@@ -302,8 +304,8 @@ function App() {
     return null;
   }
 
-  // ── Host mode requires File System Access API (Chrome/Edge over HTTPS) ──
-  if (typeof window.showOpenFilePicker !== "function") {
+  // ── Web host mode requires File System Access API (Chrome/Edge over HTTPS) ──
+  if (shouldShowBrowserUnsupported(workspaceRuntime, window)) {
     return (
       <div className="app-unsupported">
         <h1>Browser not supported</h1>

--- a/src/ui/browserSupport.ts
+++ b/src/ui/browserSupport.ts
@@ -1,0 +1,15 @@
+import type { WorkspaceRuntime } from "../runtime";
+
+interface BrowserFileSystemWindow {
+  showOpenFilePicker?: Window["showOpenFilePicker"];
+}
+
+export function shouldShowBrowserUnsupported(
+  runtime: Pick<WorkspaceRuntime, "requiresBrowserFileSystemAccess">,
+  hostWindow: BrowserFileSystemWindow,
+): boolean {
+  return (
+    runtime.requiresBrowserFileSystemAccess &&
+    typeof hostWindow.showOpenFilePicker !== "function"
+  );
+}


### PR DESCRIPTION
## Summary
- add a workspace runtime capability for browser File System Access API requirements
- keep the unsupported-browser gate for web host mode only, so desktop mode can render with the Tauri runtime
- document the desktop acceptance criterion and ignore generated Tauri build output in ESLint

## Verification
- npm run typecheck
- npm run lint
- npx vitest run src/ui/App.test.tsx src/runtime/desktopWorkspaceRuntime.test.ts src/runtime/webWorkspaceRuntime.test.ts
- npm test
- npm run build
- npm run build -- --mode desktop
- npm run desktop:build