### PR TITLE
Fix comment thread controls and header popovers

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -102,6 +102,8 @@ MarkReview extends the plain comment protocol for threaded review questions.
 - Agents reply with a separate inline `answer:` CriticMarkup comment near the same text block.
 - The reply reuses the root `thread` value and sets `replyTo` to the root question `id`.
 - The reply can also include `author` so the UI can show `Codex`, `Cursor`, or a generic `Agent` label.
+- The Comments panel keeps replies collapsed under the root question and marks the root as `answered` once an `answer:` reply exists.
+- Deleting a thread-root `question:` comment deletes the linked `answer:` replies in the same thread so replies never remain as orphan comments.
 
 Example root:
 
@@ -135,6 +137,7 @@ No server required. The editor runs as a client-side application in Chrome/Edge 
 
 - Folder opening and file tree navigation with nested directory support
 - Rich markdown rendering: tables, syntax-highlighted code blocks, Mermaid diagrams, KaTeX math, footnotes, task lists, admonitions
+- Header table-of-contents navigation for markdown headings, with the popover opening above the document surface rather than being clipped by header toolbar overflow
 - CriticMarkup parsing — annotations are hidden from the rendered view and displayed as margin comments
 - Block-level commenting UI — hover to reveal comment button, select type, write comment, and CriticMarkup is inserted into the file
 - Comment panel (right sidebar) showing all comments in document order with filtering by type and status. In folder mode, comments are grouped by file — file headers display the full relative path (not just the filename) to distinguish files with identical names in different directories

--- a/src/markup/deleteComment.ts
+++ b/src/markup/deleteComment.ts
@@ -1,6 +1,23 @@
-import type { Comment } from '../types/criticmarkup'
+import type { Comment } from "../types/criticmarkup";
 
 // Return rawContent with the comment's raw markup removed entirely.
 export function applyDelete(rawContent: string, comment: Comment): string {
-  return rawContent.slice(0, comment.rawStart) + rawContent.slice(comment.rawEnd)
+  return (
+    rawContent.slice(0, comment.rawStart) + rawContent.slice(comment.rawEnd)
+  );
+}
+
+export function applyDeleteMany(
+  rawContent: string,
+  comments: Comment[],
+): string {
+  return [...comments]
+    .sort(
+      (leftComment, rightComment) =>
+        rightComment.rawStart - leftComment.rawStart,
+    )
+    .reduce(
+      (nextRawContent, comment) => applyDelete(nextRawContent, comment),
+      rawContent,
+    );
 }

--- a/src/markup/editDelete.test.ts
+++ b/src/markup/editDelete.test.ts
@@ -1,88 +1,106 @@
-import { describe, it, expect } from 'vitest'
-import { replaceCommentMarkup, applyEdit } from './editComment'
-import { applyDelete } from './deleteComment'
-import { makeComment } from '../testing/testHelpers'
+import { describe, it, expect } from "vitest";
+import { replaceCommentMarkup, applyEdit } from "./editComment";
+import { applyDelete, applyDeleteMany } from "./deleteComment";
+import { makeComment } from "../testing/testHelpers";
 
-describe('replaceCommentMarkup', () => {
-  it('builds a note comment with no prefix', () => {
-    expect(replaceCommentMarkup(makeComment(), 'note', 'my note')).toBe('{>>my note<<}')
-  })
+describe("replaceCommentMarkup", () => {
+  it("builds a note comment with no prefix", () => {
+    expect(replaceCommentMarkup(makeComment(), "note", "my note")).toBe(
+      "{>>my note<<}",
+    );
+  });
 
-  it('builds a typed comment with prefix', () => {
-    expect(replaceCommentMarkup(makeComment(), 'fix', 'fix this')).toBe('{>>fix: fix this<<}')
-  })
+  it("builds a typed comment with prefix", () => {
+    expect(replaceCommentMarkup(makeComment(), "fix", "fix this")).toBe(
+      "{>>fix: fix this<<}",
+    );
+  });
 
-  it('preserves highlight span when criticType is highlight', () => {
-    const c = makeComment({ criticType: 'highlight', highlightedText: 'important span' })
-    expect(replaceCommentMarkup(c, 'note', 'a note')).toBe('{==important span==}{>>a note<<}')
-  })
-
-  it('preserves highlight span with typed prefix', () => {
-    const c = makeComment({ criticType: 'highlight', highlightedText: 'text' })
-    expect(replaceCommentMarkup(c, 'rewrite', 'rewrite it')).toBe('{==text==}{>>rewrite: rewrite it<<}')
-  })
-
-  it('preserves hidden thread metadata when editing a threaded question', () => {
+  it("preserves highlight span when criticType is highlight", () => {
     const c = makeComment({
-      type: 'question',
-      text: 'Why?',
+      criticType: "highlight",
+      highlightedText: "important span",
+    });
+    expect(replaceCommentMarkup(c, "note", "a note")).toBe(
+      "{==important span==}{>>a note<<}",
+    );
+  });
+
+  it("preserves highlight span with typed prefix", () => {
+    const c = makeComment({ criticType: "highlight", highlightedText: "text" });
+    expect(replaceCommentMarkup(c, "rewrite", "rewrite it")).toBe(
+      "{==text==}{>>rewrite: rewrite it<<}",
+    );
+  });
+
+  it("preserves hidden thread metadata when editing a threaded question", () => {
+    const c = makeComment({
+      type: "question",
+      text: "Why?",
       thread: {
-        commentId: 'mr-question-1',
-        threadId: 'mr-question-1',
+        commentId: "mr-question-1",
+        threadId: "mr-question-1",
       },
-    })
-    expect(replaceCommentMarkup(c, 'question', 'Updated why?')).toBe(
+    });
+    expect(replaceCommentMarkup(c, "question", "Updated why?")).toBe(
       '{>>question: Updated why? [markreview id="mr-question-1" thread="mr-question-1"]<<}',
-    )
-  })
+    );
+  });
 
-  it('preserves reply metadata and author label when editing an answer', () => {
+  it("preserves reply metadata and author label when editing an answer", () => {
     const c = makeComment({
-      type: 'answer',
-      text: 'Because.',
+      type: "answer",
+      text: "Because.",
       thread: {
-        commentId: 'mr-answer-1',
-        threadId: 'mr-question-1',
-        replyTo: 'mr-question-1',
-        authorLabel: 'Codex',
+        commentId: "mr-answer-1",
+        threadId: "mr-question-1",
+        replyTo: "mr-question-1",
+        authorLabel: "Codex",
       },
-    })
-    expect(replaceCommentMarkup(c, 'answer', 'Updated answer')).toBe(
+    });
+    expect(replaceCommentMarkup(c, "answer", "Updated answer")).toBe(
       '{>>answer: Updated answer [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}',
-    )
-  })
-})
+    );
+  });
+});
 
-describe('applyEdit', () => {
-  it('replaces comment in the middle of the content', () => {
-    const raw = 'Before.{>>old<<}After.'
-    const c = makeComment({ raw: '{>>old<<}', rawStart: 7, rawEnd: 16 })
-    expect(applyEdit(raw, c, 'fix', 'new')).toBe('Before.{>>fix: new<<}After.')
-  })
+describe("applyEdit", () => {
+  it("replaces comment in the middle of the content", () => {
+    const raw = "Before.{>>old<<}After.";
+    const c = makeComment({ raw: "{>>old<<}", rawStart: 7, rawEnd: 16 });
+    expect(applyEdit(raw, c, "fix", "new")).toBe("Before.{>>fix: new<<}After.");
+  });
 
-  it('replaces comment at the start', () => {
-    const raw = '{>>start<<}rest'
-    const c = makeComment({ raw: '{>>start<<}', rawStart: 0, rawEnd: 11 })
-    expect(applyEdit(raw, c, 'note', 'updated')).toBe('{>>updated<<}rest')
-  })
-})
+  it("replaces comment at the start", () => {
+    const raw = "{>>start<<}rest";
+    const c = makeComment({ raw: "{>>start<<}", rawStart: 0, rawEnd: 11 });
+    expect(applyEdit(raw, c, "note", "updated")).toBe("{>>updated<<}rest");
+  });
+});
 
