### PR TITLE
docs: clarify desktop development environments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,13 @@ If a change may remove backward-compatibility logic, pause and ask for confirmat
 
 ## Environment
 
-- Run project commands through WSL, not the Windows shell. Use the repo's Linux toolchain for `node`, `npm`, `git`, and test commands.
-- Preferred pattern: `wsl zsh -lic 'cd /home/zonzujiro/projects/lollipop-dragon && fnm use && npm test'`
+- Detect the checkout/runtime before choosing commands.
+- For the WSL checkout (`/home/zonzujiro/projects/lollipop-dragon`, or the Windows UNC view `\\wsl.localhost\Ubuntu-22.04\home\zonzujiro\projects\lollipop-dragon`), run project commands through WSL and use the repo's Linux toolchain for `node`, `npm`, `git`, and tests.
+- Preferred WSL pattern: `wsl zsh -lic 'cd /home/zonzujiro/projects/lollipop-dragon && fnm use && npm test'`
+- Do not treat `npm run desktop:dev` from WSL as Windows desktop UX validation. It runs a Linux Tauri/WebKitGTK app through WSLg and is diagnostic only.
+- For Windows desktop development and Windows desktop builds, use the native Windows checkout at `C:\Users\ivan\Projects\lollipop-dragon` with Windows `node`, `npm`, `cargo`, and `git`.
+- Preferred Windows desktop pattern: `cd C:\Users\ivan\Projects\lollipop-dragon; npm run desktop:dev`
+- Avoid using WSL tooling against `/mnt/c/...` as the default workflow.
 
 ## TypeScript
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,8 +12,21 @@
 ```bash
 npm install
 npm run dev          # starts dev server at http://localhost:5173
-npm run desktop:dev  # starts the Tauri desktop shell
 ```
+
+Desktop development must run on the native target OS. For Windows desktop work,
+use the Windows checkout and Windows toolchain:
+
+```powershell
+cd C:\Users\ivan\Projects\lollipop-dragon
+npm install
+npm run desktop:dev
+```
+
+For the WSL checkout at `/home/zonzujiro/projects/lollipop-dragon`, run web,
+test, typecheck, and lint commands through WSL. Do not use WSL desktop runs as
+Windows UX validation; `npm run desktop:dev` from WSL runs the Linux Tauri app
+through WSLg.
 
 To enable sharing features locally:
 


### PR DESCRIPTION
## Summary
- document runtime detection before choosing WSL or native Windows commands
- mark WSL desktop runs as diagnostic only for Windows UX
- add Windows checkout desktop setup guidance to contributing docs

## Verification
- npx prettier --check AGENTS.md docs/contributing.md