### PR TITLE
feat: persist desktop agent runs

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -6,7 +6,7 @@ Desktop agent foundation implemented. The shared runtime boundary, Tauri shell,
 native file/folder targets, configurable desktop agent runner, tab-scoped run
 state, and bounded comment-driven agent actions have landed incrementally.
 Remaining work depends on explicit backend decisions for terminal attachment,
-session persistence, and future structured runners.
+and future structured runners.
 
 ## Summary
 
@@ -300,6 +300,13 @@ can show progress without depending on terminal text as the lifecycle protocol.
 The comment panel polls this status only when the active runtime can execute
 agents, then reconciles the tab-scoped serializable run state to `completed` or
 `failed`.
+
+Run-persistence implementation note: serializable agent run metadata is now part
+of the persisted app store. Frontend reloads restore the active run mapping and
+continue polling the native runtime id. Full desktop process restarts do not
+claim to resurrect OS child processes; if the native runtime id is no longer
+known, the next status sync marks the restored run failed with the native
+`not_found` message.
 
 Tab-close implementation note: the workspace close action now checks the
 tab-scoped active run map before removing a tab. Tabs with queued, running, or

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -5,8 +5,7 @@
 Desktop agent foundation implemented. The website remains available, and the
 desktop path now covers native file/folder targets plus UI-started agent runs for
 comment review tasks. Remaining work is limited to explicit backend/product
-decisions such as terminal attachment, session persistence, and future
-structured runners.
+decisions such as terminal attachment and future structured runners.
 
 ## Problem
 
@@ -257,6 +256,11 @@ outside this first desktop planning scope.
   comment count.
 - Native runner stdout and stderr are captured into a bounded output tail shown
   on the active run panel for same-window observability.
+- Serializable agent run metadata is persisted with the app store. After a
+  reload, Dragon restores the tab-scoped run record and continues polling the
+  native runtime id when one exists. If the desktop process restarted and the
+  native run no longer exists, the next status sync marks the run failed instead
+  of silently losing the state.
 - Closing a tab with a queued, running, or attention-needed run is blocked until
   the user stops the run or it finishes.
 - Active-file unresolved comments now have a comment-panel action: desktop
@@ -282,8 +286,6 @@ outside this first desktop planning scope.
 
 - What is the minimum Windows backend for terminal/session support if `tmux` is
   not available?
-- How much agent terminal/session persistence should desktop restore across app
-  restarts?
 - Which structured runner should follow the first configurable terminal-command
   runner?
 

