### PR TITLE
feat: add desktop agent setup

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -6,7 +6,7 @@ Desktop agent foundation implemented. The shared runtime boundary, Tauri shell,
 native file/folder targets, configurable desktop agent runner, tab-scoped run
 state, and bounded comment-driven agent actions have landed incrementally.
 Remaining work depends on explicit backend decisions for terminal attachment,
-first-run auth, session persistence, and future structured runners.
+session persistence, and future structured runners.
 
 ## Summary
 
@@ -276,13 +276,14 @@ builds continue to use the browser file API runtime.
 
 Native runner implementation note: desktop agent runs now call Tauri
 `dragon_start_agent_run`. The command is intentionally configurable through
-`DRAGON_AGENT_COMMAND`; Dragon sends the generated prompt to the process stdin
-and stores only the returned runtime run id in app state. This keeps tmux, Codex
-CLI, and other runner choices behind the native runtime boundary instead of
-hard-coding one backend into the UI/store contract.
-The comment panel checks the native availability command before presenting
-run-agent actions, so an unconfigured command falls back to prompt copying with
-an inline setup message.
+native app config, with `DRAGON_AGENT_COMMAND` retained as a dogfooding fallback.
+Dragon sends the generated prompt to the process stdin and stores only the
+returned runtime run id in app state. This keeps tmux, Codex CLI, and other
+runner choices behind the native runtime boundary instead of hard-coding one
+backend into the UI/store contract.
+The Agent setup surface detects known CLIs, saves a command through native
+config, tests it with `--version`, and opens inline when a desktop run action is
+used before configuration.
 
 Run-control implementation note: the comment panel now shows the active run for
 the current tab and exposes a stop action while the run is queued, running, or

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -5,8 +5,8 @@
 Desktop agent foundation implemented. The website remains available, and the
 desktop path now covers native file/folder targets plus UI-started agent runs for
 comment review tasks. Remaining work is limited to explicit backend/product
-decisions such as terminal attachment, first-run auth, and future structured
-runners.
+decisions such as terminal attachment, session persistence, and future
+structured runners.
 
 ## Problem
 
@@ -244,8 +244,10 @@ outside this first desktop planning scope.
 - The shared app now has runtime capability facades for web and desktop builds.
 - Normal website builds keep browser file APIs and prompt-copy handoff.
 - Tauri desktop builds can open native file and folder targets.
-- Desktop agent runs start through `DRAGON_AGENT_COMMAND`, receive the generated
-  review prompt through stdin, and keep process handles outside Zustand.
+- Desktop agent runs start through the saved desktop agent command, with
+  `DRAGON_AGENT_COMMAND` retained as an environment fallback. Runs receive the
+  generated review prompt through stdin, and keep process handles outside
+  Zustand.
 - Agent run state is tab-scoped and serializable. The comment panel can stop an
   active run and polls native run status so completed or failed processes are
   reflected in the UI.
@@ -269,14 +271,15 @@ outside this first desktop planning scope.
   agent handoff.
 - Agent starts are guarded to one active run per tab and three active runs
   app-wide.
-- Desktop reads agent availability before showing run actions, so missing
-  `DRAGON_AGENT_COMMAND` falls back to prompt copying with a setup message.
+- Desktop reads agent availability before showing run actions. The Agent setup
+  surface can detect known CLIs, save a command in native app config, test it
+  with `--version`, and open inline when the user clicks an agent action before
+  configuring a command.
 - Native file and folder targets are persisted by path, so desktop tabs can
   restore live access after reload without browser handle storage.
 
 ## Remaining Backend Decisions
 