-describe('applyDelete', () => {
-  it('removes the comment markup from content', () => {
-    const raw = 'Hello.{>>delete me<<} World.'
-    const c = makeComment({ rawStart: 6, rawEnd: 21 })
-    expect(applyDelete(raw, c)).toBe('Hello. World.')
-  })
+describe("applyDelete", () => {
+  it("removes the comment markup from content", () => {
+    const raw = "Hello.{>>delete me<<} World.";
+    const c = makeComment({ rawStart: 6, rawEnd: 21 });
+    expect(applyDelete(raw, c)).toBe("Hello. World.");
+  });
 
-  it('removes a comment at the start', () => {
-    const raw = '{>>start<<}rest'
-    const c = makeComment({ rawStart: 0, rawEnd: 11 })
-    expect(applyDelete(raw, c)).toBe('rest')
-  })
+  it("removes a comment at the start", () => {
+    const raw = "{>>start<<}rest";
+    const c = makeComment({ rawStart: 0, rawEnd: 11 });
+    expect(applyDelete(raw, c)).toBe("rest");
+  });
 
-  it('removes a comment at the end', () => {
-    const raw = 'content{>>end<<}'
-    const c = makeComment({ rawStart: 7, rawEnd: 16 })
-    expect(applyDelete(raw, c)).toBe('content')
-  })
-})
+  it("removes a comment at the end", () => {
+    const raw = "content{>>end<<}";
+    const c = makeComment({ rawStart: 7, rawEnd: 16 });
+    expect(applyDelete(raw, c)).toBe("content");
+  });
+
+  it("removes multiple comments using original raw offsets", () => {
+    const raw = "A{>>q<<}B{>>a<<}C";
+    const question = makeComment({ rawStart: 1, rawEnd: 8 });
+    const answer = makeComment({ rawStart: 9, rawEnd: 16 });
+    expect(applyDeleteMany(raw, [question, answer])).toBe("ABC");
+  });
+});

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -1,8 +1,10 @@
 import type { StoreApi } from "zustand";
 import {
   applyDelete,
+  applyDeleteMany,
   applyEdit,
   assignBlockIndices,
+  buildCommentThreadGroups,
   insertComment as insertCommentService,
   parseMarkdownFrontmatter,
   parseCriticMarkup,
@@ -74,6 +76,24 @@ export function findResolvedComments(
   rawContent: string,
 ): Comment[] {
   return comments.filter((comment) => !rawContent.includes(comment.raw));
+}
+
+function getDeletedCommentsForSelection(
+  comments: Comment[],
+  selectedComment: Comment,
+): Comment[] {
+  if (!selectedComment.thread || selectedComment.thread.replyTo) {
+    return [selectedComment];
+  }
+
+  const selectedThread = buildCommentThreadGroups(comments).find(
+    (thread) => thread.root.id === selectedComment.id,
+  );
+  if (!selectedThread) {
+    return [selectedComment];
+  }
+
+  return [selectedThread.root, ...selectedThread.replies];
 }
 
 export async function writeAndUpdate<
@@ -292,7 +312,10 @@ export function createHostReviewControllerActions<
         set,
         buildUpdatedActiveTabs,
         fileHandle: tab.fileHandle,
-        newRawContent: applyDelete(tab.rawContent, comment),
+        newRawContent: applyDeleteMany(
+          tab.rawContent,
+          getDeletedCommentsForSelection(tab.comments, comment),
+        ),
       });
     },
 

--- a/src/modules/host-review/test/hostReviewActions.test.ts
+++ b/src/modules/host-review/test/hostReviewActions.test.ts
@@ -127,6 +127,110 @@ describe("store.deleteComment", () => {
     expect(tab?.rawContent).toBe("HelloWorld");
     expect(tab?.undoState?.rawContent).toBe(rawContent);
   });
