### PR TITLE
Guard desktop targets from browser file observer

### DIFF
--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -105,6 +105,10 @@ Acceptance criteria:
 - Desktop uses native path-based file access.
 - Desktop registers the native dialog runtime plugin before invoking file or
   folder picker commands.
+- Desktop native file and folder dialogs are parented to the active Tauri
+  window so picker failures do not terminate the app process silently.
+- Desktop open-file and open-folder failures are logged and shown to the user as
+  toast feedback instead of disappearing as unhandled UI promises.
 - Desktop does not render the website-only File System Access API unsupported
   screen when the browser API is unavailable.
 - Website continues using its browser filesystem implementation.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -244,10 +244,11 @@ fn dragon_agent_runtime_available() -> bool {
 }
 
 #[tauri::command]
-fn dragon_open_text_file(app: tauri::AppHandle) -> Result<Option<NativePathTarget>, String> {
-    let selected = app
+fn dragon_open_text_file(window: tauri::Window) -> Result<Option<NativePathTarget>, String> {
+    let selected = window
         .dialog()
         .file()
+        .set_parent(&window)
         .add_filter("Markdown", &["md", "markdown"])
         .blocking_pick_file();
 
@@ -257,8 +258,12 @@ fn dragon_open_text_file(app: tauri::AppHandle) -> Result<Option<NativePathTarge
 }
 
 #[tauri::command]
-fn dragon_open_directory(app: tauri::AppHandle) -> Result<Option<NativePathTarget>, String> {
-    let selected = app.dialog().file().blocking_pick_folder();
+fn dragon_open_directory(window: tauri::Window) -> Result<Option<NativePathTarget>, String> {
+    let selected = window
+        .dialog()
+        .file()
+        .set_parent(&window)
+        .blocking_pick_folder();
 
     Ok(selected
         .and_then(|file_path| file_path.as_path().map(|path| path.to_path_buf()))

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -787,74 +787,87 @@ export function createWorkspaceControllerActions<
     },
 
     openFileInNewTab: async () => {
-      const result = await openFile();
-      if (!result) {
-        return;
+      try {
+        const result = await openFile();
+        if (!result) {
+          return;
+        }
+
+        const existingTab = await findTabByHandle(
+          get().tabs,
+          result.handle,
+          "file",
+        );
+        if (existingTab) {
+          set({ activeTabId: existingTab.id });
+          return;
+        }
+
+        const rawContent = await readFile(result.handle);
+        const tab = createDefaultTab({
+          label: result.name,
+          fileHandle: result.handle,
+          fileName: result.name,
+          rawContent,
+        });
+
+        set((state) => ({
+          tabs: [...state.tabs, tab],
+          activeTabId: tab.id,
+        }));
+        await saveBrowserHandle(`tab:${tab.id}:file`, result.handle);
+      } catch (error) {
+        console.error("[openFileInNewTab] failed to open file:", error);
+        showToast("File could not be opened. Check the terminal logs.");
       }
-
-      const existingTab = await findTabByHandle(
-        get().tabs,
-        result.handle,
-        "file",
-      );
-      if (existingTab) {
-        set({ activeTabId: existingTab.id });
-        return;
-      }
-
-      const rawContent = await readFile(result.handle);
-      const tab = createDefaultTab({
-        label: result.name,
-        fileHandle: result.handle,
-        fileName: result.name,
-        rawContent,
-      });
-
-      set((state) => ({
-        tabs: [...state.tabs, tab],
-        activeTabId: tab.id,
-      }));
-      await saveBrowserHandle(`tab:${tab.id}:file`, result.handle);
     },
 
     openDirectoryInNewTab: async () => {
-      const result = await openDirectory();
-      if (!result) {
-        return;
-      }
+      try {
+        const result = await openDirectory();
+        if (!result) {
+          return;
+        }
 
-      const existingTab = await findTabByHandle(
-        get().tabs,
-        result.handle,
-        "directory",
-      );
-      if (existingTab) {
-        set({ activeTabId: existingTab.id });
-        return;
-      }
+        const existingTab = await findTabByHandle(
+          get().tabs,
+          result.handle,
+          "directory",
+        );
+        if (existingTab) {
+          set({ activeTabId: existingTab.id });
+          return;
+        }
 
-      const tab = createDefaultTab({
-        label: result.name,
-        directoryHandle: result.handle,
-        directoryName: result.name,
-        sidebarOpen: true,
-      });
+        const tab = createDefaultTab({
+          label: result.name,
+          directoryHandle: result.handle,
+          directoryName: result.name,
+          sidebarOpen: true,
+        });
 
-      set((state) => ({
-        tabs: [...state.tabs, tab],
-        activeTabId: tab.id,
-      }));
+        set((state) => ({
+          tabs: [...state.tabs, tab],
+          activeTabId: tab.id,
+        }));
 
-      await saveBrowserHandle(`tab:${tab.id}:directory`, result.handle);
-      const tree = await buildFileTree(result.handle);
-      set((state) => ({
-        tabs: buildUpdatedTabs(state.tabs, tab.id, () => ({
-          fileTree: tree,
-        })),
-      }));
+        await saveBrowserHandle(`tab:${tab.id}:directory`, result.handle);
+        const tree = await buildFileTree(result.handle);
+        set((state) => ({
+          tabs: buildUpdatedTabs(state.tabs, tab.id, () => ({
+            fileTree: tree,
+          })),
+        }));
 
-      if (get().activeTabId === tab.id) {
-        await scanAllFileComments();
+        if (get().activeTabId === tab.id) {
+          await scanAllFileComments();
+        }
+      } catch (error) {
+        console.error(
+          "[openDirectoryInNewTab] failed to open folder:",
+          error,
+        );
+        showToast("Folder could not be opened. Check the terminal logs.");
       }
     },
 

--- a/src/modules/workspace/test/tabRestore.test.ts
+++ b/src/modules/workspace/test/tabRestore.test.ts
@@ -8,6 +8,7 @@ vi.mock("../storage", async (importOriginal) => {
     getHandle: vi.fn(),
     removeHandle: vi.fn(),
     buildFileTree: vi.fn(),
+    openFile: vi.fn(),
     openDirectory: vi.fn(),
     readFile: vi.fn(),
   };
@@ -25,6 +26,7 @@ import { getActiveTab } from "../selectors";
 import {
   buildFileTree,
   getHandle,
+  openFile,
   openDirectory,
   readFile,
   saveHandle,
@@ -33,6 +35,46 @@ import {
 beforeEach(() => {
   resetTestStore();
   vi.clearAllMocks();
+});
+
+describe("store.openFileInNewTab", () => {
+  it("shows a toast when the native open file flow fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    vi.mocked(openFile).mockRejectedValue(new Error("dialog failed"));
+
+    await useAppStore.getState().openFileInNewTab();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[openFileInNewTab] failed to open file:",
+      expect.any(Error),
+    );
+    expect(useAppStore.getState().tabs).toEqual([]);
+    expect(useAppStore.getState().toast).toBe(
+      "File could not be opened. Check the terminal logs.",
+    );
+  });
+});
+
+describe("store.openDirectoryInNewTab", () => {
+  it("shows a toast when the native open folder flow fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    vi.mocked(openDirectory).mockRejectedValue(new Error("dialog failed"));
+
+    await useAppStore.getState().openDirectoryInNewTab();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[openDirectoryInNewTab] failed to open folder:",
+      expect.any(Error),
+    );
+    expect(useAppStore.getState().tabs).toEqual([]);
+    expect(useAppStore.getState().toast).toBe(
+      "Folder could not be opened. Check the terminal logs.",
+    );
+  });
 });
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/ui/hooks/useFileSystemWatcher.test.tsx
+++ b/src/ui/hooks/useFileSystemWatcher.test.tsx
@@ -1,0 +1,98 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NativeFileTarget } from "../../types/fileTree";
+import { useFileSystemWatcher } from "./useFileSystemWatcher";
+
+interface ObserveCall {
+  handle: FileSystemHandle;
+  options?: { recursive: boolean };
+}
+
+const observeCalls: ObserveCall[] = [];
+
+class TestFileSystemObserver {
+  constructor(callback: (records: { type: string }[]) => void) {
+    void callback;
+  }
+
+  observe(
+    handle: FileSystemHandle,
+    options?: { recursive: boolean },
+  ): Promise<void> {
+    observeCalls.push({ handle, options });
+    return Promise.resolve();
+  }
+
+  disconnect(): void {}
+}
+
+function createBrowserFileHandle(name: string): FileSystemFileHandle {
+  return {
+    kind: "file",
+    name,
+    isSameEntry: vi.fn(),
+    queryPermission: vi.fn(),
+    requestPermission: vi.fn(),
+    getFile: vi.fn(),
+    createWritable: vi.fn(),
+  };
+}
+
+describe("useFileSystemWatcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    observeCalls.length = 0;
+    window.FileSystemObserver = TestFileSystemObserver;
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.FileSystemObserver = undefined;
+    vi.useRealTimers();
+  });
+
+  it("uses polling for native desktop targets even when FileSystemObserver exists", async () => {
+    const nativeTarget: NativeFileTarget = {
+      kind: "native_file",
+      name: "notes.md",
+      path: "/tmp/notes.md",
+    };
+    const onRefresh = vi.fn();
+
+    renderHook(() =>
+      useFileSystemWatcher({
+        handle: nativeTarget,
+        onRefresh,
+        pollIntervalMs: 25,
+        relevantTypes: ["modified"],
+      }),
+    );
+
+    expect(observeCalls).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses FileSystemObserver for browser file handles when available", async () => {
+    const browserHandle = createBrowserFileHandle("notes.md");
+    const onRefresh = vi.fn();
+
+    renderHook(() =>
+      useFileSystemWatcher({
+        handle: browserHandle,
+        onRefresh,
+        pollIntervalMs: 25,
+        relevantTypes: ["modified"],
+      }),
+    );
+
+    expect(observeCalls).toHaveLength(1);
+    expect(observeCalls[0].handle).toBe(browserHandle);
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/hooks/useFileSystemWatcher.ts
+++ b/src/ui/hooks/useFileSystemWatcher.ts
@@ -1,10 +1,9 @@
 import { useEffect } from "react";
-
-// FileSystemObserver is experimental; Edge exposes it but crashes on use
-const supportsFileObserver =
-  typeof window !== "undefined" &&
-  "FileSystemObserver" in window &&
-  !/\bEdg\//.test(navigator.userAgent);
+import type { DirectoryTarget, FileTarget } from "../../types/fileTree";
+import {
+  isBrowserDirectoryHandle,
+  isBrowserFileHandle,
+} from "../../types/fileTree";
 
 interface FileSystemObserverRecord {
   type: string;
@@ -28,8 +27,17 @@ declare global {
   }
 }
 
+function supportsFileObserver(): boolean {
+  // FileSystemObserver is experimental; Edge exposes it but crashes on use.
+  return (
+    typeof window !== "undefined" &&
+    "FileSystemObserver" in window &&
+    !/\bEdg\//.test(navigator.userAgent)
+  );
+}
+
 interface WatcherOptions {
-  handle: FileSystemHandle | null;
+  handle: FileTarget | DirectoryTarget | null;
   onRefresh: () => void | Promise<void>;
   pollIntervalMs: number;
   recursive?: boolean;
@@ -59,17 +67,32 @@ export function useFileSystemWatcher({
       if (cancelled || pollTimer) {
         return;
       }
-      pollTimer = setTimeout(async () => {
+      pollTimer = setTimeout(() => {
         pollTimer = null;
         if (cancelled) {
           return;
         }
-        await onRefresh();
-        schedulePoll();
+        void Promise.resolve(onRefresh())
+          .catch((error: unknown) => {
+            console.error("[FileSystemObserver] refresh failed:", error);
+          })
+          .finally(() => {
+            schedulePoll();
+          });
       }, pollIntervalMs);
     }
 
-    if (!supportsFileObserver) {
+    if (!supportsFileObserver()) {
+      schedulePoll();
+      return () => {
+        cancelled = true;
+        if (pollTimer) {
+          clearTimeout(pollTimer);
+        }
+      };
+    }
+
+    if (!isBrowserFileHandle(handle) && !isBrowserDirectoryHandle(handle)) {
       schedulePoll();
       return () => {
         cancelled = true;
@@ -98,7 +121,9 @@ export function useFileSystemWatcher({
         const hasErrored = records.some((r) => r.type === "errored");
 
         if (hasRelevant) {
-          onRefresh();
+          void Promise.resolve(onRefresh()).catch((error: unknown) => {
+            console.error("[FileSystemObserver] refresh failed:", error);
+          });
         }
         if (hasErrored) {
           console.warn(


### PR DESCRIPTION
## Summary
- audit desktop runtime/browser filesystem boundary for missed Tauri and browser API cases
- keep native desktop file/folder targets on polling instead of the experimental FileSystemObserver path
- parent native open-file/open-folder dialogs to the active Tauri window
- surface open-file/open-folder failures through logs and toast feedback instead of unhandled UI promises

## Audit notes
- Tauri command names match between src/runtime/tauriBridge.ts and src-tauri/src/lib.rs
- the only Tauri plugin extension in app code is DialogExt, and tauri_plugin_dialog is registered in the builder
- no direct frontend @tauri-apps/plugin-* APIs are used, so current capabilities stay scoped to custom dragon_* commands

## Verification
- npm run typecheck
- npx vitest run src/modules/workspace/test/tabRestore.test.ts src/runtime/tauriBridge.test.ts src/runtime/desktopWorkspaceRuntime.test.ts src/ui/App.test.tsx
- npx vitest run src/ui/hooks/useFileSystemWatcher.test.tsx src/runtime/tauriBridge.test.ts src/runtime/desktopWorkspaceRuntime.test.ts src/runtime/desktopAgentRuntime.test.ts src/ui/App.test.tsx
- npm run lint -- --quiet
- npm test
- cargo check --manifest-path src-tauri/Cargo.toml
- npm run desktop:build