### PR TITLE
feat: add desktop agent terminal input

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -303,10 +303,12 @@ agents, then reconciles the tab-scoped serializable run state to `completed` or
 `failed`.
 
 Terminal-output implementation note: the first visible terminal surface is a
-read-only, collapsible output view in the active run panel. It uses the native
-runner's bounded PTY output tail and intentionally does not store terminal
-objects in Zustand. Interactive session attachment remains a separate product
-decision behind the terminal runtime boundary.
+collapsible output view in the active run panel. It uses the native runner's
+bounded PTY output tail and intentionally does not store terminal objects in
+Zustand. The first interactive attachment layer is line-based: the panel can send
+submitted text to the active native PTY run through the terminal runtime
+boundary. Full terminal emulation, resize events, and key-by-key manual takeover
+remain separate product decisions behind that same boundary.
 
 Run-persistence implementation note: serializable agent run metadata is now part
 of the persisted app store. Frontend reloads restore the active run mapping and

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -133,6 +133,8 @@ Acceptance criteria:
   supports it.
 - The first implementation may expose a read-only terminal output panel backed
   by the native runner's captured PTY output.
+- The first interactive implementation may start with line-based terminal input
+  before full terminal emulation, resize, or key-by-key control.
 - The terminal is not the primary product surface by default.
 - Hiding the terminal does not stop the run.
 - Closing a tab with an active run requires an explicit user decision.
@@ -259,6 +261,8 @@ outside this first desktop planning scope.
 - Native runner PTY output is captured into a bounded output tail. The active run
   panel exposes that tail through a collapsible terminal output view for
   same-window observability.
+- While a desktop PTY run is active, the terminal output view includes a compact
+  input row that sends line-based input back into the native PTY session.
 - Serializable agent run metadata is persisted with the app store. After a
   reload, Dragon restores the tab-scoped run record and continues polling the
   native runtime id when one exists. If the desktop process restarted and the
@@ -287,8 +291,8 @@ outside this first desktop planning scope.
 
 ## Remaining Product Decisions
 
