### PR TITLE
feat: add desktop native file watcher

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -136,11 +136,10 @@ not in Zustand.
 ### Desktop Shell
 
 The Tauri shell under `src-tauri/` loads the same React app as the website. It is
-the native container for desktop filesystem, terminal, and agent runtime
-adapters, with watcher work still future. Normal Vite builds use the web
-runtime. Tauri dev/build commands run Vite in `desktop` mode, where
-`vite.config.ts` aliases the active runtime module to the desktop runtime
-implementation.
+the native container for desktop filesystem, watcher, terminal, and agent
+runtime adapters. Normal Vite builds use the web runtime. Tauri dev/build
+commands run Vite in `desktop` mode, where `vite.config.ts` aliases the active
+runtime module to the desktop runtime implementation.
 
 The bridge from the frontend to native commands lives in
 `src/runtime/tauriBridge.ts`. It uses Tauri v2's global `window.__TAURI__.core`
@@ -192,6 +191,10 @@ writing text files, and building markdown-only directory trees. Frontend access
 to those commands stays behind `src/runtime/tauriBridge.ts` response validation.
 `src/runtime/desktopWorkspaceRuntime.ts` adapts those commands to the shared
 `WorkspaceRuntime` interface for native path targets.
+The desktop shell also registers native path-watch commands backed by Rust
+`notify`. `src/runtime/desktopWatcherRuntime.ts` starts and stops native watches
+for native path targets and lets the existing watcher hook refresh files or
+folders when the native runtime reports a pending change.
 
 Native open-file and open-folder dialogs are also exposed through Tauri bridge
 commands. The desktop workspace runtime uses those dialogs for host open flows

--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -273,6 +273,11 @@ Current implementation note: the Tauri shell now runs Vite in `desktop` mode,
 which selects the desktop runtime facade. Desktop open-file and open-folder
 actions use native Tauri dialogs and return native path targets, while normal web
 builds continue to use the browser file API runtime.
+The desktop runtime also provides a watcher adapter for native path targets. The
+Rust side uses `notify` to watch the selected file or folder and exposes a small
+pending-change flag through Tauri commands; the existing React watcher hook
+consumes that flag and refreshes the active file or folder without storing native
+watcher objects in Zustand.
 
 Native runner implementation note: desktop agent runs now call Tauri
 `dragon_start_agent_run`. The command is intentionally configurable through

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -247,6 +247,8 @@ outside this first desktop planning scope.
 - The shared app now has runtime capability facades for web and desktop builds.
 - Normal website builds keep browser file APIs and prompt-copy handoff.
 - Tauri desktop builds can open native file and folder targets.
