### PR TITLE
Prevent editing agent-authored comments

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -103,6 +103,7 @@ MarkReview extends the plain comment protocol for threaded review questions.
 - The reply reuses the root `thread` value and sets `replyTo` to the root question `id`.
 - The reply can also include `author` so the UI can show `Codex`, `Cursor`, or a generic `Agent` label.
 - The Comments panel keeps replies collapsed under the root question and marks the root as `answered` once an `answer:` reply exists.
+- Agent-authored replies render as read-only comments in the UI. Users can delete them, but cannot edit their text or type.
 - Deleting a thread-root `question:` comment deletes the linked `answer:` replies in the same thread so replies never remain as orphan comments.
 
 Example root:

--- a/src/ui/components/CommentCard/CommentCard.tsx
+++ b/src/ui/components/CommentCard/CommentCard.tsx
@@ -2,6 +2,7 @@ import "./CommentCard.css";
 import { useState } from "react";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
 import type { Comment, CommentType } from "../../../types/criticmarkup";
+import { canEditComment } from "../../../utils/commentPermissions";
 
 const COMMENT_TYPES: CommentType[] = [
   "note",
@@ -106,6 +107,7 @@ export function CommentCard({
           {!editing &&
             !confirming &&
             onEdit &&
+            canEditComment(comment) &&
             EDITABLE_TYPES.includes(comment.criticType) && (
               <button
                 className="comment-card__edit"

--- a/src/ui/components/CommentCard/CommentCardEditDelete.test.tsx
+++ b/src/ui/components/CommentCard/CommentCardEditDelete.test.tsx
@@ -1,90 +1,194 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
 import { CommentCard } from "./index";
 import { makeComment } from "../../../testing/testHelpers";
 
-const fixDefaults = { type: 'fix' as const, text: 'fix this', raw: '{>>fix: fix this<<}', rawEnd: 19 }
+const fixDefaults = {
+  type: "fix" as const,
+  text: "fix this",
+  raw: "{>>fix: fix this<<}",
+  rawEnd: 19,
+};
 
-describe('CommentCard — edit button', () => {
-  it('shows Edit button for comment criticType when onEdit is provided', () => {
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onEdit={vi.fn()} />)
-    expect(screen.getByRole('button', { name: 'Edit comment' })).toBeInTheDocument()
-  })
-
-  it('shows Edit button for highlight criticType', () => {
+describe("CommentCard — edit button", () => {
+  it("shows Edit button for comment criticType when onEdit is provided", () => {
     render(
       <CommentCard
-        comment={makeComment({ ...fixDefaults, criticType: 'highlight', highlightedText: 'some span' })}
-        top={0} onClose={vi.fn()} onEdit={vi.fn()}
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
       />,
-    )
-    expect(screen.getByRole('button', { name: 'Edit comment' })).toBeInTheDocument()
-  })
+    );
+    expect(
+      screen.getByRole("button", { name: "Edit comment" }),
+    ).toBeInTheDocument();
+  });
 
-  it('does not show Edit button for addition criticType', () => {
+  it("shows Edit button for highlight criticType", () => {
     render(
-      <CommentCard comment={makeComment({ ...fixDefaults, criticType: 'addition' })} top={0} onClose={vi.fn()} onEdit={vi.fn()} />,
-    )
-    expect(screen.queryByRole('button', { name: 'Edit comment' })).not.toBeInTheDocument()
-  })
+      <CommentCard
+        comment={makeComment({
+          ...fixDefaults,
+          criticType: "highlight",
+          highlightedText: "some span",
+        })}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Edit comment" }),
+    ).toBeInTheDocument();
+  });
 
-  it('shows inline form with pre-filled type and text on edit click', async () => {
-    const user = userEvent.setup()
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onEdit={vi.fn()} />)
-    await user.click(screen.getByRole('button', { name: 'Edit comment' }))
-    expect(screen.getByDisplayValue('fix this')).toBeInTheDocument()
-  })
+  it("does not show Edit button for addition criticType", () => {
+    render(
+      <CommentCard
+        comment={makeComment({ ...fixDefaults, criticType: "addition" })}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Edit comment" }),
+    ).not.toBeInTheDocument();
+  });
 
-  it('calls onEdit with updated type and text on save', async () => {
-    const user = userEvent.setup()
-    const onEdit = vi.fn()
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onEdit={onEdit} />)
-    await user.click(screen.getByRole('button', { name: 'Edit comment' }))
-    const textarea = screen.getByDisplayValue('fix this')
-    await user.clear(textarea)
-    await user.type(textarea, 'updated text')
-    await user.click(screen.getByRole('button', { name: 'Save' }))
-    expect(onEdit).toHaveBeenCalledWith('fix', 'updated text')
-  })
+  it("does not show Edit button for agent-authored answers", () => {
+    render(
+      <CommentCard
+        comment={makeComment({
+          type: "answer",
+          text: "Agent response",
+          raw: "{>>answer: Agent response<<}",
+          thread: {
+            commentId: "mr-answer-1",
+            threadId: "mr-question-1",
+            replyTo: "mr-question-1",
+            authorLabel: "Codex",
+          },
+        })}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Edit comment" }),
+    ).not.toBeInTheDocument();
+  });
 
-  it('hides form when Cancel is clicked', async () => {
-    const user = userEvent.setup()
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onEdit={vi.fn()} />)
-    await user.click(screen.getByRole('button', { name: 'Edit comment' }))
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-    expect(screen.queryByDisplayValue('fix this')).not.toBeInTheDocument()
-    expect(screen.getByText('fix this')).toBeInTheDocument()
-  })
-})
+  it("shows inline form with pre-filled type and text on edit click", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommentCard
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Edit comment" }));
+    expect(screen.getByDisplayValue("fix this")).toBeInTheDocument();
+  });
 