-- What is the smallest useful interactive terminal attachment surface on top of
-  the native PTY runner?
+- What full terminal-emulator behavior, if any, should follow line-based input
+  for resize, key-by-key control, and manual takeover?
 - Which structured runner should follow the first configurable terminal-command
   runner?
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ struct KnownAgentCli {
 struct AgentRunProcess {
     child: Box<dyn portable_pty::Child + Send + Sync>,
     _master: Box<dyn MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
     output: Arc<Mutex<String>>,
     output_threads: Vec<JoinHandle<()>>,
 }
@@ -643,6 +644,7 @@ fn dragon_start_agent_run(
         AgentRunProcess {
             child,
             _master: pty_pair.master,
+            writer,
             output,
             output_threads,
         },
@@ -669,6 +671,29 @@ fn dragon_stop_agent_run(run_id: String) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[tauri::command]
+fn dragon_send_agent_run_input(run_id: String, input: String) -> Result<(), String> {
+    let trimmed_input = input.trim_end_matches(['\r', '\n']);
+    if trimmed_input.is_empty() {
+        return Ok(());
+    }
+
+    let runs = active_agent_runs();
+    let mut locked_runs = runs.lock().map_err(|error| error.to_string())?;
+    let process = locked_runs
+        .get_mut(&run_id)
+        .ok_or_else(|| "Agent run is no longer available".to_string())?;
+    process
+        .writer
+        .write_all(trimmed_input.as_bytes())
+        .map_err(|error| error.to_string())?;
+    process
+        .writer
+        .write_all(b"\r\n")
+        .map_err(|error| error.to_string())?;
+    process.writer.flush().map_err(|error| error.to_string())
 }
 
 #[tauri::command]
@@ -744,6 +769,7 @@ pub fn run() {
             dragon_read_directory_tree,
             dragon_start_agent_run,
             dragon_stop_agent_run,
+            dragon_send_agent_run_input,
             dragon_get_agent_run_status
         ])
         .run(tauri::generate_context!())

--- a/src/runtime/desktopTerminalRuntime.test.ts
+++ b/src/runtime/desktopTerminalRuntime.test.ts
@@ -6,11 +6,53 @@ beforeEach(() => {
 });
 
 describe("desktop terminal runtime", () => {
-  it("does not report terminal attachment support yet", async () => {
-    expect(desktopTerminalRuntime.canShowTerminal).toBe(false);
+  it("rejects when the desktop bridge is unavailable", async () => {
+    expect(desktopTerminalRuntime.canShowTerminal).toBe(true);
 
     await expect(desktopTerminalRuntime.attach("run-1")).rejects.toThrow(
       "Desktop runtime bridge is unavailable",
     );
+  });
+
+  it("attaches and sends input through native terminal commands", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
+    window.__TAURI__ = {
+      core: {
+        invoke: (command, args) => {
+          calls.push({ command, args });
+          if (command === "dragon_runtime_ping") {
+            return Promise.resolve("ok");
+          }
+          return Promise.resolve(null);
+        },
+      },
+    };
+
+    await expect(desktopTerminalRuntime.attach("run-1")).resolves.toEqual({
+      id: "run-1",
+      runId: "run-1",
+    });
+    await desktopTerminalRuntime.sendInput("run-1", "continue");
+
+    expect(calls).toEqual([
+      {
+        command: "dragon_runtime_ping",
+        args: undefined,
+      },
+      {
+        command: "dragon_runtime_ping",
+        args: undefined,
+      },
+      {
+        command: "dragon_send_agent_run_input",
+        args: {
+          runId: "run-1",
+          input: "continue",
+        },
+      },
+    ]);
   });
 });

--- a/src/runtime/desktopTerminalRuntime.ts
+++ b/src/runtime/desktopTerminalRuntime.ts
@@ -1,10 +1,18 @@
 import type { TerminalRuntime } from "./terminal";
 import { assertDesktopRuntimeAvailable } from "./desktopAgentRuntime";
+import { sendTauriAgentRunInput } from "./tauriBridge";
 
 export const desktopTerminalRuntime: TerminalRuntime = {
-  canShowTerminal: false,
-  attach: async () => {
+  canShowTerminal: true,
+  attach: async (runId) => {
     await assertDesktopRuntimeAvailable();
-    throw new Error("Desktop terminal attachment is not implemented");
+    return {
+      id: runId,
+      runId,
+    };
+  },
+  sendInput: async (runId, input) => {
+    await assertDesktopRuntimeAvailable();
+    await sendTauriAgentRunInput(runId, input);
   },
 };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -47,6 +47,10 @@ export function getAgentRuntimeCapability() {
   return agentRuntime.getCapability();
 }
 
+export function sendTerminalInput(runId: string, input: string) {
+  return terminalRuntime.sendInput(runId, input);
+}
+
 export function openFile() {
   return workspaceRuntime.openFile();
 }

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -13,6 +13,7 @@ import {
   readTauriDirectoryTree,
   readTauriTextFile,
   saveTauriAgentConfig,
+  sendTauriAgentRunInput,
   startTauriAgentRun,
   stopTauriAgentRun,
   testTauriAgentCommand,
@@ -163,7 +164,7 @@ describe("tauri bridge", () => {
     );
   });
 
-  it("starts, stops, and reads native agent runs through Tauri commands", async () => {
+  it("starts, stops, sends input, and reads native agent runs through Tauri commands", async () => {
     const calls: {
       command: string;
       args: Record<string, unknown> | undefined;
@@ -191,6 +192,7 @@ describe("tauri bridge", () => {
 
     await expect(startTauriAgentRun(request)).resolves.toBe("native-run-1");
     await stopTauriAgentRun("native-run-1");
+    await sendTauriAgentRunInput("native-run-1", "continue");
     await expect(getTauriAgentRunStatus("native-run-1")).resolves.toEqual({
       status: "running",
       output: "Working\n",
@@ -204,6 +206,10 @@ describe("tauri bridge", () => {
       {
         command: "dragon_stop_agent_run",
         args: { runId: "native-run-1" },
+      },
+      {
+        command: "dragon_send_agent_run_input",
+        args: { runId: "native-run-1", input: "continue" },
       },
       {
         command: "dragon_get_agent_run_status",

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -26,7 +26,8 @@ export type TauriCommand =
   | "dragon_read_directory_tree"
   | "dragon_start_agent_run"
   | "dragon_stop_agent_run"
-  | "dragon_get_agent_run_status";
+  | "dragon_get_agent_run_status"
+  | "dragon_send_agent_run_input";
 
 export interface TauriNativeFileNode {
   kind: "file";
@@ -428,6 +429,16 @@ export function stopTauriAgentRun(runId: string): Promise<unknown> {
   return invokeTauriCommand({
     command: "dragon_stop_agent_run",
     args: { runId },
+  });
+}
+
+export async function sendTauriAgentRunInput(
+  runId: string,
+  input: string,
+): Promise<void> {
+  await invokeTauriCommand({
+    command: "dragon_send_agent_run_input",
+    args: { runId, input },
   });
 }
 

--- a/src/runtime/terminal.ts
+++ b/src/runtime/terminal.ts
@@ -6,10 +6,13 @@ export interface TerminalAttachment {
 export interface TerminalRuntime {
   canShowTerminal: boolean;
   attach(runId: string): Promise<TerminalAttachment>;
+  sendInput(runId: string, input: string): Promise<void>;
 }
 
 export const webTerminalRuntime: TerminalRuntime = {
   canShowTerminal: false,
   attach: () =>
+    Promise.reject(new Error("Terminal sessions are unavailable on web")),
+  sendInput: () =>
     Promise.reject(new Error("Terminal sessions are unavailable on web")),
 };

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -206,6 +206,47 @@
   white-space: pre-wrap;
 }
 
+.comment-panel__agent-run-terminal-input {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.35rem;
+  padding: 0.4rem;
+  border-top: 1px solid var(--border-light);
+  background: var(--surface-alt);
+}
+
+.comment-panel__agent-run-terminal-input input {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  padding: 0.25rem 0.35rem;
+}
+
+.comment-panel__agent-run-terminal-input button {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 650;
+  padding: 0.2rem 0.45rem;
+}
+
+.comment-panel__agent-run-terminal-input button:not(:disabled):hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.comment-panel__agent-run-terminal-input button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .comment-panel__agent-run-actions {
   flex-shrink: 0;
   display: flex;

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -12,7 +12,12 @@ import {
   getFolderAddressableCommentTargets,
 } from "../../../modules/agent-workflow";
 import type { AgentRunStatus } from "../../../modules/agent-workflow";
-import { canRunAgent, getAgentRuntimeCapability } from "../../../runtime";
+import {
+  canRunAgent,
+  canShowTerminal,
+  getAgentRuntimeCapability,
+  sendTerminalInput,
+} from "../../../runtime";
 import type { AgentRuntimeCapability } from "../../../runtime";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
@@ -220,6 +225,7 @@ export function CommentPanel({ peerMode = false }: Props) {
   const sharedContent = useAppStore((state) => state.sharedContent);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
   const [agentRunTerminalOpen, setAgentRunTerminalOpen] = useState(false);
+  const [agentRunTerminalInput, setAgentRunTerminalInput] = useState("");
   const [agentCapability, setAgentCapability] = useState(
     INITIAL_AGENT_CAPABILITY,
   );
@@ -448,6 +454,11 @@ export function CommentPanel({ peerMode = false }: Props) {
   );
   const showAgentRunStatus = !peerMode && activeAgentRun;
   const activeAgentRunId = activeAgentRun?.id ?? null;
+  const canSendAgentRunInput = Boolean(
+    canShowTerminal &&
+    activeAgentRun?.terminalAttachmentId &&
+    ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
+  );
   const activeAgentRunScope = activeAgentRun
     ? `${AGENT_RUN_TASK_LABEL[activeAgentRun.taskKind]} · ${formatAgentRunTargets(
         activeAgentRun.targetPaths,
@@ -519,6 +530,24 @@ export function CommentPanel({ peerMode = false }: Props) {
     setAgentRunTerminalOpen((current) => !current);
   }
 
+  async function handleSendAgentRunInput() {
+    if (!activeAgentRun?.terminalAttachmentId) {
+      return;
+    }
+    const input = agentRunTerminalInput.trim();
+    if (!input) {
+      return;
+    }
+
+    try {
+      await sendTerminalInput(activeAgentRun.terminalAttachmentId, input);
+      setAgentRunTerminalInput("");
+    } catch (error) {
+      console.error("[CommentPanel] failed to send terminal input:", error);
+      showToast("Couldn't send terminal input");
+    }
+  }
+
   useEffect(() => {
     if (
       peerMode ||
@@ -549,6 +578,7 @@ export function CommentPanel({ peerMode = false }: Props) {
 
   useEffect(() => {
     setAgentRunTerminalOpen(false);
+    setAgentRunTerminalInput("");
   }, [activeAgentRunId]);
 
   useEffect(() => {
@@ -685,6 +715,31 @@ export function CommentPanel({ peerMode = false }: Props) {
                 <pre className="comment-panel__agent-run-output">
                   {activeAgentRun.output || "Waiting for output..."}
                 </pre>
+                {canSendAgentRunInput && (
+                  <form
+                    className="comment-panel__agent-run-terminal-input"
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      void handleSendAgentRunInput();
+                    }}
+                  >
+                    <input
+                      value={agentRunTerminalInput}
+                      onChange={(event) =>
+                        setAgentRunTerminalInput(event.target.value)
+                      }
+                      aria-label="Terminal input"
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                    <button
+                      type="submit"
+                      disabled={!agentRunTerminalInput.trim()}
+                    >
+                      Send
+                    </button>
+                  </form>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- keep the native PTY writer alive for active desktop agent runs
- add a Tauri `dragon_send_agent_run_input` command plus terminal runtime `sendInput` bridge
- add a compact input row under the active run terminal output so desktop users can send line-based input without leaving Dragon
- update desktop agent docs to mark line-based PTY input as implemented and keep full terminal emulation as future work

## Verification
- `git diff --check`
- `cargo fmt`
- `cargo check`
- `npm run typecheck`
- `npx vitest run src/runtime/tauriBridge.test.ts src/runtime/desktopTerminalRuntime.test.ts src/ui/components/CommentPanel/CommentPanel.test.tsx`
- changed-file ESLint with `npx eslint ... --quiet`
- `npm test`
- `npm run build`
- `npm run desktop:build`

## Known unrelated issue
- `npm run lint -- --quiet` still fails on existing `worker/src/index.ts:129` with `@typescript-eslint/no-unsafe-return`.