--- a/src/modules/agent-workflow/state.ts
+++ b/src/modules/agent-workflow/state.ts
@@ -1,6 +1,8 @@
 import type { StoreApi } from "zustand";
 import type {
   AgentRun,
+  AgentRunTaskKind,
+  AgentRunnerKind,
   AgentRunStatus,
   AgentWorkflowActions,
   AgentWorkflowState,
@@ -18,6 +20,156 @@ export function createAgentWorkflowState(): AgentWorkflowState {
   return {
     agentRuns: {},
     activeAgentRunIdByTabId: {},
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isAgentRunStatus(value: unknown): value is AgentRunStatus {
+  return (
+    value === "queued" ||
+    value === "running" ||
+    value === "needs_attention" ||
+    value === "completed" ||
+    value === "failed" ||
+    value === "stopped"
+  );
+}
+
+function isAgentRunTaskKind(value: unknown): value is AgentRunTaskKind {
+  return (
+    value === "address_comments" ||
+    value === "answer_questions" ||
+    value === "review_peer_comments"
+  );
+}
+
+function isAgentRunnerKind(value: unknown): value is AgentRunnerKind {
+  return value === "terminal" || value === "codex_app_server";
+}
+
+function nullableString(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return undefined;
+}
+
+function hydrateAgentRun(value: unknown): AgentRun | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const id = value["id"];
+  const tabId = value["tabId"];
+  const status = value["status"];
+  const taskKind = value["taskKind"];
+  const targetPaths = value["targetPaths"];
+  const selectedCommentIds = value["selectedCommentIds"];
+  const prompt = value["prompt"];
+  const createdAt = value["createdAt"];
+  const completedAt = nullableString(value["completedAt"]);
+  const runnerKind = nullableString(value["runnerKind"]);
+  const terminalAttachmentId = nullableString(value["terminalAttachmentId"]);
+  const errorMessage = nullableString(value["errorMessage"]);
+  const output = value["output"];
+
+  if (
+    typeof id !== "string" ||
+    typeof tabId !== "string" ||
+    !isAgentRunStatus(status) ||
+    !isAgentRunTaskKind(taskKind) ||
+    !isStringArray(targetPaths) ||
+    !isStringArray(selectedCommentIds) ||
+    typeof prompt !== "string" ||
+    typeof createdAt !== "string" ||
+    completedAt === undefined ||
+    runnerKind === undefined ||
+    terminalAttachmentId === undefined ||
+    errorMessage === undefined ||
+    typeof output !== "string"
+  ) {
+    return null;
+  }
+
+  if (runnerKind !== null && !isAgentRunnerKind(runnerKind)) {
+    return null;
+  }
+
+  return {
+    id,
+    tabId,
+    status,
+    taskKind,
+    targetPaths,
+    selectedCommentIds,
+    prompt,
+    createdAt,
+    completedAt,
+    runnerKind,
+    terminalAttachmentId,
+    errorMessage,
+    output,
+  };
+}
+
+function hydrateAgentRuns(value: unknown): Record<string, AgentRun> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const runs: Record<string, AgentRun> = {};
+  for (const runValue of Object.values(value)) {
+    const run = hydrateAgentRun(runValue);
+    if (run) {
+      runs[run.id] = run;
+    }
+  }
+  return runs;
+}
+
+function hydrateActiveRunMap(
+  value: unknown,
+  agentRuns: Record<string, AgentRun>,
+): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const activeByTabId: Record<string, string> = {};
+  for (const [tabId, runId] of Object.entries(value)) {
+    if (typeof runId !== "string") {
+      continue;
+    }
+    const run = agentRuns[runId];
+    if (run?.tabId === tabId) {
+      activeByTabId[tabId] = runId;
+    }
+  }
+  return activeByTabId;
+}
+
+export function hydrateAgentWorkflowState(value: unknown): AgentWorkflowState {
+  if (!isRecord(value)) {
+    return createAgentWorkflowState();
+  }
+
+  const agentRuns = hydrateAgentRuns(value["agentRuns"]);
+  return {
+    agentRuns,
+    activeAgentRunIdByTabId: hydrateActiveRunMap(
+      value["activeAgentRunIdByTabId"],
+      agentRuns,
+    ),
   };
 }
 

--- a/src/modules/agent-workflow/test/agentWorkflowState.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowState.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "../../../store";
 import { resetTestStore } from "../../../testing/testHelpers";
 import { getActiveAgentRunForTab, hasActiveAgentRunForTab } from "../selectors";