-describe('CommentCard — delete button', () => {
-  it('shows Delete button when onDelete is provided', () => {
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onDelete={vi.fn()} />)
-    expect(screen.getByRole('button', { name: 'Delete comment' })).toBeInTheDocument()
-  })
+  it("calls onEdit with updated type and text on save", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(
+      <CommentCard
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={onEdit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Edit comment" }));
+    const textarea = screen.getByDisplayValue("fix this");
+    await user.clear(textarea);
+    await user.type(textarea, "updated text");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(onEdit).toHaveBeenCalledWith("fix", "updated text");
+  });
 
-  it('shows confirmation after clicking Delete', async () => {
-    const user = userEvent.setup()
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onDelete={vi.fn()} />)
-    await user.click(screen.getByRole('button', { name: 'Delete comment' }))
-    expect(screen.getByText('Delete this comment?')).toBeInTheDocument()
-  })
+  it("hides form when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommentCard
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Edit comment" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByDisplayValue("fix this")).not.toBeInTheDocument();
+    expect(screen.getByText("fix this")).toBeInTheDocument();
+  });
+});
 
-  it('calls onDelete when confirmation is confirmed', async () => {
-    const user = userEvent.setup()
-    const onDelete = vi.fn()
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onDelete={onDelete} />)
-    await user.click(screen.getByRole('button', { name: 'Delete comment' }))
-    await user.click(screen.getByRole('button', { name: 'Confirm delete' }))
-    expect(onDelete).toHaveBeenCalledOnce()
-  })
+describe("CommentCard — delete button", () => {
+  it("shows Delete button when onDelete is provided", () => {
+    render(
+      <CommentCard
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Delete comment" }),
+    ).toBeInTheDocument();
+  });
 
-  it('hides confirmation when Cancel is clicked', async () => {
-    const user = userEvent.setup()
-    render(<CommentCard comment={makeComment(fixDefaults)} top={0} onClose={vi.fn()} onDelete={vi.fn()} />)
-    await user.click(screen.getByRole('button', { name: 'Delete comment' }))
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-    expect(screen.queryByText('Delete this comment?')).not.toBeInTheDocument()
-  })
-})
+  it("shows confirmation after clicking Delete", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommentCard
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Delete comment" }));
+    expect(screen.getByText("Delete this comment?")).toBeInTheDocument();
+  });
+
+  it("calls onDelete when confirmation is confirmed", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(
+      <CommentCard
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Delete comment" }));
+    await user.click(screen.getByRole("button", { name: "Confirm delete" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("hides confirmation when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <CommentCard
+        comment={makeComment(fixDefaults)}
+        top={0}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Delete comment" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByText("Delete this comment?")).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -191,6 +191,38 @@ describe("CommentPanel — active entry", () => {
     const active = container.querySelector(".comment-panel__entry--active");
     expect(active?.textContent).toContain("Why is this here?");
   });
+
+  it("does not show edit actions for agent-authored answer comments", async () => {
+    const user = userEvent.setup();
+    setTestState({
+      comments: [
+        makeCommentBase({
+          id: "answer-reply",
+          type: "answer",
+          text: "Because it explains reconnect fallback.",
+          blockIndex: 0,
+          thread: {
+            commentId: "mr-answer-1",
+            threadId: "mr-question-1",
+            replyTo: "mr-question-1",
+            authorLabel: "Codex",
+          },
+        }),
+      ],
+    });
+
+    render(<CommentPanel />);
+
+    await user.hover(
+      screen.getByText("Because it explains reconnect fallback."),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Edit comment" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete comment" }),
+    ).toBeInTheDocument();
+  });
 });
 
 describe("CommentPanel — close", () => {

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -20,6 +20,7 @@ import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
 import type { Comment, CommentType } from "../../../types/criticmarkup";
 import type { PeerComment } from "../../../types/share";
 import type { TabState } from "../../../types/tab";
+import { canEditComment } from "../../../utils/commentPermissions";
 import { AgentTerminal } from "../AgentTerminal";
 
 const ALL_TYPES: CommentType[] = [
@@ -1064,7 +1065,8 @@ function CommentEntry({
     canEdit &&
     (!isFullComment ||
       !comment.criticType ||
-      EDITABLE_CRITIC_TYPES.includes(comment.criticType));
+      (canEditComment(comment) &&
+        EDITABLE_CRITIC_TYPES.includes(comment.criticType)));
 
   if (editing) {
     return (

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
@@ -77,7 +77,7 @@ describe("CommentThreadCard", () => {
     expect(screen.getByText("Agent")).toBeInTheDocument();
   });
 
-  it("edits the selected thread message", async () => {
+  it("edits the selected user-authored thread message", async () => {
     const user = userEvent.setup();
     const onEdit = vi.fn();
 
@@ -90,21 +90,32 @@ describe("CommentThreadCard", () => {
       />,
     );
 
-    await user.click(
-      screen.getAllByRole("button", { name: "Edit comment" })[1],
-    );
-    const textarea = screen.getByDisplayValue(
-      "It explains the reconnect fallback path.",
-    );
+    await user.click(screen.getByRole("button", { name: "Edit comment" }));
+    const textarea = screen.getByDisplayValue("Why is this section needed?");
     await user.clear(textarea);
-    await user.type(textarea, "Updated answer.");
+    await user.type(textarea, "Updated question.");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(onEdit).toHaveBeenCalledWith(
-      "reply-comment",
-      "answer",
-      "Updated answer.",
+      "root-comment",
+      "question",
+      "Updated question.",
     );
+  });
+
+  it("does not allow editing linked agent answers", () => {
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getAllByRole("button", { name: "Edit comment" }),
+    ).toHaveLength(1);
   });
 
   it("deletes the selected thread message", async () => {

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
@@ -4,6 +4,7 @@ import type { RefObject } from "react";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
 import type { Comment, CommentType } from "../../../types/criticmarkup";
 import type { CommentThreadGroup } from "../../../markup";
+import { canEditComment } from "../../../utils/commentPermissions";
 
 const EDITABLE_COMMENT_TYPES: CommentType[] = [
   "note",
@@ -149,7 +150,9 @@ function CommentRow({
   onCancelDelete,
   onConfirmDelete,
 }: CommentRowProps) {
-  const editable = EDITABLE_CRITIC_TYPES.includes(comment.criticType);
+  const editable =
+    canEditComment(comment) &&
+    EDITABLE_CRITIC_TYPES.includes(comment.criticType);
   const authorLabel =
     comment.type === "answer" ? (comment.thread?.authorLabel ?? "Agent") : null;
   const deletingThreadRoot = !!comment.thread && !comment.thread.replyTo;

--- a/src/utils/commentPermissions.ts
+++ b/src/utils/commentPermissions.ts
@@ -1,0 +1,9 @@
+import type { Comment } from "../types/criticmarkup";
+
+export function isAgentAuthoredComment(comment: Comment): boolean {
+  return comment.type === "answer" || Boolean(comment.thread?.authorLabel);
+}
+
+export function canEditComment(comment: Comment): boolean {
+  return !isAgentAuthoredComment(comment);
+}


### PR DESCRIPTION
﻿## Summary
- Add a shared comment permission helper that treats agent-authored replies as read-only.
- Hide Edit actions for `answer:` replies and comments with agent author metadata in thread cards, panel entries, and the standalone comment card.
- Document that agent-authored replies can be deleted but not edited.

## Validation
- `npm test -- --run src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx src/ui/components/CommentPanel/CommentPanel.test.tsx src/ui/components/CommentCard/CommentCardEditDelete.test.tsx`
- `npx eslint` on changed TypeScript/TSX files
- `npm run typecheck`
- `npm test` (64 files, 530 tests)
- `npm run build` (passes; existing Vite chunk-size warning remains)
