### PR TITLE
feat: run desktop agents in a pty

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -5,8 +5,8 @@
 Desktop agent foundation implemented. The shared runtime boundary, Tauri shell,
 native file/folder targets, configurable desktop agent runner, tab-scoped run
 state, and bounded comment-driven agent actions have landed incrementally.
-Remaining work depends on explicit backend decisions for terminal attachment,
-and future structured runners.
+Remaining work depends on explicit product decisions for interactive terminal
+attachment and future structured runners.
 
 ## Summary
 
@@ -255,7 +255,7 @@ Suggested implementation phases:
 3. Add serializable `AgentRun` metadata and UI capability checks without starting
    processes.
 4. Add desktop runtime shell and native filesystem adapter.
-5. Add a first desktop runner behind `AgentRuntime`.
+5. Add a first desktop PTY runner behind `AgentRuntime`.
 6. Add bounded folder-level comment actions on top of the same run model.
 7. Decide and add optional terminal attachment for supported runners.
 8. Add broader workspace agent actions after comment-driven folder runs are
@@ -277,10 +277,11 @@ builds continue to use the browser file API runtime.
 Native runner implementation note: desktop agent runs now call Tauri
 `dragon_start_agent_run`. The command is intentionally configurable through
 native app config, with `DRAGON_AGENT_COMMAND` retained as a dogfooding fallback.
-Dragon sends the generated prompt to the process stdin and stores only the
-returned runtime run id in app state. This keeps tmux, Codex CLI, and other
-runner choices behind the native runtime boundary instead of hard-coding one
-backend into the UI/store contract.
+Dragon starts the command inside a native PTY through Rust `portable-pty`, sends
+the generated prompt through the PTY input stream, and stores only the returned
+runtime run id in app state. This keeps tmux, Codex CLI, and other runner choices
+behind the native runtime boundary instead of hard-coding one backend into the
+UI/store contract.
 The Agent setup surface detects known CLIs, saves a command through native
 config, tests it with `--version`, and opens inline when a desktop run action is
 used before configuration.
@@ -292,9 +293,9 @@ updated to `stopped`.
 
 Run-status implementation note: desktop agent runs now expose
 `dragon_get_agent_run_status` through the Tauri bridge. The native command polls
-the tracked child process with `try_wait`, removes completed children from the
-native process map, and returns `running`, `completed`, `failed`, or `not_found`
-to the shared runtime boundary. Native stdout and stderr are captured into a
+the tracked PTY child process with `try_wait`, removes completed children from
+the native process map, and returns `running`, `completed`, `failed`, or
+`not_found` to the shared runtime boundary. Native PTY output is captured into a
 bounded output tail and returned with each status response, so the comment panel
 can show progress without depending on terminal text as the lifecycle protocol.
 The comment panel polls this status only when the active runtime can execute
@@ -303,9 +304,9 @@ agents, then reconciles the tab-scoped serializable run state to `completed` or
 
 Terminal-output implementation note: the first visible terminal surface is a
 read-only, collapsible output view in the active run panel. It uses the native
-runner's bounded stdout/stderr tail and intentionally does not expose a PTY or
-store terminal objects in Zustand. Interactive session attachment remains a
-separate backend decision behind the terminal runtime boundary.
+runner's bounded PTY output tail and intentionally does not store terminal
+objects in Zustand. Interactive session attachment remains a separate product
+decision behind the terminal runtime boundary.
 
 Run-persistence implementation note: serializable agent run metadata is now part
 of the persisted app store. Frontend reloads restore the active run mapping and

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -4,8 +4,8 @@
 
 Desktop agent foundation implemented. The website remains available, and the
 desktop path now covers native file/folder targets plus UI-started agent runs for
-comment review tasks. Remaining work is limited to explicit backend/product
-decisions such as terminal attachment and future structured runners.
+comment review tasks. Remaining work is limited to explicit product decisions
+such as interactive terminal attachment and future structured runners.
 
 ## Problem
 
@@ -62,7 +62,7 @@ Runtime implementations
   - Desktop runtime
       - native file and folder APIs
       - native file watching
