### PR TITLE
Add inline thread answer composer

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -100,10 +100,11 @@ MarkReview extends the plain comment protocol for threaded review questions.
 - A `question:` comment can be a thread root.
 - MarkReview writes hidden `[markreview ...]` metadata into app-created `question:` comments so a raw markdown file still carries stable thread identifiers.
 - Agents reply with a separate inline `answer:` CriticMarkup comment near the same text block.
+- Users can also reply directly from the thread card; MarkReview writes the same linked `answer:` CriticMarkup reply with `author="You"`.
 - The reply reuses the root `thread` value and sets `replyTo` to the root question `id`.
 - The reply can also include `author` so the UI can show `Codex`, `Cursor`, or a generic `Agent` label.
 - The Comments panel keeps replies collapsed under the root question and marks the root as `answered` once an `answer:` reply exists.
-- Agent-authored replies render as read-only comments in the UI. Users can delete them, but cannot edit their text or type.
+- Agent-authored replies render as read-only comments in the UI. User-authored replies can be edited or deleted.
 - Deleting a thread-root `question:` comment deletes the linked `answer:` replies in the same thread so replies never remain as orphan comments.
 
 Example root:
@@ -210,7 +211,7 @@ Typeform-inspired: the content is the interface. Light mode default with dark mo
 
 - Time from opening a folder to leaving the first comment: under 10 seconds
 - The LLM addresses standard CriticMarkup comments correctly without additional prompting beyond "read and address the comments in this file"