+import { hydrateAgentWorkflowState } from "../state";
 
 beforeEach(() => {
   resetTestStore();
@@ -12,6 +13,24 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getPersistedStoreState(): Record<string, unknown> {
+  const raw = localStorage.getItem("markreview-store");
+  if (!raw) {
+    throw new Error("Expected markreview-store to be persisted");
+  }
+
+  const parsed: unknown = JSON.parse(raw);
+  if (!isRecord(parsed) || !isRecord(parsed["state"])) {
+    throw new Error("Expected persisted store state object");
+  }
+
+  return parsed["state"];
+}
 
 describe("agent workflow state", () => {
   it("creates a queued run scoped to one tab", () => {
@@ -99,5 +118,121 @@ describe("agent workflow state", () => {
     const state = useAppStore.getState();
     expect(state.agentRuns[run.id]).toBeUndefined();
     expect(state.activeAgentRunIdByTabId["tab-1"]).toBeUndefined();
+  });
+
+  it("persists serializable run metadata", () => {
+    localStorage.removeItem("markreview-store");
+    const run = useAppStore.getState().createAgentRun({
+      tabId: "tab-1",
+      taskKind: "address_comments",
+      targetPaths: ["docs/spec.md"],
+      selectedCommentIds: ["comment-1"],
+      prompt: "Fix comments",
+      runnerKind: "terminal",
+    });
+    useAppStore.getState().updateAgentRunStatus({
+      runId: run.id,
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+      output: "Started\n",
+    });
+
+    const persistedState = getPersistedStoreState();
+    const agentRuns = persistedState["agentRuns"];
+    const activeByTabId = persistedState["activeAgentRunIdByTabId"];
+    if (!isRecord(agentRuns) || !isRecord(activeByTabId)) {
+      throw new Error("Expected persisted agent workflow records");
+    }
+
+    expect(agentRuns[run.id]).toMatchObject({
+      id: run.id,
+      tabId: "tab-1",
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+      output: "Started\n",
+    });
+    expect(activeByTabId["tab-1"]).toBe(run.id);
+  });
+
+  it("hydrates persisted run metadata and active tab mapping", () => {
+    const hydrated = hydrateAgentWorkflowState({
+      agentRuns: {
+        "run-1": {
+          id: "run-1",
+          tabId: "tab-1",
+          status: "running",
+          taskKind: "address_comments",
+          targetPaths: ["docs/spec.md"],
+          selectedCommentIds: ["comment-1"],
+          prompt: "Fix comments",
+          createdAt: "2026-06-12T18:00:00.000Z",
+          completedAt: null,
+          runnerKind: "terminal",
+          terminalAttachmentId: "native-run-1",
+          errorMessage: null,
+          output: "Started\n",
+        },
+      },
+      activeAgentRunIdByTabId: {
+        "tab-1": "run-1",
+      },
+    });
+
+    expect(hydrated.agentRuns["run-1"]).toMatchObject({
+      id: "run-1",
+      tabId: "tab-1",
+      status: "running",
+      terminalAttachmentId: "native-run-1",
+      output: "Started\n",
+    });
+    expect(hydrated.activeAgentRunIdByTabId["tab-1"]).toBe("run-1");
+  });
+
+  it("drops malformed persisted runs and stale active tab mappings", () => {
+    const hydrated = hydrateAgentWorkflowState({
+      agentRuns: {
+        "run-1": {
+          id: "run-1",
+          tabId: "tab-1",
+          status: "running",
+          taskKind: "address_comments",
+          targetPaths: ["docs/spec.md"],
+          selectedCommentIds: [],
+          prompt: "Fix comments",
+          createdAt: "2026-06-12T18:00:00.000Z",
+          completedAt: null,
+          runnerKind: "terminal",
+          terminalAttachmentId: "native-run-1",
+          errorMessage: null,
+          output: "",
+        },
+        "run-2": {
+          id: "run-2",
+          tabId: "tab-2",
+          status: "not-a-real-status",
+          taskKind: "address_comments",
+          targetPaths: ["docs/spec.md"],
+          selectedCommentIds: [],
+          prompt: "Fix comments",
+          createdAt: "2026-06-12T18:00:00.000Z",
+          completedAt: null,
+          runnerKind: "terminal",
+          terminalAttachmentId: "native-run-2",
+          errorMessage: null,
+          output: "",
+        },
+      },
+      activeAgentRunIdByTabId: {
+        "tab-1": "run-1",
+        "tab-2": "run-2",
+        "tab-3": "missing-run",
+        "wrong-tab": "run-1",
+      },
+    });
+
+    expect(Object.keys(hydrated.agentRuns)).toEqual(["run-1"]);
+    expect(hydrated.activeAgentRunIdByTabId).toEqual({
+      "tab-1": "run-1",
+    });
   });
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,6 +4,7 @@ import {
   createAgentWorkflowActions,
   createAgentWorkflowControllerActions,
   createAgentWorkflowState,
+  hydrateAgentWorkflowState,
 } from "../modules/agent-workflow";
 import type {
   AgentWorkflowActions,
@@ -352,6 +353,8 @@ export const useAppStore = create<AppState>()(
         peerName: s.peerName,
         myPeerComments: s.myPeerComments,
         submittedPeerCommentIds: s.submittedPeerCommentIds,
+        agentRuns: s.agentRuns,
+        activeAgentRunIdByTabId: s.activeAgentRunIdByTabId,
       }),
       merge: (persisted, current) => {
         if (typeof persisted !== "object" || persisted === null) {
@@ -370,12 +373,12 @@ export const useAppStore = create<AppState>()(
           : current.tabs;
         const relayDefaults = createRelayState();
         const peerReviewDefaults = createPeerReviewState();
-        const agentWorkflowDefaults = createAgentWorkflowState();
+        const agentWorkflowState = hydrateAgentWorkflowState(p);
         return {
           ...current,
           ...p,
           tabs,
-          ...agentWorkflowDefaults,
+          ...agentWorkflowState,
           ...peerReviewDefaults,
           submittedPeerCommentIds: Array.isArray(p.submittedPeerCommentIds)
             ? p.submittedPeerCommentIds


### PR DESCRIPTION
## Summary
- persist serializable desktop agent run metadata in the app store
- hydrate persisted runs and active tab mappings through a boundary parser
- document reload/restart behavior for desktop agent runs

## Verification
- npm run typecheck
- npx vitest run src/modules/agent-workflow/test/agentWorkflowState.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/modules/workspace/test/history.test.ts
- changed-file lint with `npx eslint <changed files> --quiet`
- npm test
- npm run build
- npm run desktop:build

## Known unrelated check
- `npm run lint -- --quiet` still fails on existing `worker/src/index.ts:129` with `@typescript-eslint/no-unsafe-return`.