-- How should desktop handle agent authentication and first-run setup?
 - What is the minimum Windows backend for terminal/session support if `tmux` is
   not available?
 - How much agent terminal/session persistence should desktop restore across app

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1703,6 +1703,7 @@ name = "lollipop-dragon"
 version = "0.0.0"
 dependencies = [
  "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,5 +16,6 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,12 +9,27 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::Manager;
 use tauri_plugin_dialog::DialogExt;
 
 const IGNORED_NAMES: [&str; 3] = ["node_modules", ".git", ".markreview"];
 const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
 const AGENT_COMMAND_ENV: &str = "DRAGON_AGENT_COMMAND";
 const AGENT_OUTPUT_LIMIT: usize = 20_000;
+const AGENT_CONFIG_FILE: &str = "agent-config.json";
+const AGENT_TEST_OUTPUT_LIMIT: usize = 8_000;
+const KNOWN_AGENT_CLIS: [KnownAgentCli; 2] = [
+    KnownAgentCli {
+        id: "codex",
+        label: "Codex",
+        executable: "codex",
+    },
+    KnownAgentCli {
+        id: "claude",
+        label: "Claude",
+        executable: "claude",
+    },
+];
 
 static AGENT_RUN_COUNTER: AtomicU64 = AtomicU64::new(1);
 static AGENT_RUNS: OnceLock<Mutex<HashMap<String, AgentRunProcess>>> = OnceLock::new();
@@ -54,6 +69,44 @@ struct AgentRunStatusPayload {
     output: String,
 }
 
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentConfigFile {
+    command: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentConfigPayload {
+    command: Option<String>,
+    source: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentCliDetectionPayload {
+    id: String,
+    label: String,
+    command: String,
+    path: Option<String>,
+    available: bool,
+    version: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentCommandTestPayload {
+    ok: bool,
+    message: String,
+    output: String,
+}
+
+struct KnownAgentCli {
+    id: &'static str,
+    label: &'static str,
+    executable: &'static str,
+}
+
 struct AgentRunProcess {
     child: Child,
     output: Arc<Mutex<String>>,
@@ -74,6 +127,73 @@ fn path_target_from_path(path: PathBuf) -> NativePathTarget {
 
 fn active_agent_runs() -> &'static Mutex<HashMap<String, AgentRunProcess>> {
     AGENT_RUNS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn agent_config_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let config_dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|error| error.to_string())?;
+    Ok(config_dir.join(AGENT_CONFIG_FILE))
+}
+
+fn read_saved_agent_command(app: &tauri::AppHandle) -> Result<Option<String>, String> {
+    let config_path = agent_config_path(app)?;
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    let raw_config = fs::read_to_string(config_path).map_err(|error| error.to_string())?;
+    let config: AgentConfigFile =
+        serde_json::from_str(&raw_config).map_err(|error| error.to_string())?;
+    let command = config.command.trim().to_string();
+    if command.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(command))
+}
+
+fn save_agent_command(app: &tauri::AppHandle, command: String) -> Result<(), String> {
+    let trimmed_command = command.trim().to_string();
+    if trimmed_command.is_empty() {
+        return Err("Agent command cannot be empty".to_string());
+    }
+
+    let config_path = agent_config_path(app)?;
+    let config_dir = config_path
+        .parent()
+        .ok_or_else(|| "Agent config directory is unavailable".to_string())?;
+    fs::create_dir_all(config_dir).map_err(|error| error.to_string())?;
+    let raw_config = serde_json::to_string_pretty(&AgentConfigFile {
+        command: trimmed_command,
+    })
+    .map_err(|error| error.to_string())?;
+    fs::write(config_path, raw_config).map_err(|error| error.to_string())
+}
+
+fn clear_saved_agent_command(app: &tauri::AppHandle) -> Result<(), String> {
+    let config_path = agent_config_path(app)?;
+    if config_path.exists() {
+        fs::remove_file(config_path).map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+fn configured_agent_command(app: &tauri::AppHandle) -> Result<(String, String), String> {
+    if let Some(command) = read_saved_agent_command(app)? {
+        return Ok((command, "config".to_string()));
+    }
+
+    let command = env::var(AGENT_COMMAND_ENV)
+        .map_err(|_| format!("{AGENT_COMMAND_ENV} is not configured"))?
+        .trim()
+        .to_string();
+    if command.is_empty() {
+        return Err(format!("{AGENT_COMMAND_ENV} is empty"));
+    }
+
+    Ok((command, "environment".to_string()))
 }
 
 fn append_agent_output(output: &Arc<Mutex<String>>, chunk: &str) {
@@ -136,18 +256,6 @@ fn join_agent_output_threads(process: AgentRunProcess) -> String {
     read_agent_output(&process.output)
 }
 
-fn configured_agent_command() -> Result<String, String> {
-    let command = env::var(AGENT_COMMAND_ENV)
-        .map_err(|_| format!("{AGENT_COMMAND_ENV} is not configured"))?
-        .trim()
-        .to_string();
-    if command.is_empty() {
-        return Err(format!("{AGENT_COMMAND_ENV} is empty"));
-    }
-
-    Ok(command)
-}
-
 fn create_agent_run_id() -> String {
     let counter = AGENT_RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
     let timestamp = SystemTime::now()
@@ -170,6 +278,108 @@ fn shell_command(command: &str) -> Command {
     process
 }
 
+fn executable_candidates(executable: &str) -> Vec<String> {
+    if !cfg!(target_os = "windows") {
+        return vec![executable.to_string()];
+    }
+
+    let executable_path = Path::new(executable);
+    if executable_path.extension().is_some() {
+        return vec![executable.to_string()];
+    }
+
+    let path_ext = env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    let mut candidates = vec![executable.to_string()];
+    for extension in path_ext.split(';') {
+        let trimmed_extension = extension.trim();
+        if trimmed_extension.is_empty() {
+            continue;
+        }
+        candidates.push(format!("{executable}{trimmed_extension}"));
+    }
+    candidates
+}
+
+fn command_search_paths() -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = env::var_os("PATH")
+        .map(|raw_path| env::split_paths(&raw_path).collect())
+        .unwrap_or_default();
+
+    if cfg!(target_os = "macos") {
+        paths.push(PathBuf::from("/opt/homebrew/bin"));
+        paths.push(PathBuf::from("/usr/local/bin"));
+    }
+
+    paths
+}
+
+fn find_executable(executable: &str) -> Option<PathBuf> {
+    let executable_path = Path::new(executable);
+    if executable_path.is_absolute() && executable_path.is_file() {
+        return Some(executable_path.to_path_buf());
+    }
+
+    for directory_path in command_search_paths() {
+        for candidate in executable_candidates(executable) {
+            let candidate_path = directory_path.join(candidate);
+            if candidate_path.is_file() {
+                return Some(candidate_path);
+            }
+        }
+    }
+
+    None
+}
+
+fn truncate_output(output: String, limit: usize) -> String {
+    if output.len() <= limit {
+        return output;
+    }
+
+    let keep_from = output.len() - limit;
+    let trimmed = output
+        .char_indices()
+        .find(|(index, _character)| *index >= keep_from)
+        .map(|(index, _character)| index)
+        .unwrap_or(keep_from);
+    output[trimmed..].to_string()
+}
+
+fn probe_command(command: &str) -> AgentCommandTestPayload {
+    let test_command = format!("{command} --version");
+    let output = shell_command(&test_command).output();
+    match output {
+        Ok(result) => {
+            let stdout = String::from_utf8_lossy(&result.stdout);
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            let combined_output =
+                truncate_output(format!("{stdout}{stderr}"), AGENT_TEST_OUTPUT_LIMIT);
+            if result.status.success() {
+                return AgentCommandTestPayload {
+                    ok: true,
+                    message: "Command responded to --version".to_string(),
+                    output: combined_output,
+                };
+            }
+
+            AgentCommandTestPayload {
+                ok: false,
+                message: result
+                    .status
+                    .code()
+                    .map(|code| format!("Command exited with code {code}"))
+                    .unwrap_or_else(|| "Command exited without an exit code".to_string()),
+                output: combined_output,
+            }
+        }
+        Err(error) => AgentCommandTestPayload {
+            ok: false,
+            message: error.to_string(),
+            output: String::new(),
+        },
+    }
+}
+
 fn is_ignored(name: &str) -> bool {
     name.starts_with('.') || IGNORED_NAMES.contains(&name)
 }
@@ -177,9 +387,7 @@ fn is_ignored(name: &str) -> bool {
 fn is_markdown_file(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
-        .map(|extension| {
-            MARKDOWN_EXTENSIONS.contains(&extension.to_lowercase().as_str())
-        })
+        .map(|extension| MARKDOWN_EXTENSIONS.contains(&extension.to_lowercase().as_str()))
         .unwrap_or(false)
 }
 
@@ -239,8 +447,78 @@ fn dragon_runtime_ping() -> &'static str {
 }
 
 #[tauri::command]
-fn dragon_agent_runtime_available() -> bool {
-    configured_agent_command().is_ok()
+fn dragon_agent_runtime_available(app: tauri::AppHandle) -> bool {
+    configured_agent_command(&app).is_ok()
+}
+
+#[tauri::command]
+fn dragon_get_agent_config(app: tauri::AppHandle) -> Result<AgentConfigPayload, String> {
+    match read_saved_agent_command(&app)? {
+        Some(command) => Ok(AgentConfigPayload {
+            command: Some(command),
+            source: Some("config".to_string()),
+        }),
+        None => match env::var(AGENT_COMMAND_ENV) {
+            Ok(command) if !command.trim().is_empty() => Ok(AgentConfigPayload {
+                command: Some(command.trim().to_string()),
+                source: Some("environment".to_string()),
+            }),
+            _ => Ok(AgentConfigPayload {
+                command: None,
+                source: None,
+            }),
+        },
+    }
+}
+
+#[tauri::command]
+fn dragon_save_agent_config(app: tauri::AppHandle, command: String) -> Result<(), String> {
+    save_agent_command(&app, command)
+}
+
+#[tauri::command]
+fn dragon_clear_agent_config(app: tauri::AppHandle) -> Result<(), String> {
+    clear_saved_agent_command(&app)
+}
+
+#[tauri::command]
+fn dragon_detect_agent_clis() -> Vec<AgentCliDetectionPayload> {
+    KNOWN_AGENT_CLIS
+        .iter()
+        .map(|known_cli| {
+            let path = find_executable(known_cli.executable);
+            let available = path.is_some();
+            let version = path
+                .as_ref()
+                .and_then(|_path| {
+                    let probe_result = probe_command(known_cli.executable);
+                    if probe_result.ok {
+                        return Some(probe_result.output.trim().to_string());
+                    }
+                    None
+                })
+                .filter(|output| !output.is_empty());
+
+            AgentCliDetectionPayload {
+                id: known_cli.id.to_string(),
+                label: known_cli.label.to_string(),
+                command: known_cli.executable.to_string(),
+                path: path.map(|path| path.to_string_lossy().to_string()),
+                available,
+                version,
+            }
+        })
+        .collect()
+}
+
+#[tauri::command]
+fn dragon_test_agent_command(command: String) -> Result<AgentCommandTestPayload, String> {
+    let trimmed_command = command.trim().to_string();
+    if trimmed_command.is_empty() {
+        return Err("Agent command cannot be empty".to_string());
+    }
+
+    Ok(probe_command(&trimmed_command))
 }
 
 #[tauri::command]
@@ -286,8 +564,11 @@ fn dragon_read_directory_tree(path: String) -> Result<Vec<NativeFileTreeNode>, S
 }
 
 #[tauri::command]
-fn dragon_start_agent_run(request: AgentRunRequestPayload) -> Result<String, String> {
-    let command = configured_agent_command()?;
+fn dragon_start_agent_run(
+    app: tauri::AppHandle,
+    request: AgentRunRequestPayload,
+) -> Result<String, String> {
+    let (command, _source) = configured_agent_command(&app)?;
     let run_id = create_agent_run_id();
     let mut process = shell_command(&command);
     process.stdin(Stdio::piped());
@@ -413,6 +694,11 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             dragon_runtime_ping,
             dragon_agent_runtime_available,
+            dragon_get_agent_config,
+            dragon_save_agent_config,
+            dragon_clear_agent_config,
+            dragon_detect_agent_clis,
+            dragon_test_agent_command,
             dragon_open_text_file,
             dragon_open_directory,
             dragon_read_text_file,

--- a/src/modules/app-shell/state.ts
+++ b/src/modules/app-shell/state.ts
@@ -8,6 +8,7 @@ export function createAppShellState(): AppShellState {
     theme: "light",
     focusMode: false,
     presentationMode: false,
+    agentSettingsOpen: false,
     toast: null,
   };
 }
@@ -16,7 +17,13 @@ export function createAppShellActions<StoreState extends AppShellState>(
   set: SetState<StoreState>,
 ): Pick<
   AppShellActions,
-  "setTheme" | "toggleFocusMode" | "exitPresentationMode" | "showToast" | "dismissToast"
+  | "setTheme"
+  | "toggleFocusMode"
+  | "exitPresentationMode"
+  | "openAgentSettings"
+  | "closeAgentSettings"
+  | "showToast"
+  | "dismissToast"
 > {
   return {
     setTheme: (theme) => {
@@ -27,6 +34,12 @@ export function createAppShellActions<StoreState extends AppShellState>(
     },
     exitPresentationMode: () => {
       set({ presentationMode: false });
+    },
+    openAgentSettings: () => {
+      set({ agentSettingsOpen: true });
+    },
+    closeAgentSettings: () => {
+      set({ agentSettingsOpen: false });
     },
     showToast: (message) => {
       set({ toast: message });

--- a/src/modules/app-shell/types.ts
+++ b/src/modules/app-shell/types.ts
@@ -4,6 +4,7 @@ export interface AppShellState {
   theme: AppTheme;
   focusMode: boolean;
   presentationMode: boolean;
+  agentSettingsOpen: boolean;
   toast: string | null;
 }
 
@@ -12,6 +13,8 @@ export interface AppShellActions {
   toggleFocusMode: () => void;
   enterPresentationMode: () => void;
   exitPresentationMode: () => void;
+  openAgentSettings: () => void;
+  closeAgentSettings: () => void;
   showToast: (message: string) => void;
   dismissToast: () => void;
 }

--- a/src/runtime/agent.ts
+++ b/src/runtime/agent.ts
@@ -40,6 +40,28 @@ export interface AgentRuntimeCapability {
   unavailableMessage: string | null;
 }
 
+export type AgentConfigSource = "config" | "environment";
+
+export interface AgentConfig {
+  command: string | null;
+  source: AgentConfigSource | null;
+}
+
+export interface AgentCliDetection {
+  id: string;
+  label: string;
+  command: string;
+  path: string | null;
+  available: boolean;
+  version: string | null;
+}
+
+export interface AgentCommandTestResult {
+  ok: boolean;
+  message: string;
+  output: string;
+}
+
 export interface AgentRuntime {
   canRunAgent: boolean;
   getCapability(): Promise<AgentRuntimeCapability>;

--- a/src/runtime/desktop.ts
+++ b/src/runtime/desktop.ts
@@ -10,9 +10,14 @@ export const desktopRuntime = {
 
 export {
   assertDesktopRuntimeAvailable,
+  clearDesktopAgentConfig,
+  detectDesktopAgentClis,
   desktopAgentRuntime,
   getDesktopAgentCapability,
   getDesktopAgentCapabilityStatus,
+  getDesktopAgentConfig,
+  saveDesktopAgentConfig,
+  testDesktopAgentCommand,
 } from "./desktopAgentRuntime";
 export { desktopTerminalRuntime } from "./desktopTerminalRuntime";
 export { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";

--- a/src/runtime/desktopAgentRuntime.test.ts
+++ b/src/runtime/desktopAgentRuntime.test.ts
@@ -33,7 +33,7 @@ describe("desktop agent runtime", () => {
     await expect(getDesktopAgentCapabilityStatus()).resolves.toEqual({
       canRunAgent: false,
       unavailableMessage:
-        "Configure DRAGON_AGENT_COMMAND before starting local agent runs.",
+        "Configure a desktop agent command before starting local agent runs.",
     });
   });
 

--- a/src/runtime/desktopAgentRuntime.ts
+++ b/src/runtime/desktopAgentRuntime.ts
@@ -1,11 +1,16 @@
 import type { AgentRuntime, AgentRuntimeCapability } from "./agent";
 import {
+  clearTauriAgentConfig,
+  detectTauriAgentClis,
+  getTauriAgentConfig,
   getTauriAgentRuntimeAvailable,
   getTauriAgentRunStatus,
   hasTauriBridge,
   pingTauriRuntime,
+  saveTauriAgentConfig,
   startTauriAgentRun,
   stopTauriAgentRun,
+  testTauriAgentCommand,
 } from "./tauriBridge";
 
 export async function assertDesktopRuntimeAvailable(): Promise<void> {
@@ -35,7 +40,7 @@ export async function getDesktopAgentCapabilityStatus(): Promise<AgentRuntimeCap
     return {
       canRunAgent: false,
       unavailableMessage:
-        "Configure DRAGON_AGENT_COMMAND before starting local agent runs.",
+        "Configure a desktop agent command before starting local agent runs.",
     };
   } catch (error) {
     const unavailableMessage =
@@ -65,3 +70,28 @@ export const desktopAgentRuntime: AgentRuntime = {
     return getTauriAgentRunStatus(runId);
   },
 };
+
+export async function getDesktopAgentConfig() {
+  await assertDesktopRuntimeAvailable();
+  return getTauriAgentConfig();
+}
+
+export async function saveDesktopAgentConfig(command: string): Promise<void> {
+  await assertDesktopRuntimeAvailable();
+  await saveTauriAgentConfig(command);
+}
+
+export async function clearDesktopAgentConfig(): Promise<void> {
+  await assertDesktopRuntimeAvailable();
+  await clearTauriAgentConfig();
+}
+
+export async function detectDesktopAgentClis() {
+  await assertDesktopRuntimeAvailable();
+  return detectTauriAgentClis();
+}
+
+export async function testDesktopAgentCommand(command: string) {
+  await assertDesktopRuntimeAvailable();
+  return testTauriAgentCommand(command);
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -5,11 +5,22 @@ import type {
 } from "./workspace";
 
 export type {
+  AgentCliDetection,
+  AgentCommandTestResult,
+  AgentConfig,
+  AgentConfigSource,
   AgentRuntime,
   AgentRuntimeCapability,
   AgentRunRequest,
   AgentRuntimeRunStatus,
 } from "./agent";
+export {
+  clearDesktopAgentConfig,
+  detectDesktopAgentClis,
+  getDesktopAgentConfig,
+  saveDesktopAgentConfig,
+  testDesktopAgentCommand,
+} from "./desktopAgentRuntime";
 export type { TerminalAttachment, TerminalRuntime } from "./terminal";
 export type {
   NativeWorkspaceDirectoryTarget,

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getTauriAgentRuntimeAvailable,
+  clearTauriAgentConfig,
+  detectTauriAgentClis,
   getTauriAgentRunStatus,
+  getTauriAgentConfig,
   hasTauriBridge,
   invokeTauriCommand,
   openTauriDirectory,
@@ -9,8 +12,10 @@ import {
   pingTauriRuntime,
   readTauriDirectoryTree,
   readTauriTextFile,
+  saveTauriAgentConfig,
   startTauriAgentRun,
   stopTauriAgentRun,
+  testTauriAgentCommand,
   writeTauriTextFile,
 } from "./tauriBridge";
 
@@ -59,6 +64,91 @@ describe("tauri bridge", () => {
     };
 
     await expect(getTauriAgentRuntimeAvailable()).resolves.toBe(false);
+  });
+
+  it("reads, saves, clears, detects, and tests desktop agent setup", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
+    window.__TAURI__ = {
+      core: {
+        invoke: (command, args) => {
+          calls.push({ command, args });
+          if (command === "dragon_get_agent_config") {
+            return Promise.resolve({
+              command: "codex",
+              source: "config",
+            });
+          }
+          if (command === "dragon_detect_agent_clis") {
+            return Promise.resolve([
+              {
+                id: "codex",
+                label: "Codex",
+                command: "codex",
+                path: "C:\\Tools\\codex.exe",
+                available: true,
+                version: "codex 1.0.0",
+              },
+            ]);
+          }
+          if (command === "dragon_test_agent_command") {
+            return Promise.resolve({
+              ok: true,
+              message: "Command responded to --version",
+              output: "codex 1.0.0",
+            });
+          }
+          return Promise.resolve(null);
+        },
+      },
+    };
+
+    await expect(getTauriAgentConfig()).resolves.toEqual({
+      command: "codex",
+      source: "config",
+    });
+    await saveTauriAgentConfig("codex");
+    await clearTauriAgentConfig();
+    await expect(detectTauriAgentClis()).resolves.toEqual([
+      {
+        id: "codex",
+        label: "Codex",
+        command: "codex",
+        path: "C:\\Tools\\codex.exe",
+        available: true,
+        version: "codex 1.0.0",
+      },
+    ]);
+    await expect(testTauriAgentCommand("codex")).resolves.toEqual({
+      ok: true,
+      message: "Command responded to --version",
+      output: "codex 1.0.0",
+    });
+
+    expect(calls).toEqual([
+      {
+        command: "dragon_get_agent_config",
+        args: undefined,
+      },
+      {
+        command: "dragon_save_agent_config",
+        args: { command: "codex" },
+      },
+      {
+        command: "dragon_clear_agent_config",
+        args: undefined,
+      },
+      {
+        command: "dragon_detect_agent_clis",
+        args: undefined,
+      },
+      {
+        command: "dragon_test_agent_command",
+        args: { command: "codex" },
+      },
+    ]);
   });
 
   it("rejects unexpected command response shapes", async () => {

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -1,4 +1,11 @@
-import type { AgentRunRequest, AgentRuntimeRunStatus } from "./agent";
+import type {
+  AgentCliDetection,
+  AgentCommandTestResult,
+  AgentConfig,
+  AgentConfigSource,
+  AgentRunRequest,
+  AgentRuntimeRunStatus,
+} from "./agent";
 import type {
   NativeWorkspaceDirectoryTarget,
   NativeWorkspaceFileTarget,
@@ -7,6 +14,11 @@ import type {
 export type TauriCommand =
   | "dragon_runtime_ping"
   | "dragon_agent_runtime_available"
+  | "dragon_get_agent_config"
+  | "dragon_save_agent_config"
+  | "dragon_clear_agent_config"
+  | "dragon_detect_agent_clis"
+  | "dragon_test_agent_command"
   | "dragon_open_text_file"
   | "dragon_open_directory"
   | "dragon_read_text_file"
@@ -88,6 +100,43 @@ export async function getTauriAgentRuntimeAvailable(): Promise<boolean> {
   throw new Error("Unexpected Tauri agent capability response");
 }
 
+export async function getTauriAgentConfig(): Promise<AgentConfig> {
+  const result = await invokeTauriCommand({
+    command: "dragon_get_agent_config",
+  });
+  return parseNativeAgentConfig(result);
+}
+
+export function saveTauriAgentConfig(command: string): Promise<unknown> {
+  return invokeTauriCommand({
+    command: "dragon_save_agent_config",
+    args: { command },
+  });
+}
+
+export function clearTauriAgentConfig(): Promise<unknown> {
+  return invokeTauriCommand({
+    command: "dragon_clear_agent_config",
+  });
+}
+
+export async function detectTauriAgentClis(): Promise<AgentCliDetection[]> {
+  const result = await invokeTauriCommand({
+    command: "dragon_detect_agent_clis",
+  });
+  return parseNativeAgentCliDetections(result);
+}
+
+export async function testTauriAgentCommand(
+  command: string,
+): Promise<AgentCommandTestResult> {
+  const result = await invokeTauriCommand({
+    command: "dragon_test_agent_command",
+    args: { command },
+  });
+  return parseNativeAgentCommandTest(result);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -102,6 +151,92 @@ function readStringField(
   }
 
   throw new Error(`Unexpected native file tree ${fieldName} field`);
+}
+
+function readOptionalStringField(
+  record: Record<string, unknown>,
+  fieldName: string,
+): string | null {
+  const value = record[fieldName];
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+
+  throw new Error(`Unexpected native ${fieldName} field`);
+}
+
+function readBooleanField(
+  record: Record<string, unknown>,
+  fieldName: string,
+): boolean {
+  const value = record[fieldName];
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  throw new Error(`Unexpected native ${fieldName} field`);
+}
+
+function parseAgentConfigSource(
+  value: string | null,
+): AgentConfigSource | null {
+  if (value === null) {
+    return null;
+  }
+  if (value === "config" || value === "environment") {
+    return value;
+  }
+
+  throw new Error("Unexpected native agent config source");
+}
+
+function parseNativeAgentConfig(value: unknown): AgentConfig {
+  if (!isRecord(value)) {
+    throw new Error("Unexpected native agent config response");
+  }
+
+  return {
+    command: readOptionalStringField(value, "command"),
+    source: parseAgentConfigSource(readOptionalStringField(value, "source")),
+  };
+}
+
+function parseNativeAgentCliDetection(value: unknown): AgentCliDetection {
+  if (!isRecord(value)) {
+    throw new Error("Unexpected native agent CLI detection response");
+  }
+
+  return {
+    id: readStringField(value, "id"),
+    label: readStringField(value, "label"),
+    command: readStringField(value, "command"),
+    path: readOptionalStringField(value, "path"),
+    available: readBooleanField(value, "available"),
+    version: readOptionalStringField(value, "version"),
+  };
+}
+
+function parseNativeAgentCliDetections(value: unknown): AgentCliDetection[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Unexpected native agent CLI detections response");
+  }
+
+  return value.map(parseNativeAgentCliDetection);
+}
+
+function parseNativeAgentCommandTest(value: unknown): AgentCommandTestResult {
+  if (!isRecord(value)) {
+    throw new Error("Unexpected native agent command test response");
+  }
+
+  return {
+    ok: readBooleanField(value, "ok"),
+    message: readStringField(value, "message"),
+    output: readStringField(value, "output"),
+  };
 }
 
 function readOptionalNumberField(

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,6 +13,7 @@ import { SharedPanel } from "./components/SharedPanel";
 import { PresentationMode } from "./components/PresentationMode";
 import { UndoToast } from "./components/UndoToast";
 import { Toast } from "./components/Toast";
+import { AgentSettingsDialog } from "./components/AgentSettingsDialog";
 import { PeerNamePrompt } from "./components/PeerNamePrompt";
 import { buildVirtualTree } from "../types/fileTree";
 import { findLiveFileInTree, toFileTreeNodes } from "../types/fileTree";
@@ -156,6 +157,7 @@ function App() {
   const refreshFileTree = useAppStore((s) => s.refreshFileTree);
   const switchTab = useAppStore((s) => s.switchTab);
   const reopenTab = useAppStore((s) => s.reopenTab);
+  const agentSettingsOpen = useAppStore((s) => s.agentSettingsOpen);
 
   // Peer mode
   const isPeerMode = useAppStore((s) => s.isPeerMode);
@@ -337,7 +339,13 @@ function App() {
 
   // ── No tabs open → show FilePicker ──
   if (tabs.length === 0) {
-    return <FilePicker />;
+    return (
+      <>
+        <FilePicker />
+        <Toast />
+        {agentSettingsOpen && <AgentSettingsDialog />}
+      </>
+    );
   }
 
   // ── Presentation mode (fullscreen slideshow) ──
@@ -412,6 +420,7 @@ function App() {
       )}
       <UndoToast />
       <Toast />
+      {agentSettingsOpen && <AgentSettingsDialog />}
       {focusMode && (
         <button
           onClick={toggleFocusMode}

--- a/src/ui/components/AgentSettingsDialog/AgentSettingsDialog.css
+++ b/src/ui/components/AgentSettingsDialog/AgentSettingsDialog.css
@@ -1,0 +1,204 @@
+.agent-settings {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.agent-settings__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgb(15 23 42 / 0.35);
+}
+
+.agent-settings__panel {
+  position: relative;
+  z-index: 1;
+  width: min(34rem, 100%);
+  max-height: min(42rem, calc(100vh - 3rem));
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.agent-settings__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.agent-settings__header h2 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.agent-settings__header p {
+  margin: 0.2rem 0 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.agent-settings__close {
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--surface-alt);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.agent-settings__close:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.agent-settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.agent-settings__field label,
+.agent-settings__section-title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.agent-settings__field input {
+  min-height: 2.25rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.agent-settings__field input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.agent-settings__detections {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.agent-settings__detection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--surface-alt);
+}
+
+.agent-settings__detection-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+.agent-settings__detection-copy strong {
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.agent-settings__detection-copy span,
+.agent-settings__status {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.agent-settings__detection-copy code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.agent-settings__error,
+.agent-settings__test {
+  padding: 0.6rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.agent-settings__error,
+.agent-settings__test--failed {
+  border: 1px solid color-mix(in srgb, var(--c-red) 35%, var(--border));
+  background: color-mix(in srgb, var(--surface) 88%, var(--c-red) 12%);
+  color: var(--text);
+}
+
+.agent-settings__test--ok {
+  border: 1px solid color-mix(in srgb, var(--c-green) 35%, var(--border));
+  background: color-mix(in srgb, var(--surface) 88%, var(--c-green) 12%);
+  color: var(--text);
+}
+
+.agent-settings__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.agent-settings__primary,
+.agent-settings__secondary {
+  min-height: 2rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 650;
+}
+
+.agent-settings__primary {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+
+.agent-settings__secondary {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-secondary);
+}
+
+.agent-settings__primary:hover,
+.agent-settings__secondary:hover {
+  filter: brightness(0.98);
+}
+
+.agent-settings__primary:disabled,
+.agent-settings__secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}

--- a/src/ui/components/AgentSettingsDialog/AgentSettingsDialog.test.tsx
+++ b/src/ui/components/AgentSettingsDialog/AgentSettingsDialog.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../../store";
+import { resetTestStore } from "../../../testing/testHelpers";
+import { AgentSettingsDialog } from "./AgentSettingsDialog";
+
+const runtimeMocks = vi.hoisted(() => ({
+  getDesktopAgentConfig: vi.fn(),
+  detectDesktopAgentClis: vi.fn(),
+  saveDesktopAgentConfig: vi.fn(),
+  clearDesktopAgentConfig: vi.fn(),
+  testDesktopAgentCommand: vi.fn(),
+}));
+
+vi.mock("../../../runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../runtime")>();
+  return {
+    ...actual,
+    ...runtimeMocks,
+  };
+});
+
+beforeEach(() => {
+  resetTestStore();
+  vi.restoreAllMocks();
+  runtimeMocks.getDesktopAgentConfig.mockResolvedValue({
+    command: null,
+    source: null,
+  });
+  runtimeMocks.detectDesktopAgentClis.mockResolvedValue([
+    {
+      id: "codex",
+      label: "Codex",
+      command: "codex",
+      path: "C:\\Tools\\codex.exe",
+      available: true,
+      version: "codex 1.0.0",
+    },
+  ]);
+  runtimeMocks.saveDesktopAgentConfig.mockResolvedValue(undefined);
+  runtimeMocks.clearDesktopAgentConfig.mockResolvedValue(undefined);
+  runtimeMocks.testDesktopAgentCommand.mockResolvedValue({
+    ok: true,
+    message: "Command responded to --version",
+    output: "codex 1.0.0",
+  });
+});
+
+describe("AgentSettingsDialog", () => {
+  it("loads detected CLIs and saves the selected command", async () => {
+    const user = userEvent.setup();
+    useAppStore.setState({ agentSettingsOpen: true });
+
+    render(<AgentSettingsDialog />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Desktop agent" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Codex")).toBeInTheDocument();
+    expect(screen.getByText("C:\\Tools\\codex.exe")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Use" }));
+    expect(screen.getByLabelText("Command")).toHaveValue("codex");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(runtimeMocks.saveDesktopAgentConfig).toHaveBeenCalledWith("codex");
+    });
+    expect(useAppStore.getState().toast).toBe("Agent command saved");
+    expect(useAppStore.getState().agentSettingsOpen).toBe(false);
+  });
+
+  it("tests the configured command", async () => {
+    const user = userEvent.setup();
+
+    render(<AgentSettingsDialog />);
+
+    await user.click(await screen.findByRole("button", { name: "Use" }));
+    await user.click(screen.getByRole("button", { name: "Test" }));
+
+    await waitFor(() => {
+      expect(runtimeMocks.testDesktopAgentCommand).toHaveBeenCalledWith(
+        "codex",
+      );
+    });
+    expect(
+      screen.getByText(/Command responded to --version/),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/ui/components/AgentSettingsDialog/AgentSettingsDialog.tsx
+++ b/src/ui/components/AgentSettingsDialog/AgentSettingsDialog.tsx
@@ -1,0 +1,290 @@
+import "./AgentSettingsDialog.css";
+import { useEffect, useState } from "react";
+import {
+  clearDesktopAgentConfig,
+  detectDesktopAgentClis,
+  getDesktopAgentConfig,
+  saveDesktopAgentConfig,
+  testDesktopAgentCommand,
+} from "../../../runtime";
+import type {
+  AgentCliDetection,
+  AgentCommandTestResult,
+  AgentConfig,
+} from "../../../runtime";
+import { useAppStore } from "../../../store";
+
+const EMPTY_DETECTIONS: AgentCliDetection[] = [];
+const EMPTY_CONFIG: AgentConfig = {
+  command: null,
+  source: null,
+};
+
+function configSourceLabel(config: AgentConfig): string {
+  if (config.source === "config") {
+    return "Saved in Dragon";
+  }
+  if (config.source === "environment") {
+    return "From DRAGON_AGENT_COMMAND";
+  }
+  return "Not configured";
+}
+
+function detectionStatus(detection: AgentCliDetection): string {
+  if (!detection.available) {
+    return "Not found";
+  }
+  return detection.path ?? "Found on PATH";
+}
+
+function testResultLabel(result: AgentCommandTestResult): string {
+  if (result.output.trim()) {
+    return `${result.message}: ${result.output.trim()}`;
+  }
+  return result.message;
+}
+
+export function AgentSettingsDialog() {
+  const closeAgentSettings = useAppStore((state) => state.closeAgentSettings);
+  const showToast = useAppStore((state) => state.showToast);
+  const [config, setConfig] = useState<AgentConfig>(EMPTY_CONFIG);
+  const [detections, setDetections] =
+    useState<AgentCliDetection[]>(EMPTY_DETECTIONS);
+  const [command, setCommand] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<AgentCommandTestResult | null>(
+    null,
+  );
+
+  async function reloadSettings() {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const [nextConfig, nextDetections] = await Promise.all([
+        getDesktopAgentConfig(),
+        detectDesktopAgentClis(),
+      ]);
+      setConfig(nextConfig);
+      setCommand(nextConfig.command ?? "");
+      setDetections(nextDetections);
+    } catch (error) {
+      console.error(
+        "[AgentSettingsDialog] failed to load agent settings:",
+        error,
+      );
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Agent settings failed to load.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleSave() {
+    const trimmedCommand = command.trim();
+    if (!trimmedCommand) {
+      setErrorMessage("Agent command cannot be empty.");
+      return;
+    }
+
+    setSaving(true);
+    setErrorMessage(null);
+    try {
+      await saveDesktopAgentConfig(trimmedCommand);
+      const nextConfig = await getDesktopAgentConfig();
+      setConfig(nextConfig);
+      setCommand(nextConfig.command ?? trimmedCommand);
+      showToast("Agent command saved");
+      closeAgentSettings();
+    } catch (error) {
+      console.error(
+        "[AgentSettingsDialog] failed to save agent settings:",
+        error,
+      );
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Agent command failed to save.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setSaving(true);
+    setErrorMessage(null);
+    try {
+      await clearDesktopAgentConfig();
+      const nextConfig = await getDesktopAgentConfig();
+      setConfig(nextConfig);
+      setCommand(nextConfig.command ?? "");
+      setTestResult(null);
+      showToast("Agent command cleared");
+    } catch (error) {
+      console.error(
+        "[AgentSettingsDialog] failed to clear agent settings:",
+        error,
+      );
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Agent command failed to clear.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleTest() {
+    const trimmedCommand = command.trim();
+    if (!trimmedCommand) {
+      setErrorMessage("Agent command cannot be empty.");
+      return;
+    }
+
+    setTesting(true);
+    setErrorMessage(null);
+    setTestResult(null);
+    try {
+      const result = await testDesktopAgentCommand(trimmedCommand);
+      setTestResult(result);
+    } catch (error) {
+      console.error(
+        "[AgentSettingsDialog] failed to test agent command:",
+        error,
+      );
+      setErrorMessage(
+        error instanceof Error ? error.message : "Agent command test failed.",
+      );
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  useEffect(() => {
+    void reloadSettings();
+  }, []);
+
+  return (
+    <div className="agent-settings" role="dialog" aria-modal="true">
+      <div className="agent-settings__backdrop" onClick={closeAgentSettings} />
+      <section
+        className="agent-settings__panel"
+        aria-labelledby="agent-settings-title"
+      >
+        <header className="agent-settings__header">
+          <div>
+            <h2 id="agent-settings-title">Desktop agent</h2>
+            <p>{configSourceLabel(config)}</p>
+          </div>
+          <button
+            className="agent-settings__close"
+            onClick={closeAgentSettings}
+            aria-label="Close agent settings"
+          >
+            x
+          </button>
+        </header>
+
+        {loading ? (
+          <p className="agent-settings__status">Loading agent settings...</p>
+        ) : (
+          <>
+            <div className="agent-settings__field">
+              <label htmlFor="agent-command">Command</label>
+              <input
+                id="agent-command"
+                value={command}
+                onChange={(event) => {
+                  setCommand(event.target.value);
+                  setTestResult(null);
+                }}
+                placeholder="codex"
+              />
+            </div>
+
+            <div className="agent-settings__detections">
+              <span className="agent-settings__section-title">
+                Detected CLIs
+              </span>
+              {detections.map((detection) => (
+                <div className="agent-settings__detection" key={detection.id}>
+                  <div className="agent-settings__detection-copy">
+                    <strong>{detection.label}</strong>
+                    <span>{detectionStatus(detection)}</span>
+                    {detection.version && <code>{detection.version}</code>}
+                  </div>
+                  <button
+                    className="agent-settings__secondary"
+                    onClick={() => {
+                      setCommand(detection.command);
+                      setTestResult(null);
+                    }}
+                    disabled={!detection.available}
+                  >
+                    Use
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            {errorMessage && (
+              <div className="agent-settings__error" role="alert">
+                {errorMessage}
+              </div>
+            )}
+
+            {testResult && (
+              <div
+                className={
+                  testResult.ok
+                    ? "agent-settings__test agent-settings__test--ok"
+                    : "agent-settings__test agent-settings__test--failed"
+                }
+                role="status"
+              >
+                {testResultLabel(testResult)}
+              </div>
+            )}
+
+            <footer className="agent-settings__actions">
+              <button
+                className="agent-settings__secondary"
+                onClick={() => {
+                  void handleClear();
+                }}
+                disabled={saving}
+              >
+                Clear
+              </button>
+              <button
+                className="agent-settings__secondary"
+                onClick={() => {
+                  void handleTest();
+                }}
+                disabled={testing || saving}
+              >
+                {testing ? "Testing..." : "Test"}
+              </button>
+              <button
+                className="agent-settings__primary"
+                onClick={() => {
+                  void handleSave();
+                }}
+                disabled={saving}
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </footer>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/ui/components/AgentSettingsDialog/index.ts
+++ b/src/ui/components/AgentSettingsDialog/index.ts
@@ -1,0 +1,1 @@
+export { AgentSettingsDialog } from "./AgentSettingsDialog";

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -206,6 +206,9 @@
 }
 
 .comment-panel__agent-capability {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   border-bottom: 1px solid
     color-mix(in srgb, var(--c-orange) 35%, var(--border));
@@ -213,6 +216,27 @@
   color: var(--text-secondary);
   font-size: 0.74rem;
   line-height: 1.35;
+}
+
+.comment-panel__agent-capability span {
+  min-width: 0;
+  flex: 1;
+}
+
+.comment-panel__agent-capability-action {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 650;
+  padding: 0.18rem 0.5rem;
+}
+
+.comment-panel__agent-capability-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .comment-panel__close {

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -187,6 +187,8 @@ export function CommentPanel({ peerMode = false }: Props) {
   const setCommentFilter = useAppStore((state) => state.setCommentFilter);
   const toggleCommentPanel = useAppStore((state) => state.toggleCommentPanel);
   const showToast = useAppStore((state) => state.showToast);
+  const openAgentSettings = useAppStore((state) => state.openAgentSettings);
+  const agentSettingsOpen = useAppStore((state) => state.agentSettingsOpen);
   const myPeerComments = useAppStore((state) => state.myPeerComments);
   const peerActiveFilePath = useAppStore((state) => state.peerActiveFilePath);
   const activeFilePath = peerMode
@@ -328,6 +330,7 @@ export function CommentPanel({ peerMode = false }: Props) {
   const hasAddressableComments = isFolderMode
     ? folderAddressableCommentTargets.length > 0
     : addressableCommentTargets.length > 0;
+  const shouldPromptAgentSetup = canRunAgent && !agentCapability.canRunAgent;
 
   const isResolved = !peerMode && commentFilter === "resolved";
 
@@ -432,11 +435,11 @@ export function CommentPanel({ peerMode = false }: Props) {
   }
 
   const addressCommentsAgentAction = getAddressCommentsAgentAction({
-    canRunAgent: agentCapability.canRunAgent,
+    canRunAgent: agentCapability.canRunAgent || shouldPromptAgentSetup,
     canStartAddressCommentsRun: hasAddressableComments,
   });
   const questionThreadAgentAction = getQuestionThreadAgentAction({
-    canRunAgent: agentCapability.canRunAgent,
+    canRunAgent: agentCapability.canRunAgent || shouldPromptAgentSetup,
     canStartQuestionThreadRun: hasQuestionThreads,
   });
   const canStopAgentRun = Boolean(
@@ -465,6 +468,10 @@ export function CommentPanel({ peerMode = false }: Props) {
 
     const result = await startQuestionThreadAgentRun();
     if (result.status === "unavailable") {
+      if (canRunAgent && result.reason === "agent_unavailable") {
+        openAgentSettings();
+        return;
+      }
       showToast(result.message);
     }
   }
@@ -477,6 +484,10 @@ export function CommentPanel({ peerMode = false }: Props) {
 
     const result = await startAddressCommentsAgentRun();
     if (result.status === "unavailable") {
+      if (canRunAgent && result.reason === "agent_unavailable") {
+        openAgentSettings();
+        return;
+      }
       showToast(result.message);
     }
   }
@@ -560,7 +571,7 @@ export function CommentPanel({ peerMode = false }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [peerMode]);
+  }, [agentSettingsOpen, peerMode]);
 
   useEffect(() => {
     const activePanelCommentId = peerMode
@@ -691,7 +702,13 @@ export function CommentPanel({ peerMode = false }: Props) {
 
       {showAgentCapabilityWarning && (
         <div className="comment-panel__agent-capability" role="status">
-          {agentCapability.unavailableMessage}
+          <span>{agentCapability.unavailableMessage}</span>
+          <button
+            className="comment-panel__agent-capability-action"
+            onClick={openAgentSettings}
+          >
+            Set up
+          </button>
         </div>
       )}
 

--- a/src/ui/components/FilePicker/FilePicker.tsx
+++ b/src/ui/components/FilePicker/FilePicker.tsx
@@ -1,6 +1,7 @@
 import "../../styles/landing.css";
 import { useEffect, useState } from "react";
 import { useAppStore } from "../../../store";
+import { canRunAgent } from "../../../runtime";
 
 /* ═══════════════════════════════════════════════════════════════════
    bauhaus palette
@@ -672,6 +673,7 @@ function GeoCookingDragon() {
 export function FilePicker() {
   const openFile = useAppStore((s) => s.openFileInNewTab);
   const openDirectory = useAppStore((s) => s.openDirectoryInNewTab);
+  const openAgentSettings = useAppStore((s) => s.openAgentSettings);
 
   return (
     <div className="landing">
@@ -758,6 +760,14 @@ export function FilePicker() {
             >
               open folder
             </button>
+            {canRunAgent && (
+              <button
+                onClick={openAgentSettings}
+                className="bh-btn bh-btn--secondary"
+              >
+                agent setup
+              </button>
+            )}
           </div>
         </div>
       </section>

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -12,6 +12,7 @@ import { WORKER_URL } from "../../../config";
 import { syncActiveShares } from "../../../modules/sharing";
 import { downloadActiveFile } from "./downloadActiveFile";
 import { tabRequiresRestoreAccess } from "../../../types/tab";
+import { canRunAgent } from "../../../runtime";
 
 function FocusIcon() {
   return (
@@ -258,6 +259,29 @@ function PresentIcon() {
   );
 }
 
+function AgentIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="4" y="6" width="16" height="12" rx="2" />
+      <path d="M8 10h.01" />
+      <path d="M16 10h.01" />
+      <path d="M9 14h6" />
+      <path d="M12 2v4" />
+    </svg>
+  );
+}
+
 interface Props {
   peerMode?: boolean;
   onShareFile?: () => void;
@@ -280,6 +304,7 @@ export function Header({
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const toggleCommentPanel = useAppStore((s) => s.toggleCommentPanel);
   const toggleSharedPanel = useAppStore((s) => s.toggleSharedPanel);
+  const openAgentSettings = useAppStore((s) => s.openAgentSettings);
   const syncPeerComments = useAppStore((s) => s.syncPeerComments);
   const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
 
@@ -441,6 +466,18 @@ export function Header({
           )}
 
           <div className="app-header__group app-header__group--view">
+            {!peerMode && canRunAgent && (
+              <button
+                onClick={openAgentSettings}
+                aria-label="Configure desktop agent"
+                title="Configure desktop agent"
+                className="app-header__btn app-header__btn--text"
+              >
+                <AgentIcon />
+                <span className="app-header__btn-label">Agent</span>
+              </button>
+            )}
+
             <TableOfContents peerMode={peerMode} />
 
             <button

--- a/src/ui/components/PendingCommentReview/PendingCommentReview.tsx
+++ b/src/ui/components/PendingCommentReview/PendingCommentReview.tsx
@@ -39,6 +39,8 @@ export function PendingCommentReview({ docId }: Props) {
     (state) => state.clearPendingComments,
   );
   const showToast = useAppStore((state) => state.showToast);
+  const openAgentSettings = useAppStore((state) => state.openAgentSettings);
+  const agentSettingsOpen = useAppStore((state) => state.agentSettingsOpen);
   const startPeerCommentsAgentRun = useAppStore(
     (state) => state.startPeerCommentsAgentRun,
   );
@@ -60,8 +62,9 @@ export function PendingCommentReview({ docId }: Props) {
   const canStopAgentRun = Boolean(
     activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
   );
+  const shouldPromptAgentSetup = canRunAgent && !agentCapability.canRunAgent;
   const peerCommentsAgentAction = getPeerCommentsAgentAction({
-    canRunAgent: agentCapability.canRunAgent,
+    canRunAgent: agentCapability.canRunAgent || shouldPromptAgentSetup,
     canStartPeerCommentsRun: comments.length > 0 && !canStopAgentRun,
   });
 
@@ -96,6 +99,10 @@ export function PendingCommentReview({ docId }: Props) {
 
     const result = await startPeerCommentsAgentRun(docId);
     if (result.status === "unavailable") {
+      if (canRunAgent && result.reason === "agent_unavailable") {
+        openAgentSettings();
+        return;
+      }
       showToast(result.message);
     }
   }
@@ -124,7 +131,7 @@ export function PendingCommentReview({ docId }: Props) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [agentSettingsOpen]);
 
   if (comments.length === 0) {
     return <p className="pending-review__empty">No pending comments.</p>;


### PR DESCRIPTION
## Summary
- add persisted desktop agent command config with environment fallback
- add native CLI detection and safe `--version` command testing for known agent CLIs
- add Agent settings UI plus header, landing, and inline setup entry points from agent actions
- update desktop agent docs to reflect the implemented setup flow

## Verification
- `npm run typecheck`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- changed-file lint: `npx eslint <changed web files> --quiet`
- `npm test`
- `npm run build`
- `npm run desktop:build`

## Note
- `npm run lint -- --quiet` still fails on the existing unrelated `worker/src/index.ts:129` `@typescript-eslint/no-unsafe-return` issue.