+- Tauri desktop builds watch native file and folder targets through Rust
+  `notify`, while the website keeps browser observer/polling behavior.
 - Desktop agent runs start through the saved desktop agent command, with
   `DRAGON_AGENT_COMMAND` retained as an environment fallback. Runs execute in a
   native PTY through Rust `portable-pty`, receive the generated review prompt

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -838,6 +838,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1523,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1666,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1780,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 name = "lollipop-dragon"
 version = "0.0.0"
 dependencies = [
+ "notify",
  "portable-pty",
  "serde",
  "serde_json",
@@ -1788,6 +1838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1853,6 +1904,33 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+notify = "8"
 portable-pty = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use notify::{Config as NotifyConfig, RecommendedWatcher, RecursiveMode, Watcher};
 use portable_pty::{native_pty_system, CommandBuilder, ExitStatus, MasterPty, PtySize};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -6,7 +7,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -34,6 +35,8 @@ const KNOWN_AGENT_CLIS: [KnownAgentCli; 2] = [
 
 static AGENT_RUN_COUNTER: AtomicU64 = AtomicU64::new(1);
 static AGENT_RUNS: OnceLock<Mutex<HashMap<String, AgentRunProcess>>> = OnceLock::new();
+static PATH_WATCH_COUNTER: AtomicU64 = AtomicU64::new(1);
+static PATH_WATCHES: OnceLock<Mutex<HashMap<String, PathWatch>>> = OnceLock::new();
 
 #[derive(Serialize)]
 #[serde(tag = "kind")]
@@ -116,6 +119,11 @@ struct AgentRunProcess {
     output_threads: Vec<JoinHandle<()>>,
 }
 
+struct PathWatch {
+    _watcher: RecommendedWatcher,
+    pending_change: Arc<AtomicBool>,
+}
+
 fn path_target_from_path(path: PathBuf) -> NativePathTarget {
     let name = path
         .file_name()
@@ -130,6 +138,10 @@ fn path_target_from_path(path: PathBuf) -> NativePathTarget {
 
 fn active_agent_runs() -> &'static Mutex<HashMap<String, AgentRunProcess>> {
     AGENT_RUNS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn active_path_watches() -> &'static Mutex<HashMap<String, PathWatch>> {
+    PATH_WATCHES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 fn agent_config_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
@@ -267,6 +279,16 @@ fn create_agent_run_id() -> String {
         .unwrap_or(0);
 
     format!("agent-{timestamp}-{counter}")
+}
+
+fn create_path_watch_id() -> String {
+    let counter = PATH_WATCH_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+
+    format!("watch-{timestamp}-{counter}")
 }
 
 fn shell_command(command: &str) -> Command {
@@ -592,6 +614,70 @@ fn dragon_read_directory_tree(path: String) -> Result<Vec<NativeFileTreeNode>, S
 }
 
 #[tauri::command]
+fn dragon_start_path_watch(path: String, recursive: bool) -> Result<String, String> {
+    let watch_path = PathBuf::from(path);
+    if !watch_path.exists() {
+        return Err("Path to watch does not exist".to_string());
+    }
+
+    let watch_id = create_path_watch_id();
+    let pending_change = Arc::new(AtomicBool::new(false));
+    let watcher_pending_change = Arc::clone(&pending_change);
+    let mut watcher = RecommendedWatcher::new(
+        move |result: notify::Result<notify::Event>| match result {
+            Ok(_event) => {
+                watcher_pending_change.store(true, Ordering::Relaxed);
+            }
+            Err(error) => {
+                eprintln!("[path watch] watch failed: {error}");
+                watcher_pending_change.store(true, Ordering::Relaxed);
+            }
+        },
+        NotifyConfig::default(),
+    )
+    .map_err(|error| error.to_string())?;
+
+    let recursive_mode = if recursive {
+        RecursiveMode::Recursive
+    } else {
+        RecursiveMode::NonRecursive
+    };
+    watcher
+        .watch(&watch_path, recursive_mode)
+        .map_err(|error| error.to_string())?;
+
+    let watches = active_path_watches();
+    let mut locked_watches = watches.lock().map_err(|error| error.to_string())?;
+    locked_watches.insert(
+        watch_id.clone(),
+        PathWatch {
+            _watcher: watcher,
+            pending_change,
+        },
+    );
+
+    Ok(watch_id)
+}
+
+#[tauri::command]
+fn dragon_take_path_watch_events(watch_id: String) -> Result<bool, String> {
+    let watches = active_path_watches();
+    let locked_watches = watches.lock().map_err(|error| error.to_string())?;
+    let watch = locked_watches
+        .get(&watch_id)
+        .ok_or_else(|| "Path watch is no longer available".to_string())?;
+    Ok(watch.pending_change.swap(false, Ordering::Relaxed))
+}
+
+#[tauri::command]
+fn dragon_stop_path_watch(watch_id: String) -> Result<(), String> {
+    let watches = active_path_watches();
+    let mut locked_watches = watches.lock().map_err(|error| error.to_string())?;
+    locked_watches.remove(&watch_id);
+    Ok(())
+}
+
+#[tauri::command]
 fn dragon_start_agent_run(
     app: tauri::AppHandle,
     request: AgentRunRequestPayload,
@@ -794,6 +880,9 @@ pub fn run() {
             dragon_read_text_file,
             dragon_write_text_file,
             dragon_read_directory_tree,
+            dragon_start_path_watch,
+            dragon_take_path_watch_events,
+            dragon_stop_path_watch,
             dragon_start_agent_run,
             dragon_stop_agent_run,
             dragon_send_agent_run_input,

--- a/src/runtime/desktop.ts
+++ b/src/runtime/desktop.ts
@@ -1,11 +1,13 @@
 import { desktopAgentRuntime } from "./desktopAgentRuntime";
 import { desktopTerminalRuntime } from "./desktopTerminalRuntime";
+import { desktopWatcherRuntime } from "./desktopWatcherRuntime";
 import { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";
 
 export const desktopRuntime = {
   workspaceRuntime: desktopWorkspaceRuntime,
   agentRuntime: desktopAgentRuntime,
   terminalRuntime: desktopTerminalRuntime,
+  watcherRuntime: desktopWatcherRuntime,
 };
 
 export {
@@ -20,4 +22,5 @@ export {
   testDesktopAgentCommand,
 } from "./desktopAgentRuntime";
 export { desktopTerminalRuntime } from "./desktopTerminalRuntime";
+export { desktopWatcherRuntime } from "./desktopWatcherRuntime";
 export { desktopWorkspaceRuntime } from "./desktopWorkspaceRuntime";

--- a/src/runtime/desktopWatcherRuntime.test.ts
+++ b/src/runtime/desktopWatcherRuntime.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { desktopWatcherRuntime } from "./desktopWatcherRuntime";
+import type { NativeWorkspaceDirectoryTarget } from "./workspace";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.__TAURI__ = undefined;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  window.__TAURI__ = undefined;
+});
+
+describe("desktop watcher runtime", () => {
+  it("rejects when the desktop bridge is unavailable", async () => {
+    const target: NativeWorkspaceDirectoryTarget = {
+      kind: "native_directory",
+      name: "project",
+      path: "C:\\project",
+    };
+
+    await expect(
+      desktopWatcherRuntime.watchTarget({
+        target,
+        recursive: true,
+        onChange: vi.fn(),
+      }),
+    ).rejects.toThrow("Desktop runtime bridge is unavailable");
+  });
+
+  it("starts, polls, and stops native path watches", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
+    const onChange = vi.fn();
+    let hasChange = true;
+    window.__TAURI__ = {
+      core: {
+        invoke: (command, args) => {
+          calls.push({ command, args });
+          if (command === "dragon_runtime_ping") {
+            return Promise.resolve("ok");
+          }
+          if (command === "dragon_start_path_watch") {
+            return Promise.resolve("watch-1");
+          }
+          if (command === "dragon_take_path_watch_events") {
+            const changed = hasChange;
+            hasChange = false;
+            return Promise.resolve(changed);
+          }
+          return Promise.resolve(null);
+        },
+      },
+    };
+    const target: NativeWorkspaceDirectoryTarget = {
+      kind: "native_directory",
+      name: "project",
+      path: "C:\\project",
+    };
+
+    const subscription = await desktopWatcherRuntime.watchTarget({
+      target,
+      recursive: true,
+      onChange,
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(500);
+    await subscription.stop();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(calls).toEqual([
+      {
+        command: "dragon_runtime_ping",
+        args: undefined,
+      },
+      {
+        command: "dragon_start_path_watch",
+        args: { path: "C:\\project", recursive: true },
+      },
+      {
+        command: "dragon_take_path_watch_events",
+        args: { watchId: "watch-1" },
+      },
+      {
+        command: "dragon_take_path_watch_events",
+        args: { watchId: "watch-1" },
+      },
+      {
+        command: "dragon_stop_path_watch",
+        args: { watchId: "watch-1" },
+      },
+    ]);
+  });
+});

--- a/src/runtime/desktopWatcherRuntime.ts
+++ b/src/runtime/desktopWatcherRuntime.ts
@@ -1,0 +1,77 @@
+import {
+  isNativeWorkspaceDirectoryTarget,
+  isNativeWorkspaceFileTarget,
+} from "./workspace";
+import type { WatcherRuntime, WatcherSubscription } from "./watcher";
+import { assertDesktopRuntimeAvailable } from "./desktopAgentRuntime";
+import {
+  startTauriPathWatch,
+  stopTauriPathWatch,
+  takeTauriPathWatchEvents,
+} from "./tauriBridge";
+
+const WATCH_POLL_INTERVAL_MS = 500;
+
+function createStoppedSubscription(): WatcherSubscription {
+  return {
+    stop: () => Promise.resolve(),
+  };
+}
+
+export const desktopWatcherRuntime: WatcherRuntime = {
+  canWatchTarget: (target) =>
+    isNativeWorkspaceFileTarget(target) ||
+    isNativeWorkspaceDirectoryTarget(target),
+  watchTarget: async ({ target, recursive, onChange, onError }) => {
+    if (
+      !isNativeWorkspaceFileTarget(target) &&
+      !isNativeWorkspaceDirectoryTarget(target)
+    ) {
+      return createStoppedSubscription();
+    }
+
+    await assertDesktopRuntimeAvailable();
+    const watchId = await startTauriPathWatch({
+      path: target.path,
+      recursive,
+    });
+    let stopped = false;
+    let pendingRefresh = false;
+
+    async function pollWatch() {
+      if (stopped || pendingRefresh) {
+        return;
+      }
+
+      try {
+        const changed = await takeTauriPathWatchEvents(watchId);
+        if (!changed || stopped) {
+          return;
+        }
+
+        pendingRefresh = true;
+        await onChange();
+      } catch (error) {
+        onError?.(error);
+      } finally {
+        pendingRefresh = false;
+      }
+    }
+
+    const intervalId = window.setInterval(() => {
+      void pollWatch();
+    }, WATCH_POLL_INTERVAL_MS);
+
+    return {
+      stop: async () => {
+        if (stopped) {
+          return;
+        }
+
+        stopped = true;
+        window.clearInterval(intervalId);
+        await stopTauriPathWatch(watchId);
+      },
+    };
+  },
+};

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -23,6 +23,11 @@ export {
 } from "./desktopAgentRuntime";
 export type { TerminalAttachment, TerminalRuntime } from "./terminal";
 export type {
+  WatcherRuntime,
+  WatcherSubscription,
+  WatchTargetOptions,
+} from "./watcher";
+export type {
   NativeWorkspaceDirectoryTarget,
   NativeWorkspaceFileTarget,
   OpenedWorkspaceDirectory,
@@ -39,6 +44,7 @@ export {
 export const workspaceRuntime = activeRuntime.workspaceRuntime;
 export const agentRuntime = activeRuntime.agentRuntime;
 export const terminalRuntime = activeRuntime.terminalRuntime;
+export const watcherRuntime = activeRuntime.watcherRuntime;
 
 export const canRunAgent = agentRuntime.canRunAgent;
 export const canShowTerminal = terminalRuntime.canShowTerminal;

--- a/src/runtime/runtime.web.ts
+++ b/src/runtime/runtime.web.ts
@@ -1,10 +1,12 @@
 import { webAgentRuntime } from "./agent";
 import type { RuntimeBundle } from "./runtimeBundle";
 import { webTerminalRuntime } from "./terminal";
+import { webWatcherRuntime } from "./watcher";
 import { webWorkspaceRuntime } from "./webWorkspaceRuntime";
 
 export const activeRuntime: RuntimeBundle = {
   workspaceRuntime: webWorkspaceRuntime,
   agentRuntime: webAgentRuntime,
   terminalRuntime: webTerminalRuntime,
+  watcherRuntime: webWatcherRuntime,
 };

--- a/src/runtime/runtimeBundle.ts
+++ b/src/runtime/runtimeBundle.ts
@@ -1,9 +1,11 @@
 import type { AgentRuntime } from "./agent";
 import type { TerminalRuntime } from "./terminal";
+import type { WatcherRuntime } from "./watcher";
 import type { WorkspaceRuntime } from "./workspace";
 
 export interface RuntimeBundle {
   workspaceRuntime: WorkspaceRuntime;
   agentRuntime: AgentRuntime;
   terminalRuntime: TerminalRuntime;
+  watcherRuntime: WatcherRuntime;
 }

--- a/src/runtime/tauriBridge.test.ts
+++ b/src/runtime/tauriBridge.test.ts
@@ -16,8 +16,11 @@ import {
   saveTauriAgentConfig,
   sendTauriAgentRunData,
   sendTauriAgentRunInput,
+  startTauriPathWatch,
   startTauriAgentRun,
+  stopTauriPathWatch,
   stopTauriAgentRun,
+  takeTauriPathWatchEvents,
   testTauriAgentCommand,
   writeTauriTextFile,
 } from "./tauriBridge";
@@ -406,6 +409,51 @@ describe("tauri bridge", () => {
             path: "docs/intro.md",
           },
         ],
+      },
+    ]);
+  });
+
+  it("starts, reads, and stops native path watches through Tauri commands", async () => {
+    const calls: {
+      command: string;
+      args: Record<string, unknown> | undefined;
+    }[] = [];
+    window.__TAURI__ = {
+      core: {
+        invoke: (command, args) => {
+          calls.push({ command, args });
+          if (command === "dragon_start_path_watch") {
+            return Promise.resolve("watch-1");
+          }
+          if (command === "dragon_take_path_watch_events") {
+            return Promise.resolve(true);
+          }
+          return Promise.resolve(null);
+        },
+      },
+    };
+
+    await expect(
+      startTauriPathWatch({
+        path: "/tmp/project",
+        recursive: true,
+      }),
+    ).resolves.toBe("watch-1");
+    await expect(takeTauriPathWatchEvents("watch-1")).resolves.toBe(true);
+    await stopTauriPathWatch("watch-1");
+
+    expect(calls).toEqual([
+      {
+        command: "dragon_start_path_watch",
+        args: { path: "/tmp/project", recursive: true },
+      },
+      {
+        command: "dragon_take_path_watch_events",
+        args: { watchId: "watch-1" },
+      },
+      {
+        command: "dragon_stop_path_watch",
+        args: { watchId: "watch-1" },
       },
     ]);
   });

--- a/src/runtime/tauriBridge.ts
+++ b/src/runtime/tauriBridge.ts
@@ -24,6 +24,9 @@ export type TauriCommand =
   | "dragon_read_text_file"
   | "dragon_write_text_file"
   | "dragon_read_directory_tree"
+  | "dragon_start_path_watch"
+  | "dragon_take_path_watch_events"
+  | "dragon_stop_path_watch"
   | "dragon_start_agent_run"
   | "dragon_stop_agent_run"
   | "dragon_get_agent_run_status"
@@ -411,6 +414,42 @@ export async function readTauriDirectoryTree(
     args: { path: target.path },
   });
   return parseNativeTree(result);
+}
+
+export async function startTauriPathWatch(input: {
+  path: string;
+  recursive: boolean;
+}): Promise<string> {
+  const result = await invokeTauriCommand({
+    command: "dragon_start_path_watch",
+    args: input,
+  });
+  if (typeof result === "string") {
+    return result;
+  }
+
+  throw new Error("Unexpected native path watch response");
+}
+
+export async function takeTauriPathWatchEvents(
+  watchId: string,
+): Promise<boolean> {
+  const result = await invokeTauriCommand({
+    command: "dragon_take_path_watch_events",
+    args: { watchId },
+  });
+  if (typeof result === "boolean") {
+    return result;
+  }
+
+  throw new Error("Unexpected native path watch event response");
+}
+
+export function stopTauriPathWatch(watchId: string): Promise<unknown> {
+  return invokeTauriCommand({
+    command: "dragon_stop_path_watch",
+    args: { watchId },
+  });
 }
 
 export async function startTauriAgentRun(

--- a/src/runtime/watcher.ts
+++ b/src/runtime/watcher.ts
@@ -1,0 +1,28 @@
+import type { DirectoryTarget, FileTarget } from "../types/fileTree";
+
+export interface WatcherSubscription {
+  stop(): Promise<void>;
+}
+
+export interface WatchTargetChangeHandler {
+  onChange: () => void | Promise<void>;
+  onError?: (error: unknown) => void;
+}
+
+export interface WatchTargetOptions extends WatchTargetChangeHandler {
+  target: FileTarget | DirectoryTarget;
+  recursive: boolean;
+}
+
+export interface WatcherRuntime {
+  canWatchTarget(target: FileTarget | DirectoryTarget): boolean;
+  watchTarget(options: WatchTargetOptions): Promise<WatcherSubscription>;
+}
+
+export const webWatcherRuntime: WatcherRuntime = {
+  canWatchTarget: () => false,
+  watchTarget: () =>
+    Promise.reject(
+      new Error("Native filesystem watching is unavailable on web"),
+    ),
+};

--- a/src/ui/hooks/useFileSystemWatcher.ts
+++ b/src/ui/hooks/useFileSystemWatcher.ts
@@ -4,6 +4,7 @@ import {
   isBrowserDirectoryHandle,
   isBrowserFileHandle,
 } from "../../types/fileTree";
+import { watcherRuntime } from "../../runtime";
 
 interface FileSystemObserverRecord {
   type: string;
@@ -82,35 +83,74 @@ export function useFileSystemWatcher({
       }, pollIntervalMs);
     }
 
+    function cleanupPolling() {
+      cancelled = true;
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
+    }
+
+    if (watcherRuntime.canWatchTarget(handle)) {
+      let subscription: { stop(): Promise<void> } | null = null;
+      watcherRuntime
+        .watchTarget({
+          target: handle,
+          recursive,
+          onChange: onRefresh,
+          onError: (error) => {
+            console.error("[FileSystemWatcher] native watch failed:", error);
+          },
+        })
+        .then((nextSubscription) => {
+          if (cancelled) {
+            void nextSubscription.stop().catch((error: unknown) => {
+              console.error(
+                "[FileSystemWatcher] native watch cleanup failed:",
+                error,
+              );
+            });
+            return;
+          }
+
+          subscription = nextSubscription;
+        })
+        .catch((error: unknown) => {
+          if (cancelled) {
+            return;
+          }
+
+          console.warn(
+            "[FileSystemWatcher] native watch setup failed, falling back to polling:",
+            error,
+          );
+          schedulePoll();
+        });
+
+      return () => {
+        cleanupPolling();
+        void subscription?.stop().catch((error: unknown) => {
+          console.error(
+            "[FileSystemWatcher] native watch cleanup failed:",
+            error,
+          );
+        });
+      };
+    }
+
     if (!supportsFileObserver()) {
       schedulePoll();
-      return () => {
-        cancelled = true;
-        if (pollTimer) {
-          clearTimeout(pollTimer);
-        }
-      };
+      return cleanupPolling;
     }
 
     if (!isBrowserFileHandle(handle) && !isBrowserDirectoryHandle(handle)) {
       schedulePoll();
-      return () => {
-        cancelled = true;
-        if (pollTimer) {
-          clearTimeout(pollTimer);
-        }
-      };
+      return cleanupPolling;
     }
 
     const FSObserver = window.FileSystemObserver;
     if (!FSObserver) {
       schedulePoll();
-      return () => {
-        cancelled = true;
-        if (pollTimer) {
-          clearTimeout(pollTimer);
-        }
-      };
+      return cleanupPolling;
     }
 
     const typeSet = new Set([...relevantTypes, "unknown"]);
@@ -152,11 +192,8 @@ export function useFileSystemWatcher({
     }
 
     return () => {
-      cancelled = true;
+      cleanupPolling();
       observer?.disconnect();
-      if (pollTimer) {
-        clearTimeout(pollTimer);
-      }
     };
   }, [handle, onRefresh, pollIntervalMs, recursive, relevantTypes]);
 }


### PR DESCRIPTION
## Summary
- add Rust/Tauri native path-watch commands backed by `notify`
- add a watcher runtime facade with desktop and web implementations
- route native desktop file/folder targets through the desktop watcher while keeping browser observer/polling behavior for the website
- update desktop runtime architecture docs to describe the native watcher path

## Verification
- `npm run typecheck`
- `npx vitest run src/runtime/tauriBridge.test.ts src/runtime/desktopWatcherRuntime.test.ts src/ui/hooks/useFileSystemWatcher.test.tsx`
- `cargo check` from `src-tauri/`
- changed-file ESLint: `npx eslint <changed ts/md files> --quiet`
- `git diff --check`
- `npm run desktop:build`

## Notes
- `npm run lint -- --quiet` still fails on the pre-existing unrelated `worker/src/index.ts:129 @typescript-eslint/no-unsafe-return` issue.
- Windows desktop build produced `src-tauri/target/release/lollipop-dragon.exe`, MSI, and NSIS bundles.