### PR TITLE
feat: add agent terminal output panel

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -96,7 +96,7 @@ Constraints:
 
 - Host mode still depends on browser file APIs.
 - Local agent execution is unavailable.
-- Terminal/session display is unavailable.
+- Local terminal/session display is unavailable.
 
 ### Desktop Runtime
 
@@ -300,6 +300,12 @@ can show progress without depending on terminal text as the lifecycle protocol.
 The comment panel polls this status only when the active runtime can execute
 agents, then reconciles the tab-scoped serializable run state to `completed` or
 `failed`.
+
+Terminal-output implementation note: the first visible terminal surface is a
+read-only, collapsible output view in the active run panel. It uses the native
+runner's bounded stdout/stderr tail and intentionally does not expose a PTY or
+store terminal objects in Zustand. Interactive session attachment remains a
+separate backend decision behind the terminal runtime boundary.
 
 Run-persistence implementation note: serializable agent run metadata is now part
 of the persisted app store. Frontend reloads restore the active run mapping and

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -131,6 +131,8 @@ Acceptance criteria:
 
 - The desktop runtime can expose the raw session for a run when the backend
   supports it.
+- The first implementation may expose a read-only terminal output panel backed
+  by the native runner's captured stdout/stderr.
 - The terminal is not the primary product surface by default.
 - Hiding the terminal does not stop the run.
 - Closing a tab with an active run requires an explicit user decision.
@@ -254,8 +256,9 @@ outside this first desktop planning scope.
   can copy that exact prompt for inspection or manual recovery.
 - The active run panel shows the run task, target path summary, and selected
   comment count.
-- Native runner stdout and stderr are captured into a bounded output tail shown
-  on the active run panel for same-window observability.
+- Native runner stdout and stderr are captured into a bounded output tail. The
+  active run panel exposes that tail through a collapsible terminal output view
+  for same-window observability.
 - Serializable agent run metadata is persisted with the app store. After a
   reload, Dragon restores the tab-scoped run record and continues polling the
   native runtime id when one exists. If the desktop process restarted and the
@@ -284,8 +287,8 @@ outside this first desktop planning scope.
 
 ## Remaining Backend Decisions
 
-- What is the minimum Windows backend for terminal/session support if `tmux` is
-  not available?
+- What is the minimum Windows backend for interactive PTY/session support if
+  `tmux` is not available?
 - Which structured runner should follow the first configurable terminal-command
   runner?
 

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -167,13 +167,37 @@
   color: var(--c-red);
 }
 
+.comment-panel__agent-run-terminal {
+  margin-top: 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.comment-panel__agent-run-terminal-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border-light);
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.66rem;
+}
+
+.comment-panel__agent-run-terminal-bar span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .comment-panel__agent-run-output {
   max-height: 9rem;
   overflow: auto;
-  margin: 0.25rem 0 0;
+  margin: 0;
   padding: 0.5rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
   background: var(--surface);
   color: var(--text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -402,10 +402,19 @@ describe("CommentPanel — agent prompt", () => {
     expect(
       screen.getByText("Answer questions · spec.md · 1 comment"),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Working on questions/)).toBeInTheDocument();
+    expect(screen.queryByText(/Working on questions/)).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Copy agent prompt" }),
     ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show terminal" }));
+    expect(
+      screen.getByRole("log", { name: "Agent terminal output" }),
+    ).toHaveTextContent("native-run-1");
+    expect(screen.getByText(/Working on questions/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Hide terminal" }));
+    expect(screen.queryByText(/Working on questions/)).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Copy prompt" }));
     expect(writeText).toHaveBeenCalledWith(

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -219,6 +219,7 @@ export function CommentPanel({ peerMode = false }: Props) {
   );
   const sharedContent = useAppStore((state) => state.sharedContent);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+  const [agentRunTerminalOpen, setAgentRunTerminalOpen] = useState(false);
   const [agentCapability, setAgentCapability] = useState(
     INITIAL_AGENT_CAPABILITY,
   );
@@ -446,6 +447,7 @@ export function CommentPanel({ peerMode = false }: Props) {
     activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
   );
   const showAgentRunStatus = !peerMode && activeAgentRun;
+  const activeAgentRunId = activeAgentRun?.id ?? null;
   const activeAgentRunScope = activeAgentRun
     ? `${AGENT_RUN_TASK_LABEL[activeAgentRun.taskKind]} · ${formatAgentRunTargets(
         activeAgentRun.targetPaths,
@@ -513,6 +515,10 @@ export function CommentPanel({ peerMode = false }: Props) {
     }
   }
 
+  function toggleAgentRunTerminal() {
+    setAgentRunTerminalOpen((current) => !current);
+  }
+
   useEffect(() => {
     if (
       peerMode ||
@@ -540,6 +546,10 @@ export function CommentPanel({ peerMode = false }: Props) {
     peerMode,
     syncActiveAgentRunStatus,
   ]);
+
+  useEffect(() => {
+    setAgentRunTerminalOpen(false);
+  }, [activeAgentRunId]);
 
   useEffect(() => {
     if (peerMode) {
@@ -662,13 +672,29 @@ export function CommentPanel({ peerMode = false }: Props) {
                 {activeAgentRun.errorMessage}
               </span>
             )}
-            {activeAgentRun.output && (
-              <pre className="comment-panel__agent-run-output">
-                {activeAgentRun.output}
-              </pre>
+            {agentRunTerminalOpen && (
+              <div
+                className="comment-panel__agent-run-terminal"
+                role="log"
+                aria-label="Agent terminal output"
+              >
+                <div className="comment-panel__agent-run-terminal-bar">
+                  <span>Terminal output</span>
+                  <span>{activeAgentRun.terminalAttachmentId ?? "local"}</span>
+                </div>
+                <pre className="comment-panel__agent-run-output">
+                  {activeAgentRun.output || "Waiting for output..."}
+                </pre>
+              </div>
             )}
           </div>
           <div className="comment-panel__agent-run-actions">
+            <button
+              className="comment-panel__agent-run-action"
+              onClick={toggleAgentRunTerminal}
+            >
+              {agentRunTerminalOpen ? "Hide terminal" : "Show terminal"}
+            </button>
             {activeAgentRun.prompt && (
               <button
                 className="comment-panel__agent-run-action"


### PR DESCRIPTION
## Summary
- add a collapsible read-only terminal output panel to the active agent run UI
- keep terminal output backed by the existing native runner stdout/stderr tail, without storing process/session objects in Zustand
- update desktop agent docs to distinguish this first terminal-output surface from future interactive PTY/session attachment

## Verification
- npm run typecheck
- npx vitest run src/ui/components/CommentPanel/CommentPanel.test.tsx src/modules/agent-workflow/test/agentWorkflowState.test.ts
- changed-file ESLint: npx eslint <changed ts/tsx/css/md files> --quiet
- npm test
- npm run build
- npm run desktop:build

## Known unrelated issue
- npm run lint -- --quiet still fails at worker/src/index.ts:129 with @typescript-eslint/no-unsafe-return; this file is unrelated to this PR.