-- Threaded `question:` comments can be handed off with `Copy agent prompt`, and the resulting `answer:` replies render as linked inline threads
+- Threaded `question:` comments can be answered by the user in the thread card or handed off with `Copy agent prompt`, and the resulting `answer:` replies render as linked inline threads
 - A full review-comment-revise cycle completes in under 5 minutes
 - The reading experience is rated as comfortable and clean for documents over 3,000 words
 - Zero data leaves the user's machine

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -41,6 +41,7 @@ export function buildAgentReplyPrompt(): string {
 
 Rules:
 - Leave each original question comment unchanged.
+- Read the entire existing thread for each question, including human and agent answers already present.
 - Reply with a separate inline CriticMarkup comment near the same text block.
 - Use the \`answer:\` prefix in every reply.
 - Keep the question's existing \`thread\` value.

--- a/src/markup/commentProtocol.ts
+++ b/src/markup/commentProtocol.ts
@@ -56,9 +56,10 @@ function parseMetadataAttributes(
   return attributes;
 }
 
-export function parseThreadMetadata(
-  text: string,
-): { text: string; thread?: CommentThreadMetadata } {
+export function parseThreadMetadata(text: string): {
+  text: string;
+  thread?: CommentThreadMetadata;
+} {
   const metadataMatch = METADATA_RE.exec(text);
   if (!metadataMatch) {
     return { text };
@@ -126,7 +127,9 @@ export function serializeCommentBody(input: {
   thread?: CommentThreadMetadata;
 }): string {
   const prefix = input.type === "note" ? "" : `${input.type}: `;
-  const metadata = input.thread ? ` ${serializeThreadMetadata(input.thread)}` : "";
+  const metadata = input.thread
+    ? ` ${serializeThreadMetadata(input.thread)}`
+    : "";
   return `${prefix}${input.text}${metadata}`;
 }
 
@@ -146,6 +149,23 @@ export function createQuestionThreadMetadata(): CommentThreadMetadata {
   return {
     commentId,
     threadId: commentId,
+  };
+}
+
+export function createThreadReplyMetadata(input: {
+  root: Comment;
+  authorLabel: string;
+}): CommentThreadMetadata | null {
+  const rootThread = input.root.thread;
+  if (!rootThread) {
+    return null;
+  }
+
+  return {
+    commentId: createRandomCommentId(),
+    threadId: rootThread.threadId,
+    replyTo: rootThread.commentId,
+    authorLabel: input.authorLabel,
   };
 }
 
@@ -185,7 +205,10 @@ export function buildCommentThreadGroups(
       const rootComment = commentsByThreadCommentId.get(
         comment.thread?.replyTo ?? "",
       );
-      if (rootComment && rootComment.thread?.threadId === comment.thread?.threadId) {
+      if (
+        rootComment &&
+        rootComment.thread?.threadId === comment.thread?.threadId
+      ) {
         continue;
       }
       groups.push({ root: comment, replies: [] });
@@ -195,8 +218,9 @@ export function buildCommentThreadGroups(
     const replies =
       repliesByRootCommentId
         .get(comment.thread?.commentId ?? "")
-        ?.filter((reply) => reply.thread?.threadId === comment.thread?.threadId) ??
-      [];
+        ?.filter(
+          (reply) => reply.thread?.threadId === comment.thread?.threadId,
+        ) ?? [];
     groups.push({ root: comment, replies });
   }
 

--- a/src/markup/insertComment.test.ts
+++ b/src/markup/insertComment.test.ts
@@ -1,145 +1,231 @@
-import { describe, it, expect } from 'vitest'
-import { insertComment } from './insertComment'
-import { makeComment } from '../testing/testHelpers'
+import { describe, it, expect } from "vitest";
+import { insertComment, insertThreadReply } from "./insertComment";
+import { makeComment } from "../testing/testHelpers";
 
-describe('insertComment — plain content (no existing markup)', () => {
-  it('appends a note comment (no prefix) after the first paragraph', () => {
-    const raw = 'Hello world.\n\nSecond paragraph.'
+describe("insertComment — plain content (no existing markup)", () => {
+  it("appends a note comment (no prefix) after the first paragraph", () => {
+    const raw = "Hello world.\n\nSecond paragraph.";
     const result = insertComment({
       rawContent: raw,
       existingComments: [],
       cleanMarkdown: raw,
       blockIndex: 0,
-      type: 'note',
-      text: 'my note',
-    })
-    expect(result).toBe('Hello world.{>>my note<<}\n\nSecond paragraph.')
-  })
+      type: "note",
+      text: "my note",
+    });
+    expect(result).toBe("Hello world.{>>my note<<}\n\nSecond paragraph.");
+  });
 
-  it('appends a typed comment with its prefix after a later paragraph', () => {
-    const raw = 'First.\n\nSecond.'
+  it("appends a typed comment with its prefix after a later paragraph", () => {
+    const raw = "First.\n\nSecond.";
     const result = insertComment({
       rawContent: raw,
       existingComments: [],
       cleanMarkdown: raw,
       blockIndex: 1,
-      type: 'fix',
-      text: 'fix this',
-    })
-    expect(result).toBe('First.\n\nSecond.{>>fix: fix this<<}')
-  })
+      type: "fix",
+      text: "fix this",
+    });
+    expect(result).toBe("First.\n\nSecond.{>>fix: fix this<<}");
+  });
 
-  it('returns rawContent unchanged when blockIndex is out of range', () => {
-    const raw = 'Single paragraph.'
-    expect(insertComment({
-      rawContent: raw,
-      existingComments: [],
-      cleanMarkdown: raw,
-      blockIndex: 5,
-      type: 'note',
-      text: 'hi',
-    })).toBe(raw)
-    expect(insertComment({
-      rawContent: raw,
-      existingComments: [],
-      cleanMarkdown: raw,
-      blockIndex: -1,
-      type: 'note',
-      text: 'hi',
-    })).toBe(raw)
-  })
+  it("returns rawContent unchanged when blockIndex is out of range", () => {
+    const raw = "Single paragraph.";
+    expect(
+      insertComment({
+        rawContent: raw,
+        existingComments: [],
+        cleanMarkdown: raw,
+        blockIndex: 5,
+        type: "note",
+        text: "hi",
+      }),
+    ).toBe(raw);
+    expect(
+      insertComment({
+        rawContent: raw,
+        existingComments: [],
+        cleanMarkdown: raw,
+        blockIndex: -1,
+        type: "note",
+        text: "hi",
+      }),
+    ).toBe(raw);
+  });
 
-  it('handles a single-paragraph document', () => {
-    const raw = 'Only paragraph.'
+  it("handles a single-paragraph document", () => {
+    const raw = "Only paragraph.";
     const result = insertComment({
       rawContent: raw,
       existingComments: [],
       cleanMarkdown: raw,
       blockIndex: 0,
-      type: 'rewrite',
-      text: 'rewrite it',
-    })
-    expect(result).toBe('Only paragraph.{>>rewrite: rewrite it<<}')
-  })
+      type: "rewrite",
+      text: "rewrite it",
+    });
+    expect(result).toBe("Only paragraph.{>>rewrite: rewrite it<<}");
+  });
 
-  it('adds hidden thread metadata when inserting a question', () => {
-    const raw = 'Only paragraph.'
+  it("adds hidden thread metadata when inserting a question", () => {
+    const raw = "Only paragraph.";
     const result = insertComment({
       rawContent: raw,
       existingComments: [],
       cleanMarkdown: raw,
       blockIndex: 0,
-      type: 'question',
-      text: 'Why is this here?',
-    })
+      type: "question",
+      text: "Why is this here?",
+    });
 
     expect(result).toMatch(
       /Only paragraph\.\{>>question: Why is this here\? \[markreview id="mr-[^"]+" thread="mr-[^"]+"\]<<}/,
-    )
-  })
-})
+    );
+  });
+});
 
-describe('insertComment — content with existing CriticMarkup', () => {
-  it('inserts after a block that ends with a {>>comment<<} (zero-width replacement)', () => {
+describe("insertComment — content with existing CriticMarkup", () => {
+  it("inserts after a block that ends with a {>>comment<<} (zero-width replacement)", () => {
     // raw: "Hello.{>>existing<<}\n\nSecond."
     // comment removes itself from clean ("Hello.\n\nSecond.")
-    const raw = 'Hello.{>>existing<<}\n\nSecond.'
-    const clean = 'Hello.\n\nSecond.'
+    const raw = "Hello.{>>existing<<}\n\nSecond.";
+    const clean = "Hello.\n\nSecond.";
     const existing = [
       makeComment({ rawStart: 6, rawEnd: 20, cleanStart: 6, cleanEnd: 6 }),
       // {>>existing<<} = 14 chars (6..20)
-    ]
+    ];
     const result = insertComment({
       rawContent: raw,
       existingComments: existing,
       cleanMarkdown: clean,
       blockIndex: 0,
-      type: 'note',
-      text: 'new',
-    })
+      type: "note",
+      text: "new",
+    });
     // Block 0 ends at clean offset 6, which maps to raw offset 20 (after the markup)
-    expect(result).toBe('Hello.{>>existing<<}{>>new<<}\n\nSecond.')
-  })
+    expect(result).toBe("Hello.{>>existing<<}{>>new<<}\n\nSecond.");
+  });
 
-  it('inserts after a block containing a {++addition++} (text kept in clean)', () => {
+  it("inserts after a block containing a {++addition++} (text kept in clean)", () => {
     // raw: "Hello {++world++}.\n\nSecond."
     // clean: "Hello world.\n\nSecond."
-    const raw = 'Hello {++world++}.\n\nSecond.'
-    const clean = 'Hello world.\n\nSecond.'
+    const raw = "Hello {++world++}.\n\nSecond.";
+    const clean = "Hello world.\n\nSecond.";
     const existing = [
       makeComment({
-        criticType: 'addition',
-        rawStart: 6, rawEnd: 17,    // "{++world++}" = 11 chars
-        cleanStart: 6, cleanEnd: 11, // "world" = 5 chars
+        criticType: "addition",
+        rawStart: 6,
+        rawEnd: 17, // "{++world++}" = 11 chars
+        cleanStart: 6,
+        cleanEnd: 11, // "world" = 5 chars
       }),
-    ]
+    ];
     const result = insertComment({
       rawContent: raw,
       existingComments: existing,
       cleanMarkdown: clean,
       blockIndex: 0,
-      type: 'note',
-      text: 'note',
-    })
+      type: "note",
+      text: "note",
+    });
     // Block 0 ends at clean offset 12 ("Hello world."), which is in the plain
     // segment after the addition span. Raw offset = 17 + (12 - 11) = 18 (the '.')
-    expect(result).toBe('Hello {++world++}.{>>note<<}\n\nSecond.')
-  })
+    expect(result).toBe("Hello {++world++}.{>>note<<}\n\nSecond.");
+  });
 
-  it('inserts after the second block in a multi-block document with markup', () => {
-    const raw = 'Para one.\n\nPara two.{>>existing<<}'
-    const clean = 'Para one.\n\nPara two.'
+  it("inserts after the second block in a multi-block document with markup", () => {
+    const raw = "Para one.\n\nPara two.{>>existing<<}";
+    const clean = "Para one.\n\nPara two.";
     const existing = [
       makeComment({ rawStart: 20, rawEnd: 34, cleanStart: 20, cleanEnd: 20 }),
-    ]
+    ];
     const result = insertComment({
       rawContent: raw,
       existingComments: existing,
       cleanMarkdown: clean,
       blockIndex: 1,
-      type: 'fix',
-      text: 'fix it',
-    })
-    expect(result).toBe('Para one.\n\nPara two.{>>existing<<}{>>fix: fix it<<}')
-  })
-})
+      type: "fix",
+      text: "fix it",
+    });
+    expect(result).toBe(
+      "Para one.\n\nPara two.{>>existing<<}{>>fix: fix it<<}",
+    );
+  });
+});
+
+describe("insertThreadReply", () => {
+  it("adds a linked answer after the root question when there are no replies", () => {
+    const questionRaw =
+      '{>>question: Why? [markreview id="mr-question-1" thread="mr-question-1"]<<}';
+    const raw = `Before ${questionRaw} after`;
+    const questionStart = raw.indexOf(questionRaw);
+    const root = makeComment({
+      id: "question-root",
+      type: "question",
+      raw: questionRaw,
+      rawStart: questionStart,
+      rawEnd: questionStart + questionRaw.length,
+      thread: {
+        commentId: "mr-question-1",
+        threadId: "mr-question-1",
+      },
+    });
+
+    const result = insertThreadReply({
+      rawContent: raw,
+      root,
+      replies: [],
+      text: "Because it explains the fallback.",
+      authorLabel: "You",
+    });
+
+    expect(result).toMatch(
+      /Before \{>>question: Why\? \[markreview id="mr-question-1" thread="mr-question-1"\]<<}\{>>answer: Because it explains the fallback\. \[markreview id="mr-[^"]+" thread="mr-question-1" replyTo="mr-question-1" author="You"\]<<} after/,
+    );
+  });
+
+  it("adds a linked answer after the latest existing reply", () => {
+    const questionRaw =
+      '{>>question: Why? [markreview id="mr-question-1" thread="mr-question-1"]<<}';
+    const answerRaw =
+      '{>>answer: Existing answer. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}';
+    const raw = `${questionRaw} middle ${answerRaw} end`;
+    const questionStart = raw.indexOf(questionRaw);
+    const answerStart = raw.indexOf(answerRaw);
+    const root = makeComment({
+      id: "question-root",
+      type: "question",
+      raw: questionRaw,
+      rawStart: questionStart,
+      rawEnd: questionStart + questionRaw.length,
+      thread: {
+        commentId: "mr-question-1",
+        threadId: "mr-question-1",
+      },
+    });
+    const reply = makeComment({
+      id: "answer-reply",
+      type: "answer",
+      raw: answerRaw,
+      rawStart: answerStart,
+      rawEnd: answerStart + answerRaw.length,
+      thread: {
+        commentId: "mr-answer-1",
+        threadId: "mr-question-1",
+        replyTo: "mr-question-1",
+        authorLabel: "Codex",
+      },
+    });
+
+    const result = insertThreadReply({
+      rawContent: raw,
+      root,
+      replies: [reply],
+      text: "Follow-up answer.",
+      authorLabel: "You",
+    });
+
+    expect(result).toMatch(
+      /\{>>answer: Existing answer\. \[markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"\]<<}\{>>answer: Follow-up answer\. \[markreview id="mr-[^"]+" thread="mr-question-1" replyTo="mr-question-1" author="You"\]<<} end/,
+    );
+  });
+});

--- a/src/markup/insertComment.ts
+++ b/src/markup/insertComment.ts
@@ -2,6 +2,7 @@ import { getBlockPositions } from "./blockIndex";
 import type { Comment, CommentType } from "../types/criticmarkup";
 import {
   createQuestionThreadMetadata,
+  createThreadReplyMetadata,
   serializeCommentBody,
 } from "./commentProtocol";
 
@@ -108,8 +109,49 @@ export function insertComment(input: {
     thread,
   })}<<}`;
   return (
-    input.rawContent.slice(0, rawPos) +
+    input.rawContent.slice(0, rawPos) + markup + input.rawContent.slice(rawPos)
+  );
+}
+
+export function insertThreadReply(input: {
+  rawContent: string;
+  root: Comment;
+  replies: Comment[];
+  text: string;
+  authorLabel: string;
+}): string {
+  const thread = createThreadReplyMetadata({
+    root: input.root,
+    authorLabel: input.authorLabel,
+  });
+  if (!thread) {
+    console.error("[insertThreadReply] root comment has no thread metadata", {
+      rootId: input.root.id,
+    });
+    return input.rawContent;
+  }
+
+  const latestThreadComment = [input.root, ...input.replies]
+    .filter(
+      (comment) =>
+        comment.thread?.threadId === thread.threadId &&
+        (comment.id === input.root.id ||
+          comment.thread?.replyTo === thread.replyTo),
+    )
+    .sort(
+      (leftComment, rightComment) => rightComment.rawEnd - leftComment.rawEnd,
+    )[0];
+
+  const insertPosition = latestThreadComment?.rawEnd ?? input.root.rawEnd;
+  const markup = `{>>${serializeCommentBody({
+    type: "answer",
+    text: input.text,
+    thread,
+  })}<<}`;
+
+  return (
+    input.rawContent.slice(0, insertPosition) +
     markup +
-    input.rawContent.slice(rawPos)
+    input.rawContent.slice(insertPosition)
   );
 }

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -243,6 +243,7 @@ describe("question thread agent run context", () => {
       workspaceRootPath: "/tmp/project",
     });
     expect(request.prompt).toContain("Work only in docs/spec.md");