+
+  it("removes a whole question thread when deleting the root question", async () => {
+    const { handle, mockWritable } = makeHandle();
+    const questionRaw =
+      '{>>question: Why? [markreview id="mr-question-1" thread="mr-question-1"]<<}';
+    const answerRaw =
+      '{>>answer: Because. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}';
+    const rawContent = `Before ${questionRaw} middle ${answerRaw} after`;
+    const questionStart = rawContent.indexOf(questionRaw);
+    const answerStart = rawContent.indexOf(answerRaw);
+    const question = makeComment({
+      id: "question-root",
+      type: "question",
+      text: "Why?",
+      raw: questionRaw,
+      rawStart: questionStart,
+      rawEnd: questionStart + questionRaw.length,
+      thread: {
+        commentId: "mr-question-1",
+        threadId: "mr-question-1",
+      },
+    });
+    const answer = makeComment({
+      id: "answer-reply",
+      type: "answer",
+      text: "Because.",
+      raw: answerRaw,
+      rawStart: answerStart,
+      rawEnd: answerStart + answerRaw.length,
+      thread: {
+        commentId: "mr-answer-1",
+        threadId: "mr-question-1",
+        replyTo: "mr-question-1",
+        authorLabel: "Codex",
+      },
+    });
+    setTestState({
+      fileHandle: handle,
+      rawContent,
+      comments: [question, answer],
+    });
+
+    await useAppStore.getState().deleteComment("question-root");
+
+    const expectedContent = rawContent
+      .replace(questionRaw, "")
+      .replace(answerRaw, "");
+    expect(mockWritable.write).toHaveBeenCalledWith(expectedContent);
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.rawContent).toBe(expectedContent);
+    expect(tab?.rawContent).not.toContain("answer:");
+    expect(tab?.undoState?.rawContent).toBe(rawContent);
+  });
+
+  it("removes only the selected answer when deleting a thread reply", async () => {
+    const { handle, mockWritable } = makeHandle();
+    const questionRaw =
+      '{>>question: Why? [markreview id="mr-question-1" thread="mr-question-1"]<<}';
+    const answerRaw =
+      '{>>answer: Because. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}';
+    const rawContent = `Before ${questionRaw} middle ${answerRaw} after`;
+    const questionStart = rawContent.indexOf(questionRaw);
+    const answerStart = rawContent.indexOf(answerRaw);
+    setTestState({
+      fileHandle: handle,
+      rawContent,
+      comments: [
+        makeComment({
+          id: "question-root",
+          type: "question",
+          text: "Why?",
+          raw: questionRaw,
+          rawStart: questionStart,
+          rawEnd: questionStart + questionRaw.length,
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+        makeComment({
+          id: "answer-reply",
+          type: "answer",
+          text: "Because.",
+          raw: answerRaw,
+          rawStart: answerStart,
+          rawEnd: answerStart + answerRaw.length,
+          thread: {
+            commentId: "mr-answer-1",
+            threadId: "mr-question-1",
+            replyTo: "mr-question-1",
+            authorLabel: "Codex",
+          },
+        }),
+      ],
+    });
+
+    await useAppStore.getState().deleteComment("answer-reply");
+
+    const expectedContent = rawContent.replace(answerRaw, "");
+    expect(mockWritable.write).toHaveBeenCalledWith(expectedContent);
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.rawContent).toContain("question:");
+    expect(tab?.rawContent).not.toContain("answer:");
+  });
 });
 
 describe("store.undo", () => {

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -59,23 +59,6 @@
   background-color: color-mix(in srgb, var(--c-red) 10%, transparent);
 }
 
-.comment-panel__secondary-action {
-  margin-left: auto;
-  background: var(--surface);
-  border: 1px solid var(--border-light);
-  border-radius: 999px;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: 0.7rem;
-  font-weight: 600;
-  padding: 0.18rem 0.55rem;
-}
-
-.comment-panel__secondary-action:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
 .comment-panel__danger-trigger {
   background: var(--surface);
   border: 1px solid var(--border-light);
@@ -441,6 +424,19 @@
   font-size: 0.7rem;
   color: var(--text-muted);
   font-family: var(--font-mono);
+}
+
+.comment-panel__status {
+  flex-shrink: 0;
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+  color: var(--accent);
+  font-size: 0.64rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.16rem 0.4rem;
+  text-transform: uppercase;
 }
 
 /* ── Cross-file comment panel ──────────────────────────────── */

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -183,6 +183,7 @@ describe("CommentPanel — active entry", () => {
     const { container } = render(<CommentPanel />);
 
     expect(screen.getByText("Why is this here?")).toBeInTheDocument();
+    expect(screen.getByText("answered")).toBeInTheDocument();
     expect(
       screen.queryByText("Because it explains reconnect fallback."),
     ).not.toBeInTheDocument();
@@ -206,7 +207,7 @@ describe("CommentPanel — close", () => {
 });
 
 describe("CommentPanel — agent prompt", () => {
-  it("shows a copy review prompt button when actionable comments exist", () => {
+  it("does not show copy-prompt actions in the comments panel header", () => {
     setTestState({
       activeFilePath: "docs/spec.md",
       comments: [
@@ -220,46 +221,14 @@ describe("CommentPanel — agent prompt", () => {
 
     render(<CommentPanel />);
     expect(
-      screen.getByRole("button", { name: "Copy review prompt" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Copy review prompt" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy agent prompt" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("copies the address-comments prompt to the clipboard", async () => {
-    const user = userEvent.setup();
-    const writeText = vi
-      .spyOn(navigator.clipboard, "writeText")
-      .mockResolvedValue(undefined);
-
-    setTestState({
-      activeFilePath: "docs/spec.md",
-      comments: [
-        makeCommentBase({
-          id: "fix-root",
-          type: "fix",
-          text: "Fix the intro",
-        }),
-      ],
-    });
-
-    render(<CommentPanel />);
-    await user.click(
-      screen.getByRole("button", { name: "Copy review prompt" }),
-    );
-
-    expect(writeText).toHaveBeenCalledOnce();
-    expect(writeText.mock.calls[0]?.[0]).toContain("Work only in docs/spec.md");
-    expect(writeText.mock.calls[0]?.[0]).toContain(
-      "- fix-root (fix): Fix the intro",
-    );
-    expect(useAppStore.getState().toast).toBe("Agent review prompt copied");
-  });
-
-  it("copies a folder address-comments prompt from scanned file comments", async () => {
-    const user = userEvent.setup();
-    const writeText = vi
-      .spyOn(navigator.clipboard, "writeText")
-      .mockResolvedValue(undefined);
-
+  it("does not show folder-level copy-prompt actions in the comments panel header", () => {
     setTestState({
       fileTree: [
         {
@@ -295,26 +264,12 @@ describe("CommentPanel — agent prompt", () => {
     });
 
     render(<CommentPanel />);
-    await user.click(
-      screen.getByRole("button", { name: "Copy review prompt" }),
-    );
-
-    expect(writeText).toHaveBeenCalledOnce();
-    expect(writeText.mock.calls[0]?.[0]).toContain(
-      "Work only in the listed markdown files",
-    );
-    expect(writeText.mock.calls[0]?.[0]).toContain("- docs/notes.md");
-    expect(writeText.mock.calls[0]?.[0]).toContain(
-      "  - note-root (note): Check this claim",
-    );
-    expect(writeText.mock.calls[0]?.[0]).toContain("- docs/spec.md");
-    expect(writeText.mock.calls[0]?.[0]).toContain(
-      "  - fix-root (fix): Fix the intro",
-    );
-    expect(useAppStore.getState().toast).toBe("Agent review prompt copied");
+    expect(
+      screen.queryByRole("button", { name: "Copy review prompt" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("shows a copy prompt button when question threads exist", () => {
+  it("does not show question-thread copy-prompt actions in the comments panel header", () => {
     setTestState({
       comments: [
         makeCommentBase({
@@ -331,35 +286,8 @@ describe("CommentPanel — agent prompt", () => {
 
     render(<CommentPanel />);
     expect(
-      screen.getByRole("button", { name: "Copy agent prompt" }),
-    ).toBeInTheDocument();
-  });
-
-  it("copies the agent prompt to the clipboard", async () => {
-    const user = userEvent.setup();
-    const writeText = vi
-      .spyOn(navigator.clipboard, "writeText")
-      .mockResolvedValue(undefined);
-
-    setTestState({
-      comments: [
-        makeCommentBase({
-          id: "question-root",
-          type: "question",
-          text: "Why is this here?",
-          thread: {
-            commentId: "mr-question-1",
-            threadId: "mr-question-1",
-          },
-        }),
-      ],
-    });
-
-    render(<CommentPanel />);
-    await user.click(screen.getByRole("button", { name: "Copy agent prompt" }));
-
-    expect(writeText).toHaveBeenCalledOnce();
-    expect(useAppStore.getState().toast).toBe("Agent prompt copied");
+      screen.queryByRole("button", { name: "Copy agent prompt" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows and stops an active agent run for the current tab", async () => {

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -1,16 +1,9 @@
 import "./CommentPanel.css";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  buildAddressCommentsAgentPrompt,
-  buildAgentReplyPrompt,
-  buildCommentThreadGroups,
-  buildFolderAddressCommentsAgentPrompt,
-} from "../../../markup";
+import { buildCommentThreadGroups } from "../../../markup";
 import {
   getActiveAgentRunForTab,
-  getAddressableCommentTargets,
   getFinishedAgentRunHistoryForTab,
-  getFolderAddressableCommentTargets,
 } from "../../../modules/agent-workflow";
 import type { AgentRun, AgentRunStatus } from "../../../modules/agent-workflow";
 import {
@@ -27,10 +20,6 @@ import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
 import type { Comment, CommentType } from "../../../types/criticmarkup";
 import type { PeerComment } from "../../../types/share";
 import type { TabState } from "../../../types/tab";
-import {
-  getAddressCommentsAgentAction,
-  getQuestionThreadAgentAction,
-} from "../../agentActions";
 import { AgentTerminal } from "../AgentTerminal";
 
 const ALL_TYPES: CommentType[] = [
@@ -75,6 +64,11 @@ const EMPTY_COMMENTS: Comment[] = [];
 const EMPTY_FILE_TREE: TabState["fileTree"] = [];
 const EMPTY_ALL_FILE_COMMENTS: TabState["allFileComments"] = {};
 const EMPTY_AGENT_RUNS: AgentRun[] = [];
+const EMPTY_ANSWERED_COMMENT_IDS = new Set<string>();
+const EMPTY_ANSWERED_COMMENT_IDS_BY_PATH = new Map<
+  string,
+  ReadonlySet<string>
+>();
 const INITIAL_AGENT_CAPABILITY: AgentRuntimeCapability = {
   canRunAgent: false,
   unavailableMessage: canRunAgent
@@ -160,6 +154,19 @@ function getRootOnlyComments(comments: Comment[]): Comment[] {
   return buildCommentThreadGroups(comments).map((group) => group.root);
 }
 
+function getAnsweredQuestionIds(comments: Comment[]): ReadonlySet<string> {
+  const answeredQuestionIds = new Set<string>();
+  for (const group of buildCommentThreadGroups(comments)) {
+    if (
+      group.root.type === "question" &&
+      group.replies.some((reply) => reply.type === "answer")
+    ) {
+      answeredQuestionIds.add(group.root.id);
+    }
+  }
+  return answeredQuestionIds;
+}
+
 function getActiveRootCommentId(
   comments: Comment[],
   activeCommentId: string | null,
@@ -191,6 +198,10 @@ export function CommentPanel({ peerMode = false }: Props) {
     () => getRootOnlyComments(comments),
     [comments],
   );
+  const answeredQuestionIds = useMemo(
+    () => getAnsweredQuestionIds(comments),
+    [comments],
+  );
   const resolvedComments = tab?.resolvedComments ?? EMPTY_COMMENTS;
   const activeCommentId = tab?.activeCommentId ?? null;
   const activeRootCommentId = useMemo(
@@ -218,12 +229,6 @@ export function CommentPanel({ peerMode = false }: Props) {
   const editPeerComment = useAppStore((state) => state.editPeerComment);
   const deletePeerComment = useAppStore((state) => state.deletePeerComment);
   const selectPeerFile = useAppStore((state) => state.selectPeerFile);
-  const startQuestionThreadAgentRun = useAppStore(
-    (state) => state.startQuestionThreadAgentRun,
-  );
-  const startAddressCommentsAgentRun = useAppStore(
-    (state) => state.startAddressCommentsAgentRun,
-  );
   const stopActiveAgentRun = useAppStore((state) => state.stopActiveAgentRun);
   const syncActiveAgentRunStatus = useAppStore(
     (state) => state.syncActiveAgentRunStatus,
@@ -305,6 +310,16 @@ export function CommentPanel({ peerMode = false }: Props) {
     );
     return entries;
   }, [isFolderMode, allFileComments]);
+  const answeredQuestionIdsByPath = useMemo(() => {
+    if (!isFolderMode) {
+      return EMPTY_ANSWERED_COMMENT_IDS_BY_PATH;
+    }
+    const byPath = new Map<string, ReadonlySet<string>>();
+    for (const entry of Object.values(allFileComments)) {
+      byPath.set(entry.filePath, getAnsweredQuestionIds(entry.comments));
+    }
+    return byPath;
+  }, [allFileComments, isFolderMode]);
 
   // Total count across all files for folder/peer-multi-file mode
   const totalCrossFileCount = useMemo(() => {
@@ -319,38 +334,6 @@ export function CommentPanel({ peerMode = false }: Props) {
       0,
     );
   }, [isPeerMultiFile, myPeerComments.length, isFolderMode, crossFileComments]);
-
-  const hasQuestionThreads = useMemo(() => {
-    if (peerMode) {
-      return false;
-    }
-    if (isFolderMode) {
-      return crossFileComments.some((entry) =>
-        entry.comments.some(
-          (comment) => comment.type === "question" && !!comment.thread,
-        ),
-      );
-    }
-    return hostRootComments.some(
-      (comment) => comment.type === "question" && !!comment.thread,
-    );
-  }, [crossFileComments, hostRootComments, isFolderMode, peerMode]);
-  const addressableCommentTargets = useMemo(() => {
-    if (peerMode || isFolderMode) {
-      return [];
-    }
-    return getAddressableCommentTargets(comments);
-  }, [comments, isFolderMode, peerMode]);
-  const folderAddressableCommentTargets = useMemo(() => {
-    if (peerMode || !isFolderMode) {
-      return [];
-    }
-    return getFolderAddressableCommentTargets(crossFileComments);
-  }, [crossFileComments, isFolderMode, peerMode]);
-  const hasAddressableComments = isFolderMode
-    ? folderAddressableCommentTargets.length > 0
-    : addressableCommentTargets.length > 0;
-  const shouldPromptAgentSetup = canRunAgent && !agentCapability.canRunAgent;
 
   const isResolved = !peerMode && commentFilter === "resolved";
 
@@ -424,44 +407,20 @@ export function CommentPanel({ peerMode = false }: Props) {
     return body.length > 72 ? body.slice(0, 72) + "…" : body;
   }
 
-  async function handleCopyAgentPrompt() {
-    try {
-      await navigator.clipboard.writeText(buildAgentReplyPrompt());
-      showToast("Agent prompt copied");
-    } catch (error) {
-      console.error("[CommentPanel] failed to copy agent prompt:", error);
-      showToast("Couldn't copy agent prompt");
-    }
+  function handleEditHostComment(id: string, type: CommentType, text: string) {
+    editComment(id, type, text).catch((error) => {
+      console.error("[CommentPanel] failed to edit comment:", error);
+      showToast("Couldn't edit comment");
+    });
   }
 
-  async function handleCopyAddressCommentsPrompt() {
-    const targetPath =
-      activeFilePath ?? tab?.fileName ?? "the active markdown file";
-    const prompt = isFolderMode
-      ? buildFolderAddressCommentsAgentPrompt({
-          targets: folderAddressableCommentTargets,
-        })
-      : buildAddressCommentsAgentPrompt({
-          targetPath,
-          comments: addressableCommentTargets,
-        });
-    try {
-      await navigator.clipboard.writeText(prompt);
-      showToast("Agent review prompt copied");
-    } catch (error) {
-      console.error("[CommentPanel] failed to copy agent prompt:", error);
-      showToast("Couldn't copy agent prompt");
-    }
+  function handleDeleteHostComment(id: string) {
+    deleteComment(id).catch((error) => {
+      console.error("[CommentPanel] failed to delete comment:", error);
+      showToast("Couldn't delete comment");
+    });
   }
 
-  const addressCommentsAgentAction = getAddressCommentsAgentAction({
-    canRunAgent: agentCapability.canRunAgent || shouldPromptAgentSetup,
-    canStartAddressCommentsRun: hasAddressableComments,
-  });
-  const questionThreadAgentAction = getQuestionThreadAgentAction({
-    canRunAgent: agentCapability.canRunAgent || shouldPromptAgentSetup,
-    canStartQuestionThreadRun: hasQuestionThreads,
-  });
   const canStopAgentRun = Boolean(
     activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
   );
@@ -498,38 +457,6 @@ export function CommentPanel({ peerMode = false }: Props) {
     !agentCapability.canRunAgent &&
     agentCapability.unavailableMessage,
   );
-
-  async function handleQuestionThreadAgentAction() {
-    if (questionThreadAgentAction.kind === "copy_prompt") {
-      await handleCopyAgentPrompt();
-      return;
-    }
-
-    const result = await startQuestionThreadAgentRun();
-    if (result.status === "unavailable") {
-      if (canRunAgent && result.reason === "agent_unavailable") {
-        openAgentSettings();
-        return;
-      }
-      showToast(result.message);
-    }
-  }
-
-  async function handleAddressCommentsAgentAction() {
-    if (addressCommentsAgentAction.kind === "copy_prompt") {
-      await handleCopyAddressCommentsPrompt();
-      return;
-    }
-
-    const result = await startAddressCommentsAgentRun();
-    if (result.status === "unavailable") {
-      if (canRunAgent && result.reason === "agent_unavailable") {
-        openAgentSettings();
-        return;
-      }
-      showToast(result.message);
-    }
-  }
 
   async function handleStopAgentRun() {
     const result = await stopActiveAgentRun();
@@ -711,37 +638,13 @@ export function CommentPanel({ peerMode = false }: Props) {
           )}
         </span>
         {!peerMode && displayCount > 0 && (
-          <>
-            {hasAddressableComments && !canStopAgentRun && (
-              <button
-                className="comment-panel__secondary-action"
-                onClick={() => {
-                  void handleAddressCommentsAgentAction();
-                }}
-                title={addressCommentsAgentAction.title}
-              >
-                {addressCommentsAgentAction.label}
-              </button>
-            )}
-            {hasQuestionThreads && !canStopAgentRun && (
-              <button
-                className="comment-panel__secondary-action"
-                onClick={() => {
-                  void handleQuestionThreadAgentAction();
-                }}
-                title={questionThreadAgentAction.title}
-              >
-                {questionThreadAgentAction.label}
-              </button>
-            )}
-            <button
-              className="comment-panel__danger-trigger"
-              onClick={() => setConfirmDeleteAll(true)}
-              title="Review before deleting all comments from the file"
-            >
-              Clear
-            </button>
-          </>
+          <button
+            className="comment-panel__danger-trigger"
+            onClick={() => setConfirmDeleteAll(true)}
+            title="Review before deleting all comments from the file"
+          >
+            Clear
+          </button>
         )}
         <button
           className="comment-panel__close"
@@ -995,6 +898,7 @@ export function CommentPanel({ peerMode = false }: Props) {
             onCrossFileClick={(filePath) => selectPeerFile(filePath)}
             onEdit={editPeerComment}
             onDelete={deletePeerComment}
+            answeredCommentIdsByPath={EMPTY_ANSWERED_COMMENT_IDS_BY_PATH}
           />
         ) : isFolderMode ? (
           <CrossFileList
@@ -1003,8 +907,9 @@ export function CommentPanel({ peerMode = false }: Props) {
             activeCommentId={activeRootCommentId}
             onEntryClick={handleEntryClick}
             onCrossFileClick={handleCrossFileClick}
-            onEdit={editComment}
-            onDelete={deleteComment}
+            onEdit={handleEditHostComment}
+            onDelete={handleDeleteHostComment}
+            answeredCommentIdsByPath={answeredQuestionIdsByPath}
           />
         ) : (
           <SingleFileList
@@ -1016,8 +921,11 @@ export function CommentPanel({ peerMode = false }: Props) {
             onEntryClick={handleEntryClick}
             entryLabel={entryLabel}
             hostEntryLabel={hostEntryLabel}
-            onEdit={peerMode ? editPeerComment : editComment}
-            onDelete={peerMode ? deletePeerComment : deleteComment}
+            onEdit={peerMode ? editPeerComment : handleEditHostComment}
+            onDelete={peerMode ? deletePeerComment : handleDeleteHostComment}
+            answeredCommentIds={
+              peerMode ? EMPTY_ANSWERED_COMMENT_IDS : answeredQuestionIds
+            }
           />
         )}
       </div>
@@ -1127,6 +1035,7 @@ function CommentEntry({
   isActive,
   isOtherFile,
   canEdit,
+  answered,
   onClick,
   onEdit,
   onDelete,
@@ -1135,6 +1044,7 @@ function CommentEntry({
   isActive: boolean;
   isOtherFile: boolean;
   canEdit: boolean;
+  answered: boolean;
   onClick: () => void;
   onEdit?: (id: string, type: CommentType, text: string) => void;
   onDelete?: (id: string) => void;
@@ -1219,6 +1129,14 @@ function CommentEntry({
       {comment.blockIndex !== undefined && (
         <span className="comment-panel__ref">¶{comment.blockIndex + 1}</span>
       )}
+      {answered && (
+        <span
+          className="comment-panel__status"
+          title="This question has an answer"
+        >
+          answered
+        </span>
+      )}
       {canEdit && (
         <span
           className="comment-panel__entry-actions"
@@ -1257,6 +1175,7 @@ function CrossFileList({
   onCrossFileClick,
   onEdit,
   onDelete,
+  answeredCommentIdsByPath,
 }: {
   entries: {
     filePath: string;
@@ -1269,6 +1188,7 @@ function CrossFileList({
   onCrossFileClick: (filePath: string, rawStart: number) => void;
   onEdit: (id: string, type: CommentType, text: string) => void;
   onDelete: (id: string) => void;
+  answeredCommentIdsByPath: ReadonlyMap<string, ReadonlySet<string>>;
 }) {
   const totalCount = entries.reduce(
     (sum, entry) => sum + entry.comments.length,
@@ -1294,6 +1214,9 @@ function CrossFileList({
             {entry.comments.map((comment) => {
               const rawStart = "rawStart" in comment ? comment.rawStart : 0;
               const canEdit = true;
+              const answeredCommentIds =
+                answeredCommentIdsByPath.get(entry.filePath) ??
+                EMPTY_ANSWERED_COMMENT_IDS;
               return (
                 <CommentEntry
                   key={`${entry.filePath}:${comment.id}`}
@@ -1301,6 +1224,7 @@ function CrossFileList({
                   isActive={isActiveFile && activeCommentId === comment.id}
                   isOtherFile={!isActiveFile}
                   canEdit={canEdit}
+                  answered={answeredCommentIds.has(comment.id)}
                   onClick={() => {
                     if (isActiveFile) {
                       onEntryClick(comment.id, comment.blockIndex);
@@ -1333,6 +1257,7 @@ function SingleFileList({
   hostEntryLabel,
   onEdit,
   onDelete,
+  answeredCommentIds,
 }: {
   visible: (Comment | DisplayComment)[];
   isResolved: boolean;
@@ -1344,6 +1269,7 @@ function SingleFileList({
   hostEntryLabel: (comment: Comment) => string;
   onEdit: (id: string, type: CommentType, text: string) => void;
   onDelete: (id: string) => void;
+  answeredCommentIds: ReadonlySet<string>;
 }) {
   if (visible.length === 0) {
     return (
@@ -1397,6 +1323,7 @@ function SingleFileList({
             isActive={activeCommentId === comment.id}
             isOtherFile={false}
             canEdit={true}
+            answered={answeredCommentIds.has(comment.id)}
             onClick={() => onEntryClick(comment.id, comment.blockIndex)}
             onEdit={onEdit}
             onDelete={onDelete}

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
@@ -90,7 +90,9 @@ describe("CommentThreadCard", () => {
       />,
     );
 
-    await user.click(screen.getAllByRole("button", { name: "Edit comment" })[1]);
+    await user.click(
+      screen.getAllByRole("button", { name: "Edit comment" })[1],
+    );
     const textarea = screen.getByDisplayValue(
       "It explains the reconnect fallback path.",
     );
@@ -124,5 +126,24 @@ describe("CommentThreadCard", () => {
     await user.click(screen.getByRole("button", { name: "Confirm delete" }));
 
     expect(onDelete).toHaveBeenCalledWith("reply-comment");
+  });
+
+  it("labels root deletion as deleting the thread", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    await user.click(
+      screen.getAllByRole("button", { name: "Delete comment" })[0],
+    );
+
+    expect(screen.getByText("Delete this thread?")).toBeInTheDocument();
   });
 });

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
@@ -49,7 +49,9 @@ function CommentBody({ comment }: { comment: Comment }) {
           "{comment.highlightedText}"
         </p>
       )}
-      {comment.text && <p className="comment-thread-card__content">{comment.text}</p>}
+      {comment.text && (
+        <p className="comment-thread-card__content">{comment.text}</p>
+      )}
     </>
   );
 }
@@ -149,9 +151,8 @@ function CommentRow({
 }: CommentRowProps) {
   const editable = EDITABLE_CRITIC_TYPES.includes(comment.criticType);
   const authorLabel =
-    comment.type === "answer"
-      ? (comment.thread?.authorLabel ?? "Agent")
-      : null;
+    comment.type === "answer" ? (comment.thread?.authorLabel ?? "Agent") : null;
+  const deletingThreadRoot = !!comment.thread && !comment.thread.replyTo;
 
   return (
     <div
@@ -199,7 +200,11 @@ function CommentRow({
         />
       ) : confirmingDelete ? (
         <div className="comment-thread-card__confirm">
-          <p>Delete this comment?</p>
+          <p>
+            {deletingThreadRoot
+              ? "Delete this thread?"
+              : "Delete this comment?"}
+          </p>
           <div className="comment-add-form__actions">
             <button
               className="comment-thread-card__confirm-yes"
@@ -266,7 +271,9 @@ export function CommentThreadCard({
 
       <div className="comment-thread-card__list">
         {comments.length === 0 && (
-          <p className="comment-thread-card__empty">No comments in this thread.</p>
+          <p className="comment-thread-card__empty">
+            No comments in this thread.
+          </p>
         )}
         {comments.map((comment, index) => (
           <CommentRow

--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -206,6 +206,44 @@
   border-color: var(--accent);
 }
 
+.app-header__menu-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.app-header__menu {
+  position: fixed;
+  z-index: 80;
+  min-width: 12rem;
+  padding: 0.35rem;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--surface);
+  box-shadow: var(--shadow-md);
+}
+
+.app-header__menu-item {
+  width: 100%;
+  min-height: 2rem;
+  padding: 0.4rem 0.55rem;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.app-header__menu-item:hover,
+.app-header__menu-item:focus-visible {
+  outline: none;
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
 /* ── Peer badge in header ─────────────────────────────────────── */
 .app-header__peer-badge {
   font-size: 0.6875rem;

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -1,5 +1,16 @@
 import "./Header.css";
-import { buildCommentThreadGroups } from "../../../markup";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildAddressCommentsAgentPrompt,
+  buildAgentReplyPrompt,
+  buildCommentThreadGroups,
+  buildFolderAddressCommentsAgentPrompt,
+} from "../../../markup";
+import {
+  getActiveAgentRunForTab,
+  getAddressableCommentTargets,
+  getFolderAddressableCommentTargets,
+} from "../../../modules/agent-workflow";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { selectUnsubmittedPeerComments } from "../../../modules/peer-review";
@@ -10,9 +21,11 @@ import { TableOfContents } from "../TableOfContents";
 import { ConnectionStatus } from "../ConnectionStatus";
 import { WORKER_URL } from "../../../config";
 import { syncActiveShares } from "../../../modules/sharing";
+import { canRunAgent } from "../../../runtime";
 import { downloadActiveFile } from "./downloadActiveFile";
 import { tabRequiresRestoreAccess } from "../../../types/tab";
-import { canRunAgent } from "../../../runtime";
+import type { Comment } from "../../../types/criticmarkup";
+import type { TabState } from "../../../types/tab";
 
 function FocusIcon() {
   return (
@@ -240,6 +253,30 @@ function CommentIcon() {
   );
 }
 
+function AgentIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 8V4H8" />
+      <rect width="16" height="12" x="4" y="8" rx="2" />
+      <path d="M2 14h2" />
+      <path d="M20 14h2" />
+      <path d="M15 13v2" />
+      <path d="M9 13v2" />
+    </svg>
+  );
+}
+
 function PresentIcon() {
   return (
     <svg
@@ -259,27 +296,41 @@ function PresentIcon() {
   );
 }
 
-function AgentIcon() {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="4" y="6" width="16" height="12" rx="2" />
-      <path d="M8 10h.01" />
-      <path d="M16 10h.01" />
-      <path d="M9 14h6" />
-      <path d="M12 2v4" />
-    </svg>
-  );
+const ACTIVE_AGENT_RUN_STATUSES = new Set([
+  "queued",
+  "running",
+  "needs_attention",
+]);
+const EMPTY_COMMENTS: Comment[] = [];
+const EMPTY_ALL_FILE_COMMENTS: TabState["allFileComments"] = {};
+const EMPTY_FILE_TREE: TabState["fileTree"] = [];
+const EMPTY_SHARES: TabState["shares"] = [];
+
+interface FileCommentEntry {
+  filePath: string;
+  fileName: string;
+  comments: Comment[];
+}
+
+interface HeaderMenuPosition {
+  top: number;
+  right: number;
+}
+
+function getRootOnlyComments(comments: Comment[]): Comment[] {
+  return buildCommentThreadGroups(comments).map((group) => group.root);
+}
+
+function getRootOnlyFileComments(
+  allFileComments: TabState["allFileComments"],
+): FileCommentEntry[] {
+  return Object.values(allFileComments)
+    .map((entry) => ({
+      ...entry,
+      comments: getRootOnlyComments(entry.comments),
+    }))
+    .filter((entry) => entry.comments.length > 0)
+    .sort((entryA, entryB) => entryA.filePath.localeCompare(entryB.filePath));
 }
 
 interface Props {
@@ -304,7 +355,6 @@ export function Header({
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const toggleCommentPanel = useAppStore((s) => s.toggleCommentPanel);
   const toggleSharedPanel = useAppStore((s) => s.toggleSharedPanel);
-  const openAgentSettings = useAppStore((s) => s.openAgentSettings);
   const syncPeerComments = useAppStore((s) => s.syncPeerComments);
   const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
 
@@ -316,15 +366,16 @@ export function Header({
 
   const fileName = tab?.fileName ?? null;
   const directoryName = tab?.directoryName ?? null;
-  const fileTree = tab?.fileTree ?? [];
+  const fileTree = tab?.fileTree ?? EMPTY_FILE_TREE;
   const sidebarOpen = tab?.sidebarOpen ?? false;
-  const comments = tab?.comments ?? [];
-  const allFileComments = tab?.allFileComments ?? {};
+  const comments = tab?.comments ?? EMPTY_COMMENTS;
+  const allFileComments = tab?.allFileComments ?? EMPTY_ALL_FILE_COMMENTS;
+  const activeFilePath = tab?.activeFilePath ?? null;
   const peerCommentPanelOpen = useAppStore((s) => s.peerCommentPanelOpen);
   const rawCommentPanelOpen = peerMode
     ? peerCommentPanelOpen
     : (tab?.commentPanelOpen ?? false);
-  const shares = tab?.shares ?? [];
+  const shares = tab?.shares ?? EMPTY_SHARES;
   const rawSharedPanelOpen = tab?.sharedPanelOpen ?? false;
   const hasActiveShares = shares.some(
     (share) => new Date(share.expiresAt) > new Date(),
@@ -353,6 +404,16 @@ export function Header({
     ? false
     : rawCommentPanelOpen;
   const sharedPanelOpen = disableHostReviewActions ? false : rawSharedPanelOpen;
+  const showToast = useAppStore((state) => state.showToast);
+  const startAddressCommentsAgentRun = useAppStore(
+    (state) => state.startAddressCommentsAgentRun,
+  );
+  const startQuestionThreadAgentRun = useAppStore(
+    (state) => state.startQuestionThreadAgentRun,
+  );
+  const activeAgentRun = useAppStore((state) =>
+    tab?.id ? getActiveAgentRunForTab(state, tab.id) : null,
+  );
   const totalPending = shares.reduce(
     (total, share) => total + share.pendingCommentCount,
     0,
@@ -365,6 +426,96 @@ export function Header({
       : hasContent
         ? "File review"
         : "";
+  const rootComments = useMemo(() => getRootOnlyComments(comments), [comments]);
+  const crossFileComments = useMemo(
+    () => getRootOnlyFileComments(allFileComments),
+    [allFileComments],
+  );
+  const addressableCommentTargets = useMemo(() => {
+    if (peerMode || hasFolderComments) {
+      return [];
+    }
+    return getAddressableCommentTargets(comments);
+  }, [comments, hasFolderComments, peerMode]);
+  const folderAddressableCommentTargets = useMemo(() => {
+    if (peerMode || !hasFolderComments) {
+      return [];
+    }
+    return getFolderAddressableCommentTargets(crossFileComments);
+  }, [crossFileComments, hasFolderComments, peerMode]);
+  const hasAddressableComments = hasFolderComments
+    ? folderAddressableCommentTargets.length > 0
+    : addressableCommentTargets.length > 0;
+  const hasQuestionThreads =
+    !peerMode &&
+    (hasFolderComments
+      ? crossFileComments.some((entry) =>
+          entry.comments.some(
+            (comment) => comment.type === "question" && !!comment.thread,
+          ),
+        )
+      : rootComments.some(
+          (comment) => comment.type === "question" && !!comment.thread,
+        ));
+  const activeAgentRunInProgress = Boolean(
+    activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
+  );
+  const showAgentActions =
+    !peerMode &&
+    hasContent &&
+    !disableHostReviewActions &&
+    (hasAddressableComments || hasQuestionThreads);
+
+  async function handleCopyAddressCommentsPrompt() {
+    const targetPath = activeFilePath ?? fileName ?? "the active markdown file";
+    const prompt = hasFolderComments
+      ? buildFolderAddressCommentsAgentPrompt({
+          targets: folderAddressableCommentTargets,
+        })
+      : buildAddressCommentsAgentPrompt({
+          targetPath,
+          comments: addressableCommentTargets,
+        });
+    try {
+      await navigator.clipboard.writeText(prompt);
+      showToast("Agent review prompt copied");
+    } catch (error) {
+      console.error("[Header] failed to copy review prompt:", error);
+      showToast("Couldn't copy agent prompt");
+    }
+  }
+
+  async function handleCopyQuestionPrompt() {
+    try {
+      await navigator.clipboard.writeText(buildAgentReplyPrompt());
+      showToast("Agent prompt copied");
+    } catch (error) {
+      console.error("[Header] failed to copy question prompt:", error);
+      showToast("Couldn't copy agent prompt");
+    }
+  }
+
+  async function handleAddressCommentsAction() {
+    if (!canRunAgent) {
+      await handleCopyAddressCommentsPrompt();
+      return;
+    }
+    const result = await startAddressCommentsAgentRun();
+    if (result.status === "unavailable") {
+      showToast(result.message);
+    }
+  }
+
+  async function handleQuestionThreadAction() {
+    if (!canRunAgent) {
+      await handleCopyQuestionPrompt();
+      return;
+    }
+    const result = await startQuestionThreadAgentRun();
+    if (result.status === "unavailable") {
+      showToast(result.message);
+    }
+  }
 
   return (
     <>
@@ -391,7 +542,9 @@ export function Header({
           {!peerMode && (
             <div className="app-header__group app-header__group--source">
               <button
-                onClick={openFileInNewTab}
+                onClick={() => {
+                  void openFileInNewTab();
+                }}
                 className="app-header__btn app-header__btn--text"
                 title="Open file"
               >
@@ -399,7 +552,9 @@ export function Header({
                 <span className="app-header__btn-label">Open file</span>
               </button>
               <button
-                onClick={openDirectoryInNewTab}
+                onClick={() => {
+                  void openDirectoryInNewTab();
+                }}
                 className="app-header__btn app-header__btn--text"
                 title="Open folder"
               >
@@ -453,7 +608,9 @@ export function Header({
               </button>
               {hasActiveShares && (
                 <button
-                  onClick={syncActiveShares}
+                  onClick={() => {
+                    void syncActiveShares();
+                  }}
                   title="Push latest content to all active shares"
                   className="app-header__btn app-header__btn--text"
                   disabled={disableHostReviewActions}
@@ -466,18 +623,6 @@ export function Header({
           )}
 
           <div className="app-header__group app-header__group--view">
-            {!peerMode && canRunAgent && (
-              <button
-                onClick={openAgentSettings}
-                aria-label="Configure desktop agent"
-                title="Configure desktop agent"
-                className="app-header__btn app-header__btn--text"
-              >
-                <AgentIcon />
-                <span className="app-header__btn-label">Agent</span>
-              </button>
-            )}
-
             <TableOfContents peerMode={peerMode} />
 
             <button
@@ -496,7 +641,9 @@ export function Header({
             <div className="app-header__group app-header__group--peer">
               {unsubmittedPeerCount > 0 && (
                 <button
-                  onClick={syncPeerComments}
+                  onClick={() => {
+                    void syncPeerComments();
+                  }}
                   aria-label="Submit comments"
                   title={
                     documentUpdateAvailable
@@ -513,7 +660,9 @@ export function Header({
                 </button>
               )}
               <button
-                onClick={downloadActiveFile}
+                onClick={() => {
+                  void downloadActiveFile();
+                }}
                 aria-label="Save file"
                 title="Download current file as .md"
                 className="app-header__btn app-header__btn--text"
@@ -525,6 +674,21 @@ export function Header({
           )}
 
           <div className="app-header__group app-header__group--review">
+            {showAgentActions && (
+              <ReviewAgentMenu
+                disabled={activeAgentRunInProgress}
+                canAddressComments={hasAddressableComments}
+                canAnswerQuestions={hasQuestionThreads}
+                addressLabel={
+                  canRunAgent ? "Address comments" : "Copy review prompt"
+                }
+                questionLabel={
+                  canRunAgent ? "Answer questions" : "Copy answer prompt"
+                }
+                onAddressComments={handleAddressCommentsAction}
+                onAnswerQuestions={handleQuestionThreadAction}
+              />
+            )}
             <button
               onClick={toggleCommentPanel}
               aria-label={
@@ -572,5 +736,130 @@ export function Header({
         </div>
       </header>
     </>
+  );
+}
+
+function ReviewAgentMenu({
+  disabled,
+  canAddressComments,
+  canAnswerQuestions,
+  addressLabel,
+  questionLabel,
+  onAddressComments,
+  onAnswerQuestions,
+}: {
+  disabled: boolean;
+  canAddressComments: boolean;
+  canAnswerQuestions: boolean;
+  addressLabel: string;
+  questionLabel: string;
+  onAddressComments: () => Promise<void>;
+  onAnswerQuestions: () => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<HeaderMenuPosition | null>(
+    null,
+  );
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  const updateMenuPosition = useCallback(() => {
+    const button = buttonRef.current;
+    if (!button) {
+      return;
+    }
+    const rect = button.getBoundingClientRect();
+    setMenuPosition({
+      top: rect.bottom + 6,
+      right: Math.max(8, window.innerWidth - rect.right),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handleDocumentClick(event: MouseEvent) {
+      const targetNode = event.target;
+      if (targetNode instanceof Node && menuRef.current?.contains(targetNode)) {
+        return;
+      }
+      setOpen(false);
+    }
+
+    updateMenuPosition();
+    document.addEventListener("click", handleDocumentClick);
+    window.addEventListener("resize", updateMenuPosition);
+    window.addEventListener("scroll", updateMenuPosition, true);
+    return () => {
+      document.removeEventListener("click", handleDocumentClick);
+      window.removeEventListener("resize", updateMenuPosition);
+      window.removeEventListener("scroll", updateMenuPosition, true);
+    };
+  }, [open, updateMenuPosition]);
+
+  async function handleMenuAction(action: () => Promise<void>) {
+    setOpen(false);
+    await action();
+  }
+
+  return (
+    <div className="app-header__menu-wrap" ref={menuRef}>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`app-header__btn app-header__btn--icon app-header__btn--review${open ? " app-header__btn--active" : ""}`}
+        aria-label="Review actions"
+        aria-expanded={open}
+        title={
+          disabled
+            ? "Wait for the active agent run to finish"
+            : "Review actions"
+        }
+        disabled={disabled}
+        onClick={(event) => {
+          event.stopPropagation();
+          if (!open) {
+            updateMenuPosition();
+          }
+          setOpen((currentOpen) => !currentOpen);
+        }}
+      >
+        <AgentIcon />
+      </button>
+      {open && (
+        <div
+          className="app-header__menu"
+          role="menu"
+          style={{ position: "fixed", ...(menuPosition ?? {}) }}
+        >
+          {canAddressComments && (
+            <button
+              type="button"
+              className="app-header__menu-item"
+              role="menuitem"
+              onClick={() => {
+                void handleMenuAction(onAddressComments);
+              }}
+            >
+              {addressLabel}
+            </button>
+          )}
+          {canAnswerQuestions && (
+            <button
+              type="button"
+              className="app-header__menu-item"
+              role="menuitem"
+              onClick={() => {
+                void handleMenuAction(onAnswerQuestions);
+              }}
+            >
+              {questionLabel}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/ui/components/Header/HeaderShare.test.tsx
+++ b/src/ui/components/Header/HeaderShare.test.tsx
@@ -7,7 +7,11 @@ vi.mock("../../../config", () => ({
 }));
 
 import { Header } from "./index";
-import { resetTestStore, setTestState } from "../../../testing/testHelpers";
+import {
+  makeComment,
+  resetTestStore,
+  setTestState,
+} from "../../../testing/testHelpers";
 
 beforeEach(() => {
   resetTestStore();
@@ -126,5 +130,71 @@ describe("Header share buttons", () => {
       await user.click(screen.getByRole("button", { name: "Share folder" }));
       expect(onShareFolder).toHaveBeenCalledOnce();
     });
+  });
+});
+
+describe("Header review actions", () => {
+  it("keeps the address-comments prompt available from the toolbar menu", async () => {
+    const user = userEvent.setup();
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
+    setTestState({
+      fileName: "spec.md",
+      activeFilePath: "docs/spec.md",
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix the intro",
+        }),
+      ],
+    });
+
+    render(<Header />);
+    await user.click(screen.getByRole("button", { name: "Review actions" }));
+    await user.click(
+      screen.getByRole("menuitem", { name: "Copy review prompt" }),
+    );
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText.mock.calls[0]?.[0]).toContain("Work only in docs/spec.md");
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "- fix-root (fix): Fix the intro",
+    );
+  });
+
+  it("keeps the question-answer prompt available from the toolbar menu", async () => {
+    const user = userEvent.setup();
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
+    setTestState({
+      fileName: "spec.md",
+      comments: [
+        makeComment({
+          id: "question-root",
+          type: "question",
+          text: "Why is this here?",
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+      ],
+    });
+
+    render(<Header />);
+    await user.click(screen.getByRole("button", { name: "Review actions" }));
+    await user.click(
+      screen.getByRole("menuitem", { name: "Copy answer prompt" }),
+    );
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText.mock.calls[0]?.[0]).toContain(
+      "answer MarkReview threaded questions inline",
+    );
   });
 });

--- a/src/ui/components/TableOfContents/TableOfContents.css
+++ b/src/ui/components/TableOfContents/TableOfContents.css
@@ -3,9 +3,7 @@
 }
 
 .toc__menu {
-  position: absolute;
-  top: calc(100% + 0.25rem);
-  right: 0;
+  position: fixed;
   z-index: 100;
   width: 280px;
   background: var(--surface);

--- a/src/ui/components/TableOfContents/TableOfContents.test.tsx
+++ b/src/ui/components/TableOfContents/TableOfContents.test.tsx
@@ -30,6 +30,18 @@ describe("TableOfContents", () => {
     expect(screen.getByText("Section")).toBeInTheDocument();
   });
 
+  it("positions the popover outside header overflow clipping", () => {
+    setTestState({ rawContent: "# Title\n\nText." });
+    const { container } = render(<TableOfContents />);
+    fireEvent.click(screen.getByRole("button", { name: "Table of contents" }));
+    const menu = container.querySelector(".toc__menu");
+    expect(menu).toBeInTheDocument();
+    if (!(menu instanceof Element)) {
+      throw new Error("Expected table-of-contents menu to render");
+    }
+    expect(window.getComputedStyle(menu).position).toBe("fixed");
+  });
+
   it("closes popover after clicking a heading", () => {
     setTestState({ rawContent: "# Title\n\nText." });
     render(<TableOfContents />);

--- a/src/ui/components/TableOfContents/TableOfContents.tsx
+++ b/src/ui/components/TableOfContents/TableOfContents.tsx
@@ -1,5 +1,5 @@
 import "./TableOfContents.css";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
 import { parseCriticMarkup, parseMarkdownFrontmatter } from "../../../markup";
@@ -40,9 +40,16 @@ interface Props {
   peerMode?: boolean;
 }
 
+interface MenuPosition {
+  top: number;
+  right: number;
+}
+
 export function TableOfContents({ peerMode = false }: Props) {
   const [isOpen, setIsOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const tab = useActiveTab();
   const peerRawContent = useAppStore((s) => s.peerRawContent);
@@ -60,22 +67,45 @@ export function TableOfContents({ peerMode = false }: Props) {
 
   const disabled = headings.length === 0;
 
+  const updateMenuPosition = useCallback(() => {
+    const button = buttonRef.current;
+    if (!button) {
+      return;
+    }
+    const rect = button.getBoundingClientRect();
+    setMenuPosition({
+      top: rect.bottom + 4,
+      right: Math.max(8, window.innerWidth - rect.right),
+    });
+  }, []);
+
   // Close on click outside
   useEffect(() => {
     if (!isOpen) {
       return;
     }
     function handleClick(e: MouseEvent) {
+      const targetNode = e.target;
       if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
+        targetNode instanceof Node &&
+        dropdownRef.current?.contains(targetNode)
       ) {
+        return;
+      }
+      if (targetNode instanceof Node) {
         setIsOpen(false);
       }
     }
+    updateMenuPosition();
     document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [isOpen]);
+    window.addEventListener("resize", updateMenuPosition);
+    window.addEventListener("scroll", updateMenuPosition, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("resize", updateMenuPosition);
+      window.removeEventListener("scroll", updateMenuPosition, true);
+    };
+  }, [isOpen, updateMenuPosition]);
 
   function handleHeadingClick(blockIndex: number) {
     scrollToBlock(blockIndex);
@@ -85,17 +115,26 @@ export function TableOfContents({ peerMode = false }: Props) {
   return (
     <div className="toc" ref={dropdownRef}>
       <button
+        ref={buttonRef}
         className="app-header__btn app-header__btn--icon"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => {
+          if (!isOpen) {
+            updateMenuPosition();
+          }
+          setIsOpen(!isOpen);
+        }}
         disabled={disabled}
         aria-label="Table of contents"
-        title="Table of contents"
+        title={disabled ? "No headings in this document" : "Table of contents"}
       >
         <OutlineIcon />
       </button>
 
       {isOpen && (
-        <div className="toc__menu">
+        <div
+          className="toc__menu"
+          style={{ position: "fixed", ...(menuPosition ?? {}) }}
+        >
           <div className="toc__header">Contents</div>
           <ul className="toc__list">
             {headings.map((heading, i) => (


### PR DESCRIPTION
﻿## Summary
- Mark answered question roots in the Comments panel while keeping linked answer replies collapsed under the root thread.
- Move comment/answer agent actions out of the Comments panel header into a compact Review actions menu in the app header.
- Fix header popovers so the Table of Contents and Review actions menus render as fixed overlays instead of being clipped by toolbar overflow.
- Delete an entire question thread when its root question is deleted, and clarify the root-thread delete confirmation.

## Validation
- `npm test -- --run src/ui/components/CommentPanel/CommentPanel.test.tsx src/modules/host-review/test/hostReviewActions.test.ts src/ui/components/Header/HeaderShare.test.tsx src/ui/components/TableOfContents/TableOfContents.test.tsx`
- `npx eslint` on changed TypeScript/TSX files
- `npm run typecheck`
- `npm test` (64 files, 527 tests)
- `npm run build` (passes; existing Vite chunk-size warning remains)