-      - agent runs
+      - PTY-backed agent runs
       - optional terminal/session panel
 ```
 
@@ -132,7 +132,7 @@ Acceptance criteria:
 - The desktop runtime can expose the raw session for a run when the backend
   supports it.
 - The first implementation may expose a read-only terminal output panel backed
-  by the native runner's captured stdout/stderr.
+  by the native runner's captured PTY output.
 - The terminal is not the primary product surface by default.
 - Hiding the terminal does not stop the run.
 - Closing a tab with an active run requires an explicit user decision.
@@ -246,9 +246,9 @@ outside this first desktop planning scope.
 - Normal website builds keep browser file APIs and prompt-copy handoff.
 - Tauri desktop builds can open native file and folder targets.
 - Desktop agent runs start through the saved desktop agent command, with
-  `DRAGON_AGENT_COMMAND` retained as an environment fallback. Runs receive the
-  generated review prompt through stdin, and keep process handles outside
-  Zustand.
+  `DRAGON_AGENT_COMMAND` retained as an environment fallback. Runs execute in a
+  native PTY through Rust `portable-pty`, receive the generated review prompt
+  through the PTY input stream, and keep process handles outside Zustand.
 - Agent run state is tab-scoped and serializable. The comment panel can stop an
   active run and polls native run status so completed or failed processes are
   reflected in the UI.
@@ -256,9 +256,9 @@ outside this first desktop planning scope.
   can copy that exact prompt for inspection or manual recovery.
 - The active run panel shows the run task, target path summary, and selected
   comment count.
-- Native runner stdout and stderr are captured into a bounded output tail. The
-  active run panel exposes that tail through a collapsible terminal output view
-  for same-window observability.
+- Native runner PTY output is captured into a bounded output tail. The active run
+  panel exposes that tail through a collapsible terminal output view for
+  same-window observability.
 - Serializable agent run metadata is persisted with the app store. After a
   reload, Dragon restores the tab-scoped run record and continues polling the
   native runtime id when one exists. If the desktop process restarted and the
@@ -285,10 +285,10 @@ outside this first desktop planning scope.
 - Native file and folder targets are persisted by path, so desktop tabs can
   restore live access after reload without browser handle storage.
 
-## Remaining Backend Decisions
+## Remaining Product Decisions
 
-- What is the minimum Windows backend for interactive PTY/session support if
-  `tmux` is not available?
+- What is the smallest useful interactive terminal attachment surface on top of
+  the native PTY runner?
 - Which structured runner should follow the first configurable terminal-command
   runner?
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -310,6 +310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +638,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +705,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -742,6 +754,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1614,6 +1637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1731,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 name = "lollipop-dragon"
 version = "0.0.0"
 dependencies = [
+ "portable-pty",
  "serde",
  "serde_json",
  "tauri",
@@ -1812,6 +1842,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "num-conv"
@@ -2214,6 +2256,27 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -2716,6 +2779,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,6 +2830,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4465,6 +4555,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+portable-pty = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,11 @@
+use portable_pty::{native_pty_system, CommandBuilder, ExitStatus, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
@@ -108,7 +109,8 @@ struct KnownAgentCli {
 }
 
 struct AgentRunProcess {
-    child: Child,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    _master: Box<dyn MasterPty + Send>,
     output: Arc<Mutex<String>>,
     output_threads: Vec<JoinHandle<()>>,
 }
@@ -276,6 +278,31 @@ fn shell_command(command: &str) -> Command {
     let mut process = Command::new("sh");
     process.arg("-lc").arg(command);
     process
+}
+
+fn shell_pty_command(command: &str) -> CommandBuilder {
+    if cfg!(target_os = "windows") {
+        let mut process = CommandBuilder::new("cmd");
+        process.arg("/C");
+        process.arg(command);
+        return process;
+    }
+
+    let mut process = CommandBuilder::new("sh");
+    process.arg("-lc");
+    process.arg(command);
+    process
+}
+
+fn pty_exit_code(status: &ExitStatus) -> Option<i32> {
+    i32::try_from(status.exit_code()).ok()
+}
+
+fn pty_exit_message(status: &ExitStatus) -> String {
+    status
+        .signal()
+        .map(|signal| format!("Agent terminated by {signal}"))
+        .unwrap_or_else(|| format!("Agent exited with code {}", status.exit_code()))
 }
 
 fn executable_candidates(executable: &str) -> Vec<String> {
@@ -570,32 +597,44 @@ fn dragon_start_agent_run(
 ) -> Result<String, String> {
     let (command, _source) = configured_agent_command(&app)?;
     let run_id = create_agent_run_id();
-    let mut process = shell_command(&command);
-    process.stdin(Stdio::piped());
-    process.stdout(Stdio::piped());
-    process.stderr(Stdio::piped());
+    let pty_system = native_pty_system();
+    let pty_pair = pty_system
+        .openpty(PtySize {
+            rows: 30,
+            cols: 120,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|error| error.to_string())?;
+    let mut process = shell_pty_command(&command);
 
     if let Some(workspace_root_path) = request.workspace_root_path {
         if !workspace_root_path.trim().is_empty() {
-            process.current_dir(workspace_root_path);
+            process.cwd(workspace_root_path);
         }
     }
 
-    let mut child = process.spawn().map_err(|error| error.to_string())?;
+    let child = pty_pair
+        .slave
+        .spawn_command(process)
+        .map_err(|error| error.to_string())?;
     let output = Arc::new(Mutex::new(String::new()));
-    let mut output_threads = Vec::new();
-    if let Some(stdout) = child.stdout.take() {
-        output_threads.push(spawn_agent_output_reader(stdout, Arc::clone(&output)));
-    }
-    if let Some(stderr) = child.stderr.take() {
-        output_threads.push(spawn_agent_output_reader(stderr, Arc::clone(&output)));
-    }
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(request.prompt.as_bytes())
-            .map_err(|error| error.to_string())?;
-        stdin.write_all(b"\n").map_err(|error| error.to_string())?;
-    }
+    let reader = pty_pair
+        .master
+        .try_clone_reader()
+        .map_err(|error| error.to_string())?;
+    let output_threads = vec![spawn_agent_output_reader(reader, Arc::clone(&output))];
+    let mut writer = pty_pair
+        .master
+        .take_writer()
+        .map_err(|error| error.to_string())?;
+    writer
+        .write_all(request.prompt.as_bytes())
+        .map_err(|error| error.to_string())?;
+    writer
+        .write_all(b"\r\n")
+        .map_err(|error| error.to_string())?;
+    writer.flush().map_err(|error| error.to_string())?;
 
     let runs = active_agent_runs();
     let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
@@ -603,6 +642,7 @@ fn dragon_start_agent_run(
         run_id.clone(),
         AgentRunProcess {
             child,
+            _master: pty_pair.master,
             output,
             output_threads,
         },
@@ -669,16 +709,14 @@ fn dragon_get_agent_run_status(run_id: String) -> Result<AgentRunStatusPayload, 
     if exit_status.success() {
         return Ok(AgentRunStatusPayload {
             status: "completed".to_string(),
-            exit_code: exit_status.code(),
+            exit_code: pty_exit_code(&exit_status),
             message: None,
             output,
         });
     }
 
-    let exit_code = exit_status.code();
-    let message = exit_code
-        .map(|code| format!("Agent exited with code {code}"))
-        .unwrap_or_else(|| "Agent exited without an exit code".to_string());
+    let exit_code = pty_exit_code(&exit_status);
+    let message = pty_exit_message(&exit_status);
     Ok(AgentRunStatusPayload {
         status: "failed".to_string(),
         exit_code,


### PR DESCRIPTION
## Summary
- run configured desktop agent commands inside a native PTY using Rust `portable-pty`
- keep the existing Tauri run/status/stop contract and bounded output tail, so UI/store state remains serializable
- update desktop agent docs to mark the cross-platform PTY backend decision as implemented while leaving interactive terminal attachment as the next product decision

## Verification
- git diff --check
- cargo fmt
- cargo check
- npm run typecheck
- changed-file ESLint: npx eslint <changed ts/tsx/css/md/json files excluding src-tauri> --quiet
- npm test
- npm run build
- npm run desktop:build

## Known unrelated issue
- npm run lint -- --quiet still fails at worker/src/index.ts:129 with @typescript-eslint/no-unsafe-return; this file is unrelated to this PR.