+    expect(request.prompt).toContain("Read the entire existing thread");
     expect(request.prompt).toContain("- mr-question-1");
     expect(request.prompt).toContain("- mr-question-2");
     expect(request.prompt).toContain("Do not edit unrelated files");

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -6,6 +6,7 @@ import {
   assignBlockIndices,
   buildCommentThreadGroups,
   insertComment as insertCommentService,
+  insertThreadReply,
   parseMarkdownFrontmatter,
   parseCriticMarkup,
   shiftCommentRawOffsets,
@@ -192,6 +193,7 @@ export function createHostReviewControllerActions<
   | "deleteAllComments"
   | "editComment"
   | "addComment"
+  | "replyToCommentThread"
   | "undo"
 > {
   const {
@@ -387,6 +389,41 @@ export function createHostReviewControllerActions<
         buildUpdatedActiveTabs,
         fileHandle: tab.fileHandle,
         newRawContent: nextRawContent,
+      });
+    },
+
+    replyToCommentThread: async (rootCommentId, text) => {
+      const tab = getActiveTab(get);
+      if (!tab?.fileHandle) {
+        return;
+      }
+
+      const selectedThread = buildCommentThreadGroups(tab.comments).find(
+        (thread) => thread.root.id === rootCommentId,
+      );
+      if (
+        !selectedThread ||
+        selectedThread.root.type !== "question" ||
+        !selectedThread.root.thread ||
+        selectedThread.root.thread.replyTo
+      ) {
+        console.error("[replyToCommentThread] thread root not found", {
+          rootCommentId,
+        });
+        return;
+      }
+
+      await writeAndUpdate({
+        set,
+        buildUpdatedActiveTabs,
+        fileHandle: tab.fileHandle,
+        newRawContent: insertThreadReply({
+          rawContent: tab.rawContent,
+          root: selectedThread.root,
+          replies: selectedThread.replies,
+          text,
+          authorLabel: "You",
+        }),
       });
     },
 

