### PR TITLE
fix: register tauri dialog plugin

### DIFF
--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -103,6 +103,8 @@ Acceptance criteria:
 
 - Desktop can open and edit local markdown files and folders.
 - Desktop uses native path-based file access.
+- Desktop registers the native dialog runtime plugin before invoking file or
+  folder picker commands.
 - Desktop does not render the website-only File System Access API unsupported
   screen when the browser API is unavailable.
 - Website continues using its browser filesystem implementation.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -404,6 +404,7 @@ fn dragon_get_agent_run_status(run_id: String) -> Result<AgentRunStatusPayload, 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .invoke_handler(tauri::generate_handler![
             dragon_runtime_ping,
             dragon_agent_runtime_available,


### PR DESCRIPTION
## Summary
- register the Tauri dialog plugin before native file/folder picker commands are invoked
- document the desktop runtime requirement so this crash is covered by the desktop spec

## Root cause
The desktop frontend called `dragon_open_text_file`, which uses `app.dialog()`, but the Rust builder had not installed `tauri_plugin_dialog::init()`. Tauri panicked with `state() called before manage()` when the user clicked Open file.

## Verification
- cargo check --manifest-path src-tauri/Cargo.toml
- npm run typecheck
- npm run desktop:build