--- a/src/modules/host-review/test/hostReviewActions.test.ts
+++ b/src/modules/host-review/test/hostReviewActions.test.ts
@@ -233,6 +233,50 @@ describe("store.deleteComment", () => {
   });
 });
 
+describe("store.replyToCommentThread", () => {
+  it("writes a linked user answer and saves undoState", async () => {
+    const { handle, mockWritable } = makeHandle();
+    const questionRaw =
+      '{>>question: Why? [markreview id="mr-question-1" thread="mr-question-1"]<<}';
+    const rawContent = `Before ${questionRaw} after`;
+    const questionStart = rawContent.indexOf(questionRaw);
+    setTestState({
+      fileHandle: handle,
+      rawContent,
+      comments: [
+        makeComment({
+          id: "question-root",
+          type: "question",
+          text: "Why?",
+          raw: questionRaw,
+          rawStart: questionStart,
+          rawEnd: questionStart + questionRaw.length,
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+      ],
+    });
+
+    await useAppStore
+      .getState()
+      .replyToCommentThread("question-root", "Because it explains fallback.");
+
+    const writtenContent: unknown = mockWritable.write.mock.calls[0]?.[0];
+    if (typeof writtenContent !== "string") {
+      throw new Error("Expected reply write to receive markdown text.");
+    }
+
+    expect(writtenContent).toMatch(
+      /Before \{>>question: Why\? \[markreview id="mr-question-1" thread="mr-question-1"\]<<}\{>>answer: Because it explains fallback\. \[markreview id="mr-[^"]+" thread="mr-question-1" replyTo="mr-question-1" author="You"\]<<} after/,
+    );
+    const tab = getActiveTab(useAppStore.getState());
+    expect(tab?.rawContent).toBe(writtenContent);
+    expect(tab?.undoState?.rawContent).toBe(rawContent);
+  });
+});
+
 describe("store.undo", () => {
   it("restores rawContent from undoState and clears it", async () => {
     const { handle, mockWritable } = makeHandle();

--- a/src/modules/host-review/types.ts
+++ b/src/modules/host-review/types.ts
@@ -1,10 +1,6 @@
 import type { Comment, CommentType } from "../../types/criticmarkup";
 
-export type HostCommentFilter =
-  | CommentType
-  | "all"
-  | "pending"
-  | "resolved";
+export type HostCommentFilter = CommentType | "all" | "pending" | "resolved";
 
 export interface FileCommentEntry {
   filePath: string;
@@ -60,6 +56,7 @@ export interface HostReviewActions {
   ) => Promise<void>;
   editComment: (id: string, type: CommentType, text: string) => Promise<void>;
   deleteComment: (id: string) => Promise<void>;
+  replyToCommentThread: (rootCommentId: string, text: string) => Promise<void>;
   deleteAllComments: () => Promise<void>;
   undo: () => Promise<void>;
   clearUndo: () => void;

--- a/src/ui/components/CommentMargin/CommentMargin.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.tsx
@@ -134,6 +134,7 @@ export function CommentMargin({
 }: Props) {
   const editCommentAction = useAppStore((s) => s.editComment);
   const deleteCommentAction = useAppStore((s) => s.deleteComment);
+  const replyToCommentThreadAction = useAppStore((s) => s.replyToCommentThread);
   const [addingBlock, setAddingBlock] = useState<{
     index: number;
     top: number;
@@ -160,9 +161,7 @@ export function CommentMargin({
       const visibleComments = pendingComments.filter(
         (comment) => comment.path === currentPath,
       );
-      return visibleComments.length > 0
-        ? visibleComments
-        : EMPTY_PEER_COMMENTS;
+      return visibleComments.length > 0 ? visibleComments : EMPTY_PEER_COMMENTS;
     }),
   );
   const documentUpdateAvailable = useAppStore(selectDocumentUpdateAvailable);
@@ -185,7 +184,9 @@ export function CommentMargin({
         ? commentFilter === "resolved"
           ? []
           : allThreadGroups
-        : allThreadGroups.filter((thread) => thread.root.type === commentFilter),
+        : allThreadGroups.filter(
+            (thread) => thread.root.type === commentFilter,
+          ),
     [allThreadGroups, commentFilter],
   );
   const [groups, setGroups] = useState<DotGroup[]>([]);
@@ -225,12 +226,7 @@ export function CommentMargin({
       byBlock.set(idx, arr);
     }
     return byBlock;
-  }, [
-    peerMode,
-    myPeerComments,
-    peerActiveFilePath,
-    hostPendingPeerComments,
-  ]);
+  }, [peerMode, myPeerComments, peerActiveFilePath, hostPendingPeerComments]);
 
   // Close card when clicking outside
   useEffect(() => {
@@ -368,38 +364,40 @@ export function CommentMargin({
 
   return (
     <div className="comment-margin">
-      {hoveredBlock && !addingBlock && !(peerMode && documentUpdateAvailable) && (
-        <div
-          className="comment-margin__add-wrapper"
-          style={{ top: hoveredBlock.top }}
-        >
-          <button
-            className="comment-margin__add"
-            aria-label="Add comment"
-            onClick={(e) => {
-              e.stopPropagation();
-              setAddingBlock(hoveredBlock);
-              if (peerMode) {
-                setPeerDraftCommentOpen(true);
-              }
-            }}
+      {hoveredBlock &&
+        !addingBlock &&
+        !(peerMode && documentUpdateAvailable) && (
+          <div
+            className="comment-margin__add-wrapper"
+            style={{ top: hoveredBlock.top }}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+            <button
+              className="comment-margin__add"
+              aria-label="Add comment"
+              onClick={(e) => {
+                e.stopPropagation();
+                setAddingBlock(hoveredBlock);
+                if (peerMode) {
+                  setPeerDraftCommentOpen(true);
+                }
+              }}
             >
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-            </svg>
-          </button>
-        </div>
-      )}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              </svg>
+            </button>
+          </div>
+        )}
       {addingBlock && (
         <AddCommentForm
           top={addingBlock.top}
@@ -480,10 +478,32 @@ export function CommentMargin({
                 top={floatingTop ?? top}
                 cardRef={activeCardRef}
                 onClose={() => setActiveId(null)}
-                onEdit={(id, type, text) => editCommentAction(id, type, text)}
+                onEdit={(id, type, text) => {
+                  editCommentAction(id, type, text).catch((error) => {
+                    console.error(
+                      "[CommentMargin] failed to edit comment:",
+                      error,
+                    );
+                  });
+                }}
                 onDelete={(id) => {
-                  deleteCommentAction(id);
+                  deleteCommentAction(id).catch((error) => {
+                    console.error(
+                      "[CommentMargin] failed to delete comment:",
+                      error,
+                    );
+                  });
                   setActiveId(null);
+                }}
+                onReply={(rootCommentId, text) => {
+                  replyToCommentThreadAction(rootCommentId, text).catch(
+                    (error) => {
+                      console.error(
+                        "[CommentMargin] failed to reply to thread:",
+                        error,
+                      );
+                    },
+                  );
                 }}
               />
             )}
@@ -494,9 +514,7 @@ export function CommentMargin({
       {Array.from(peerDotGroups.entries()).map(([blockIdx, peerComments]) => {
         // Skip blocks already rendered with host groups
         if (
-          groups.some(
-            (group) => group.threads[0]?.root.blockIndex === blockIdx,
-          )
+          groups.some((group) => group.threads[0]?.root.blockIndex === blockIdx)
         ) {
           return null;
         }

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.css
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.css
@@ -199,6 +199,51 @@
   color: var(--text-muted);
 }
 
+.comment-thread-card__reply-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--border-light);
+}
+
+.comment-thread-card__reply-input {
+  min-height: 2.75rem;
+  max-height: 8rem;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.4;
+  padding: 0.55rem 0.65rem;
+}
+
+.comment-thread-card__reply-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-bg);
+}
+
+.comment-thread-card__reply-send {
+  align-self: stretch;
+  min-width: 5rem;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  font-weight: 650;
+  padding: 0 0.85rem;
+}
+
+.comment-thread-card__reply-send:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 @media (max-width: 720px) {
   .comment-thread-card {
     left: 0;
@@ -207,5 +252,13 @@
 
   .comment-thread-card__item--reply {
     margin-left: 0.45rem;
+  }
+
+  .comment-thread-card__reply-form {
+    grid-template-columns: 1fr;
+  }
+
+  .comment-thread-card__reply-send {
+    min-height: 2.25rem;
   }
 }

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
@@ -157,4 +157,45 @@ describe("CommentThreadCard", () => {
 
     expect(screen.getByText("Delete this thread?")).toBeInTheDocument();
   });
+
+  it("submits a user answer from the thread composer", async () => {
+    const user = userEvent.setup();
+    const onReply = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onReply={onReply}
+      />,
+    );
+
+    const input = screen.getByLabelText("Answer text");
+    await user.type(input, "This is my answer.");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onReply).toHaveBeenCalledWith("root-comment", "This is my answer.");
+    expect(input).toHaveValue("");
+  });
+
+  it("keeps send disabled until the answer has text", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onReply={vi.fn()}
+      />,
+    );
+
+    const sendButton = screen.getByRole("button", { name: "Send" });
+    expect(sendButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Answer text"), "ok");
+
+    expect(sendButton).toBeEnabled();
+  });
 });

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
@@ -238,6 +238,7 @@ interface Props {
   onClose: () => void;
   onEdit?: (id: string, type: CommentType, text: string) => void;
   onDelete?: (id: string) => void;
+  onReply?: (rootCommentId: string, text: string) => void;
 }
 
 export function CommentThreadCard({
@@ -247,10 +248,25 @@ export function CommentThreadCard({
   onClose,
   onEdit,
   onDelete,
+  onReply,
 }: Props) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [replyText, setReplyText] = useState("");
   const comments = [thread.root, ...thread.replies];
+  const canReplyToThread =
+    thread.root.type === "question" && !!thread.root.thread && !!onReply;
+
+  function handleReplySubmit(event: React.FormEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+    const trimmedText = replyText.trim();
+    if (!trimmedText || !onReply) {
+      return;
+    }
+    onReply(thread.root.id, trimmedText);
+    setReplyText("");
+  }
 
   return (
     <div
@@ -306,6 +322,28 @@ export function CommentThreadCard({
           />
         ))}
       </div>
+      {canReplyToThread && (
+        <form
+          className="comment-thread-card__reply-form"
+          onSubmit={handleReplySubmit}
+        >
+          <textarea
+            className="comment-thread-card__reply-input"
+            aria-label="Answer text"
+            placeholder="Write an answer..."
+            rows={2}
+            value={replyText}
+            onChange={(event) => setReplyText(event.target.value)}
+          />
+          <button
+            type="submit"
+            className="comment-thread-card__reply-send"
+            disabled={!replyText.trim()}
+          >
+            Send
+          </button>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
﻿## Summary
- Add a bottom answer composer to question thread cards so the host can reply inline from the UI.
- Write replies as linked `answer:` CriticMarkup comments with the original thread id, `replyTo`, and `author="You"`.
- Make question-agent prompts explicitly read the full existing thread, including human and agent answers, before answering.
- Update threaded-comment docs and regression coverage for markup insertion, host writes, UI composer behavior, and agent prompt context.

## Validation
- `npm test -- --run src/markup/insertComment.test.ts src/modules/host-review/test/hostReviewActions.test.ts src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentMargin/CommentMargin.test.tsx`
- `npx eslint` on changed TypeScript/TSX files
- `npm run typecheck`
- `npm test` (64 files, 535 tests)
- `npm run build` (passes; existing Vite chunk-size warning remains)
