### PR TITLE
Streamline review actions and draggable comment panels

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -349,14 +349,13 @@ that explicitly report local execution as unavailable. This keeps website
 behavior unchanged while giving desktop runtime work a stable state and
 capability boundary.
 
-UI capability note: the comment-panel threaded-question action resolves through
-an agent action capability helper. In the web runtime it remains the existing
-"Copy agent prompt" action. When a desktop runtime reports local agent
-execution, the same surface becomes "Ask agent" and calls the
-question-thread run controller action.
-The active-file unresolved-comments action follows the same capability path:
-website builds copy a review prompt, while desktop builds call the address
-comments run controller action.
+UI capability note: the host toolbar exposes one review agent action for the
+active file or folder. In the web runtime it copies a scoped review prompt that
+addresses unresolved MarkReview comments and answers question threads as needed.
+When a desktop runtime reports local agent execution, the same surface calls the
+address-comments controller action, which now carries question-thread ids in the
+generated prompt. The lower-level question-thread controller remains available
+for direct workflow use.
 
 Desktop shell implementation note: `src-tauri/` now contains the first Tauri v2
 native shell. It loads the existing Vite app in a native window and adds

--- a/docs/design/v1-technical-design.md
+++ b/docs/design/v1-technical-design.md
@@ -29,16 +29,16 @@ v1 is the first usable version of MarkReview: a client-side React app that opens
 
 ## 2. Tech Stack
 
-| Layer | Choice | Why |
-|---|---|---|
-| Framework | React 19 + Vite | Fast dev cycle, huge ecosystem |
-| Markdown parsing | `react-markdown` + `remark-gfm` | Industry standard, plugin-based, safe rendering |
-| Diagrams | `mermaid` (direct) | Official library, render to SVG in a custom component |
-| Syntax highlighting | `rehype-shiki` (`@shikijs/rehype`) | Modern, accurate, async, 180+ languages |
-| File access | File System Access API | Native browser API, no server needed |
-| Styling | Tailwind CSS | Utility-first, fast to iterate on design |
-| State management | Zustand | Lightweight, no boilerplate, good for mid-size apps |
-| CriticMarkup parsing | Custom parser (see §5) | No maintained library exists; syntax is simple enough to parse with regex + state machine |
+| Layer                | Choice                             | Why                                                                                       |
+| -------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| Framework            | React 19 + Vite                    | Fast dev cycle, huge ecosystem                                                            |
+| Markdown parsing     | `react-markdown` + `remark-gfm`    | Industry standard, plugin-based, safe rendering                                           |
+| Diagrams             | `mermaid` (direct)                 | Official library, render to SVG in a custom component                                     |
+| Syntax highlighting  | `rehype-shiki` (`@shikijs/rehype`) | Modern, accurate, async, 180+ languages                                                   |
+| File access          | File System Access API             | Native browser API, no server needed                                                      |
+| Styling              | Tailwind CSS                       | Utility-first, fast to iterate on design                                                  |
+| State management     | Zustand                            | Lightweight, no boilerplate, good for mid-size apps                                       |
+| CriticMarkup parsing | Custom parser (see §5)             | No maintained library exists; syntax is simple enough to parse with regex + state machine |
 
 ---
 
@@ -106,29 +106,38 @@ No maintained JS library exists for CriticMarkup, so we build a custom parser. T
 **Input:** Raw markdown string containing CriticMarkup annotations.
 
 **Output:**
+
 - `cleanMarkdown`: The markdown with all CriticMarkup removed (for rendering)
 - `comments[]`: Array of extracted comment objects with position info
 
 ```typescript
 interface Comment {
-  id: string;                  // Generated unique ID
-  type: CommentType;           // 'fix' | 'rewrite' | 'expand' | 'clarify' | 'question' | 'remove' | 'note'
-  text: string;                // The comment body (after type prefix)
-  highlightedText?: string;    // The text between {== ==} if present
-  rawMarkup: string;           // Original CriticMarkup string (for reinsertion)
+  id: string; // Generated unique ID
+  type: CommentType; // 'fix' | 'rewrite' | 'expand' | 'clarify' | 'question' | 'remove' | 'note'
+  text: string; // The comment body (after type prefix)
+  highlightedText?: string; // The text between {== ==} if present
+  rawMarkup: string; // Original CriticMarkup string (for reinsertion)
   position: {
-    startOffset: number;       // Character offset in raw markdown
+    startOffset: number; // Character offset in raw markdown
     endOffset: number;
-    blockIndex: number;        // Which rendered block this maps to
+    blockIndex: number; // Which rendered block this maps to
   };
-  syntax: 'highlight_comment'  // {==text==}{>>comment<<}
-        | 'standalone_comment' // {>>comment<<}
-        | 'addition'           // {++text++}
-        | 'deletion'           // {--text--}
-        | 'substitution';      // {~~old~>new~~}
+  syntax:
+    | "highlight_comment" // {==text==}{>>comment<<}
+    | "standalone_comment" // {>>comment<<}
+    | "addition" // {++text++}
+    | "deletion" // {--text--}
+    | "substitution"; // {~~old~>new~~}
 }
 
-type CommentType = 'fix' | 'rewrite' | 'expand' | 'clarify' | 'question' | 'remove' | 'note';
+type CommentType =
+  | "fix"
+  | "rewrite"
+  | "expand"
+  | "clarify"
+  | "question"
+  | "remove"
+  | "note";
 ```
 
 ### 5.3 Parsing approach
@@ -144,6 +153,7 @@ const CRITIC_PATTERNS = {
 ```
 
 Parse in two passes:
+
 1. **Extract pass**: Find all CriticMarkup spans, record their positions and content, assign to nearest block
 2. **Clean pass**: Remove all CriticMarkup from the markdown string to produce clean render input
 
@@ -190,11 +200,13 @@ When the user adds a comment on a block:
 ### Insertion example
 
 **Before:**
+
 ```markdown
 PostgreSQL is the best choice for this project.
 ```
 
 **After user adds a "fix" comment:**
+
 ```markdown
 PostgreSQL is the best choice for this project.{>>fix: This claim needs evidence. Compare PostgreSQL, MySQL, and SQLite.<<}
 ```
@@ -216,15 +228,19 @@ interface AppStore {
 
   // UI state
   commentPanelOpen: boolean;
-  commentFilter: CommentType | 'all';
-  theme: 'light' | 'dark';
+  commentFilter: CommentType | "all";
+  theme: "light" | "dark";
   focusMode: boolean;
 
   // Actions
   openFile: () => Promise<void>;
-  addComment: (blockIndex: number, type: CommentType, text: string) => Promise<void>;
+  addComment: (
+    blockIndex: number,
+    type: CommentType,
+    text: string,
+  ) => Promise<void>;
   refreshFile: () => Promise<void>;
-  setTheme: (theme: 'light' | 'dark') => void;
+  setTheme: (theme: "light" | "dark") => void;
   toggleFocusMode: () => void;
 }
 ```
@@ -296,14 +312,14 @@ Spacing:
 
 ## 11. Known Limitations & Risks
 
-| Risk | Mitigation |
-|---|---|
-| File System Access API is Chrome/Edge only | Clearly state browser requirement; Phase 2 adds server mode |
-| Large files (10k+ lines) may slow react-markdown | Virtualize rendering if needed; defer mermaid for off-screen blocks |
-| CriticMarkup regex parser may miss edge cases | Start with common patterns; add test suite with real-world examples |
-| Block index mapping can break if markdown structure is ambiguous | Use conservative mapping; log warnings for unmapped comments |
-| Permission prompts on every session | Inform user; explore `navigator.storage.getDirectory()` for persistence |
-| No undo for comment insertion | Rely on git / manual editing for now; add undo in v2 |
+| Risk                                                             | Mitigation                                                              |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| File System Access API is Chrome/Edge only                       | Clearly state browser requirement; Phase 2 adds server mode             |
+| Large files (10k+ lines) may slow react-markdown                 | Virtualize rendering if needed; defer mermaid for off-screen blocks     |
+| CriticMarkup regex parser may miss edge cases                    | Start with common patterns; add test suite with real-world examples     |
+| Block index mapping can break if markdown structure is ambiguous | Use conservative mapping; log warnings for unmapped comments            |
+| Permission prompts on every session                              | Inform user; explore `navigator.storage.getDirectory()` for persistence |
+| No undo for comment insertion                                    | Rely on git / manual editing for now; add undo in v2                    |
 
 ---
 
@@ -311,15 +327,16 @@ Spacing:
 
 ### 12.1 Tools
 
-| Tool | Purpose |
-|---|---|
-| Vitest | Unit and integration tests (Vite-native, fast) |
-| React Testing Library | Component rendering and interaction tests |
-| Playwright | E2E browser tests (needs real File System Access API) |
+| Tool                  | Purpose                                               |
+| --------------------- | ----------------------------------------------------- |
+| Vitest                | Unit and integration tests (Vite-native, fast)        |
+| React Testing Library | Component rendering and interaction tests             |
+| Playwright            | E2E browser tests (needs real File System Access API) |
 
 ### 12.2 Unit Tests
 
 **CriticMarkup parser** — the highest-risk custom code, needs the most coverage:
+
 - Extraction: each syntax type (highlight+comment, standalone, addition, deletion, substitution) parsed correctly
 - Type prefix parsing: `fix:`, `rewrite:`, `expand:`, etc. extracted and categorized
 - Clean output: all CriticMarkup removed, surrounding markdown intact
@@ -328,12 +345,14 @@ Spacing:
 - Edge cases: nested markup, CriticMarkup inside code blocks (should be ignored), empty comments, multiline comments, adjacent comments on same block, malformed/incomplete syntax
 
 **Comment insertion logic:**
+
 - Standalone comment appended to correct block position
 - Type prefix formatted correctly
 - Insertion doesn't corrupt surrounding markdown or existing CriticMarkup
 - Insertion at document start, end, and between blocks
 
 **File system service:**
+
 - Read returns correct string content
 - Write persists content (mocked `FileSystemFileHandle` in unit tests)
 - Graceful handling of permission denied, file not found, file locked
@@ -341,8 +360,8 @@ Spacing:
 ### 12.3 Component Tests
 
 - **MarkdownRenderer**: renders GFM tables, code blocks, task lists, mermaid; blocks have `data-block-index` attributes
-- **CommentMargin**: correct number of dots per block, color matches comment type, click expands card
-- **CommentPanel**: lists all comments in document order, filters work by type, shows correct count
+- **CommentMargin**: correct number of dots per block, color matches comment type, click expands a draggable floating card
+- **CommentPanel**: lists all comments in document order, filters work by type, shows correct count, clicking an entry opens the related floating card
 - **AddCommentPopover**: opens on hover icon click, type selector works, submit inserts comment
 - **FilePicker**: picker opens, file name displayed in header, "open another" resets state
 
@@ -364,19 +383,19 @@ Spacing:
 
 A checklist of markdown features to visually verify before each release:
 
-| Feature | Renders correctly | With CriticMarkup nearby |
-|---|---|---|
-| Paragraphs | ☐ | ☐ |
-| Headings (h1–h6) | ☐ | ☐ |
-| GFM tables | ☐ | ☐ |
-| Fenced code blocks | ☐ | ☐ |
-| Mermaid diagrams | ☐ | ☐ |
-| Task lists | ☐ | ☐ |
-| Footnotes | ☐ | ☐ |
-| Nested lists | ☐ | ☐ |
-| Blockquotes | ☐ | ☐ |
-| Images | ☐ | ☐ |
-| Horizontal rules | ☐ | ☐ |
+| Feature            | Renders correctly | With CriticMarkup nearby |
+| ------------------ | ----------------- | ------------------------ |
+| Paragraphs         | ☐                 | ☐                        |
+| Headings (h1–h6)   | ☐                 | ☐                        |
+| GFM tables         | ☐                 | ☐                        |
+| Fenced code blocks | ☐                 | ☐                        |
+| Mermaid diagrams   | ☐                 | ☐                        |
+| Task lists         | ☐                 | ☐                        |
+| Footnotes          | ☐                 | ☐                        |
+| Nested lists       | ☐                 | ☐                        |
+| Blockquotes        | ☐                 | ☐                        |
+| Images             | ☐                 | ☐                        |
+| Horizontal rules   | ☐                 | ☐                        |
 
 ---
 

--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -46,7 +46,7 @@ Developers and technical professionals who use LLM CLIs to generate structured r
 
 **Step 3:** Developer selects any block and leaves a comment. The editor writes CriticMarkup directly into the markdown file with a Conventional Comments-style type prefix.
 
-**Step 4:** Developer tells the LLM CLI: "Read this file and address all CriticMarkup comments." For standard comments, the LLM sees the comments inline, makes the fixes, and removes the markup. For threaded `question:` comments, the developer can use MarkReview's `Copy agent prompt` helper so the agent answers inline with a linked `answer:` reply instead of rewriting the original question.
+**Step 4:** Developer uses MarkReview's review prompt to tell the LLM CLI to review the current file. For standard comments, the LLM sees the comments inline, makes the fixes, and removes the markup. For threaded `question:` comments, the same prompt asks the agent to answer inline with a linked `answer:` reply instead of rewriting the original question.
 
 **Step 5:** Developer refreshes (Phase 1) or sees live updates (Phase 2) with the LLM's changes applied.
 
@@ -121,7 +121,7 @@ Example reply:
 
 ### 6.4 Why This Works
 
-For standard comments, the LLM reads the file and sees comments as part of the content — no separate protocol to learn. CriticMarkup is well-represented in LLM training data, so models already understand it. For threaded `question:` comments, MarkReview adds a small metadata extension plus a `Copy agent prompt` helper so replies stay linked without introducing sidecar files. Comments and content still stay in sync because everything lives in the same file. Any text editor can view and edit the annotations. No sidecar files, no sync issues, no export/import steps.
+For standard comments, the LLM reads the file and sees comments as part of the content — no separate protocol to learn. CriticMarkup is well-represented in LLM training data, so models already understand it. For threaded `question:` comments, MarkReview adds a small metadata extension plus the unified review prompt so replies stay linked without introducing sidecar files. Comments and content still stay in sync because everything lives in the same file. Any text editor can view and edit the annotations. No sidecar files, no sync issues, no export/import steps.
 
 ### 6.5 Editor Responsibilities
 
@@ -187,7 +187,7 @@ metadata block.
 
 ### 8.3 Block-Level Commenting UI
 
-Every rendered block (paragraph, heading, table, code block, diagram, list item) is commentable. On hover, a visible comment icon appears in the left margin. Clicking opens an inline comment form with type selector and text input. Existing comments show as colored markers in the margin — color-coded by type, with a stronger selected state so their document anchor is clear. Clicking a marker expands the comment card. The right sidebar shows all comments in document order. Filters: all, by type, pending only (CriticMarkup still present), resolved (CriticMarkup removed by the LLM). Bulk deletion requires a confirmation step instead of deleting directly from the panel header.
+Every rendered block (paragraph, heading, table, code block, diagram, list item) is commentable. On hover, a visible comment icon appears in the left margin. Clicking opens an inline comment form with type selector and text input. Existing comments show as colored markers in the margin — color-coded by type, with a stronger selected state so their document anchor is clear. Clicking a marker expands the floating comment card. Clicking a comment in the right sidebar opens the same floating card at the related document block. The floating card can be dragged around the viewport and resets to its anchored position when another comment opens. The right sidebar shows all comments in document order. Filters: all, by type, pending only (CriticMarkup still present), resolved (CriticMarkup removed by the LLM). Bulk deletion requires a confirmation step instead of deleting directly from the panel header.
 
 ### 8.4 Design
 
@@ -211,7 +211,7 @@ Typeform-inspired: the content is the interface. Light mode default with dark mo
 
 - Time from opening a folder to leaving the first comment: under 10 seconds
 - The LLM addresses standard CriticMarkup comments correctly without additional prompting beyond "read and address the comments in this file"
-- Threaded `question:` comments can be answered by the user in the thread card or handed off with `Copy agent prompt`, and the resulting `answer:` replies render as linked inline threads
+- Threaded `question:` comments can be answered by the user in the thread card or handed off with the review prompt, and the resulting `answer:` replies render as linked inline threads
 - A full review-comment-revise cycle completes in under 5 minutes
 - The reading experience is rated as comfortable and clean for documents over 3,000 words
 - Zero data leaves the user's machine

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -7,11 +7,13 @@ interface AddressCommentsPromptComment {
 interface AddressCommentsPromptInput {
   targetPath: string;
   comments: AddressCommentsPromptComment[];
+  questionThreadIds?: string[];
 }
 
 interface FolderAddressCommentsPromptTarget {
   filePath: string;
   comments: AddressCommentsPromptComment[];
+  questionThreadIds?: string[];
 }
 
 interface FolderAddressCommentsPromptInput {
@@ -36,10 +38,8 @@ interface PendingPeerCommentsPromptInput {
   targets: PendingPeerCommentPromptTarget[];
 }
 
-export function buildAgentReplyPrompt(): string {
-  return `Review this markdown file and answer MarkReview threaded questions inline.
-
-Rules:
+function buildQuestionReplyRules(): string {
+  return `Question thread replies:
 - Leave each original question comment unchanged.
 - Read the entire existing thread for each question, including human and agent answers already present.
 - Reply with a separate inline CriticMarkup comment near the same text block.
@@ -48,7 +48,31 @@ Rules:
 - Set \`replyTo\` to the question's \`id\`.
 - Give your reply its own unique \`id\`.
 - Add your agent name in \`author\` (for example \`Codex\` or \`Cursor\`).
-- Keep answers concise, specific, and grounded in the referenced text.
+- Keep answers concise, specific, and grounded in the referenced text.`;
+}
+
+function buildCommentList(comments: AddressCommentsPromptComment[]): string {
+  if (comments.length === 0) {
+    return "- None listed.";
+  }
+
+  return comments
+    .map((comment) => `- ${comment.id} (${comment.type}): ${comment.text}`)
+    .join("\n");
+}
+
+function buildQuestionThreadList(questionThreadIds: string[]): string {
+  if (questionThreadIds.length === 0) {
+    return "- Answer any MarkReview question threads you find as needed.";
+  }
+
+  return questionThreadIds.map((commentId) => `- ${commentId}`).join("\n");
+}
+
+export function buildAgentReplyPrompt(): string {
+  return `Review this markdown file and answer MarkReview threaded questions inline.
+
+${buildQuestionReplyRules()}
 
 Example question:
 {>>question: Why is this section needed? [markreview id="mr-question-1" thread="mr-question-1"]<<}
@@ -60,20 +84,25 @@ Example answer:
 export function buildAddressCommentsAgentPrompt(
   input: AddressCommentsPromptInput,
 ): string {
-  const commentList = input.comments
-    .map((comment) => `- ${comment.id} (${comment.type}): ${comment.text}`)
-    .join("\n");
+  const commentList = buildCommentList(input.comments);
+  const questionThreadList = buildQuestionThreadList(
+    input.questionThreadIds ?? [],
+  );
 
-  return `Review this markdown file and address the listed MarkReview comments.
+  return `Review ${input.targetPath} and update it directly.
 
 Scope:
 - Work only in ${input.targetPath}.
-- Address only these unresolved comment ids:
+- Address these unresolved MarkReview comments:
 ${commentList}
+- Answer these MarkReview question threads as needed:
+${questionThreadList}
 - Apply the requested edits directly in the markdown.
 - Remove each addressed MarkReview comment once its requested change is applied.
-- Do not answer threaded question comments in this run.
-- Do not edit unrelated files or unrelated comments.`;
+- Do not remove question comments when answering them.
+- Do not edit unrelated files or unrelated comments.
+
+${buildQuestionReplyRules()}`;
 }
 
 export function buildFolderAddressCommentsAgentPrompt(
@@ -86,20 +115,36 @@ export function buildFolderAddressCommentsAgentPrompt(
           (comment) => `  - ${comment.id} (${comment.type}): ${comment.text}`,
         )
         .join("\n");
-      return `- ${target.filePath}\n${commentList}`;
+      const questionThreadList = (target.questionThreadIds ?? [])
+        .map((commentId) => `  - ${commentId}`)
+        .join("\n");
+      const sections = [`- ${target.filePath}`];
+      if (commentList) {
+        sections.push("  Comments:", commentList);
+      }
+      if (questionThreadList) {
+        sections.push("  Question threads:", questionThreadList);
+      }
+      if (!commentList && !questionThreadList) {
+        sections.push("  - Review this file for any MarkReview threads.");
+      }
+      return sections.join("\n");
     })
     .join("\n");
 
-  return `Review this markdown folder and address the listed MarkReview comments.
+  return `Review these markdown files and update them directly.
 
 Scope:
 - Work only in the listed markdown files.
-- Address only these unresolved comment ids:
+- Address the listed unresolved MarkReview comments.
+- Answer the listed MarkReview question threads as needed.
 ${targetList}
 - Apply the requested edits directly in the markdown files.
 - Remove each addressed MarkReview comment once its requested change is applied.
-- Do not answer threaded question comments in this run.
-- Do not edit unrelated files or unrelated comments.`;
+- Do not remove question comments when answering them.
+- Do not edit unrelated files or unrelated comments.
+
+${buildQuestionReplyRules()}`;
 }
 
 export function buildPendingPeerCommentsAgentPrompt(

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -64,6 +64,7 @@ interface AddressCommentsRunContext {
   tabId: string;
   targetPath: string;
   comments: AddressableCommentTarget[];
+  questionThreadIds: string[];
   workspaceRootPath: string | null;
 }
 
@@ -72,9 +73,15 @@ interface FolderAddressableCommentTarget {
   comments: AddressableCommentTarget[];
 }
 
+interface FolderReviewCommentTarget {
+  filePath: string;
+  comments: AddressableCommentTarget[];
+  questionThreadIds: string[];
+}
+
 interface FolderAddressCommentsRunContext {
   tabId: string;
-  targets: FolderAddressableCommentTarget[];
+  targets: FolderReviewCommentTarget[];
   workspaceRootPath: string | null;
 }
 
@@ -179,6 +186,51 @@ export function getFolderAddressableCommentTargets(
       comments,
     });
     selectedCommentCount += comments.length;
+  }
+
+  return targets;
+}
+
+export function getFolderReviewCommentTargets(
+  entries: FileCommentEntry[],
+): FolderReviewCommentTarget[] {
+  const targets: FolderReviewCommentTarget[] = [];
+  let selectedCommentCount = 0;
+
+  const sortedEntries = [...entries].sort((entryA, entryB) =>
+    entryA.filePath.localeCompare(entryB.filePath),
+  );
+
+  for (const entry of sortedEntries) {
+    if (targets.length >= MAX_FOLDER_AGENT_TARGET_FILES) {
+      break;
+    }
+    if (selectedCommentCount >= MAX_FOLDER_AGENT_COMMENTS) {
+      break;
+    }
+
+    const remainingCommentCount =
+      MAX_FOLDER_AGENT_COMMENTS - selectedCommentCount;
+    const comments = getAddressableCommentTargets(entry.comments).slice(
+      0,
+      remainingCommentCount,
+    );
+    const remainingQuestionCount = remainingCommentCount - comments.length;
+    const questionThreadIds = getQuestionThreadCommentIds(entry.comments).slice(
+      0,
+      Math.max(0, remainingQuestionCount),
+    );
+    const targetCommentCount = comments.length + questionThreadIds.length;
+    if (targetCommentCount === 0) {
+      continue;
+    }
+
+    targets.push({
+      filePath: entry.filePath,
+      comments,
+      questionThreadIds,
+    });
+    selectedCommentCount += targetCommentCount;
   }
 
   return targets;
@@ -302,12 +354,16 @@ export function buildAddressCommentsAgentRunRequest(
     tabId: context.tabId,
     taskKind: "address_comments",
     targetPaths: [context.targetPath],
-    selectedCommentIds: context.comments.map((comment) => comment.id),
+    selectedCommentIds: [
+      ...context.comments.map((comment) => comment.id),
+      ...context.questionThreadIds,
+    ],
     runnerKind: "terminal",
     workspaceRootPath: context.workspaceRootPath,
     prompt: buildAddressCommentsAgentPrompt({
       targetPath: context.targetPath,
       comments: context.comments,
+      questionThreadIds: context.questionThreadIds,
     }),
   };
 }
@@ -319,9 +375,12 @@ export function buildFolderAddressCommentsAgentRunRequest(
     tabId: context.tabId,
     taskKind: "address_comments",
     targetPaths: context.targets.map((target) => target.filePath),
-    selectedCommentIds: context.targets.flatMap((target) =>
-      target.comments.map((comment) => `${target.filePath}#${comment.id}`),
-    ),
+    selectedCommentIds: context.targets.flatMap((target) => [
+      ...target.comments.map((comment) => `${target.filePath}#${comment.id}`),
+      ...target.questionThreadIds.map(
+        (commentId) => `${target.filePath}#${commentId}`,
+      ),
+    ]),
     runnerKind: "terminal",
     workspaceRootPath: context.workspaceRootPath,
     prompt: buildFolderAddressCommentsAgentPrompt({
@@ -532,13 +591,13 @@ export function createAgentWorkflowControllerActions<
       }
 
       if (isFolderAgentRunTab(tab)) {
-        const folderTargets = getFolderAddressableCommentTargets(
+        const folderTargets = getFolderReviewCommentTargets(
           Object.values(tab.allFileComments),
         );
         if (folderTargets.length === 0) {
           return unavailableResult({
             reason: "no_addressable_comments",
-            message: "No unresolved actionable comments are available.",
+            message: "No unresolved review comments are available.",
           });
         }
 
@@ -560,10 +619,11 @@ export function createAgentWorkflowControllerActions<
       }
 
       const addressableComments = getAddressableCommentTargets(tab.comments);
-      if (addressableComments.length === 0) {
+      const questionThreadIds = getQuestionThreadCommentIds(tab.comments);
+      if (addressableComments.length === 0 && questionThreadIds.length === 0) {
         return unavailableResult({
           reason: "no_addressable_comments",
-          message: "No unresolved actionable comments are available.",
+          message: "No unresolved review comments are available.",
         });
       }
 
@@ -572,6 +632,7 @@ export function createAgentWorkflowControllerActions<
           tabId: tab.id,
           targetPath,
           comments: addressableComments,
+          questionThreadIds,
           workspaceRootPath: getAgentWorkspaceRootPath(tab),
         }),
       );

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -16,6 +16,7 @@ import {
   createAgentWorkflowControllerActions,
   getAddressableCommentTargets,
   getFolderAddressableCommentTargets,
+  getFolderReviewCommentTargets,
   getPendingPeerCommentTargets,
   getQuestionThreadCommentIds,
 } from "../controller";
@@ -88,6 +89,7 @@ describe("address comments agent run context", () => {
           text: "Rewrite this paragraph",
         },
       ],
+      questionThreadIds: ["mr-question-1"],
       workspaceRootPath: "/tmp/project",
     });
 
@@ -95,7 +97,7 @@ describe("address comments agent run context", () => {
       tabId: "tab-1",
       taskKind: "address_comments",
       targetPaths: ["docs/spec.md"],
-      selectedCommentIds: ["comment-1", "comment-2"],
+      selectedCommentIds: ["comment-1", "comment-2", "mr-question-1"],
       runnerKind: "terminal",
       workspaceRootPath: "/tmp/project",
     });
@@ -105,8 +107,9 @@ describe("address comments agent run context", () => {
       "- comment-2 (rewrite): Rewrite this paragraph",
     );
     expect(request.prompt).toContain(
-      "Do not answer threaded question comments",
+      "Answer these MarkReview question threads",
     );
+    expect(request.prompt).toContain("- mr-question-1");
   });
 
   it("selects a bounded set of folder comment targets", () => {
@@ -153,6 +156,34 @@ describe("address comments agent run context", () => {
     ]);
   });
 
+  it("selects folder review targets with question threads", () => {
+    const targets = getFolderReviewCommentTargets([
+      {
+        filePath: "docs/questions.md",
+        fileName: "questions.md",
+        comments: [
+          makeComment({
+            id: "question-root",
+            type: "question",
+            text: "Why is this here?",
+            thread: {
+              commentId: "mr-question-1",
+              threadId: "mr-question-1",
+            },
+          }),
+        ],
+      },
+    ]);
+
+    expect(targets).toEqual([
+      {
+        filePath: "docs/questions.md",
+        comments: [],
+        questionThreadIds: ["mr-question-1"],
+      },
+    ]);
+  });
+
   it("builds a bounded folder request for addressing comments", () => {
     const request = buildFolderAddressCommentsAgentRunRequest({
       tabId: "tab-1",
@@ -167,6 +198,7 @@ describe("address comments agent run context", () => {
               text: "Fix A",
             },
           ],
+          questionThreadIds: ["mr-question-a"],
         },
         {
           filePath: "docs/b.md",
@@ -177,6 +209,7 @@ describe("address comments agent run context", () => {
               text: "Check B",
             },
           ],
+          questionThreadIds: [],
         },
       ],
     });
@@ -185,13 +218,18 @@ describe("address comments agent run context", () => {
       tabId: "tab-1",
       taskKind: "address_comments",
       targetPaths: ["docs/a.md", "docs/b.md"],
-      selectedCommentIds: ["docs/a.md#fix-a", "docs/b.md#note-b"],
+      selectedCommentIds: [
+        "docs/a.md#fix-a",
+        "docs/a.md#mr-question-a",
+        "docs/b.md#note-b",
+      ],
       runnerKind: "terminal",
       workspaceRootPath: "/tmp/project",
     });
     expect(request.prompt).toContain("Work only in the listed markdown files");
     expect(request.prompt).toContain("- docs/a.md");
     expect(request.prompt).toContain("  - fix-a (fix): Fix A");
+    expect(request.prompt).toContain("  - mr-question-a");
     expect(request.prompt).toContain("- docs/b.md");
     expect(request.prompt).toContain("  - note-b (note): Check B");
   });
@@ -504,19 +542,26 @@ describe("address comments agent run controller", () => {
     expect(requests).toEqual([]);
   });
 
-  it("returns unavailable when no actionable comments exist", async () => {
+  it("creates a review run when only question threads exist", async () => {
+    const requests: AgentRunRequest[] = [];
     const runtime: AgentRuntime = {
       canRunAgent: true,
       getCapability: () =>
         Promise.resolve({ canRunAgent: true, unavailableMessage: null }),
-      startRun: () => Promise.resolve("terminal-session-1"),
+      startRun: (request) => {
+        requests.push(request);
+        return Promise.resolve("terminal-session-1");
+      },
       stopRun: () => Promise.resolve(),
       getRunStatus: () => Promise.resolve({ status: "running", output: "" }),
     };
+    const showToastMessages: string[] = [];
     const actions = createAgentWorkflowControllerActions({
       get: useAppStore.getState,
       getActiveTab: (get) => getActiveTab(get()),
-      showToast: () => {},
+      showToast: (message) => {
+        showToastMessages.push(message);
+      },
       runtime,
     });
 
@@ -535,12 +580,18 @@ describe("address comments agent run controller", () => {
 
     const result = await actions.startAddressCommentsAgentRun();
 
-    expect(result).toEqual({
-      status: "unavailable",
-      reason: "no_addressable_comments",
-      message: "No unresolved actionable comments are available.",
+    expect(result.status).toBe("started");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      tabId: "test-tab",
+      taskKind: "address_comments",
+      targetPaths: ["spec.md"],
+      selectedCommentIds: ["mr-question-1"],
     });
-    expect(useAppStore.getState().agentRuns).toEqual({});
+    expect(requests[0]?.prompt).toContain(
+      "Answer these MarkReview question threads",
+    );
+    expect(showToastMessages).toEqual(["Agent run started"]);
   });
 
   it("creates a folder run from scanned file comments", async () => {

--- a/src/ui/components/CommentMargin/CommentMargin.test.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.test.tsx
@@ -1,73 +1,158 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, it, expect, vi } from 'vitest'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { CommentMargin } from "./index";
 import { useAppStore } from "../../../store";
-import { setTestState, resetTestStore } from "../../../testing/testHelpers";
+import {
+  makeComment,
+  setTestState,
+  resetTestStore,
+} from "../../../testing/testHelpers";
 
 beforeEach(() => {
-  resetTestStore()
+  resetTestStore();
   setTestState({
     comments: [],
-    commentFilter: 'all',
+    commentFilter: "all",
     activeCommentId: null,
-  })
-  vi.restoreAllMocks()
-})
+  });
+  vi.restoreAllMocks();
+});
 
-const fakeContainerRef = { current: null } as React.RefObject<HTMLDivElement | null>
+const fakeContainerRef: React.RefObject<HTMLDivElement | null> = {
+  current: null,
+};
 
-describe('CommentMargin — add button', () => {
-  it('shows the add button when hoveredBlock is provided', () => {
+function createContainerRef(blockTops: number[]) {
+  const scrollArea = document.createElement("div");
+  Object.defineProperty(scrollArea, "scrollTop", {
+    value: 0,
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(scrollArea, "clientHeight", {
+    value: 640,
+    configurable: true,
+  });
+
+  const container = document.createElement("div");
+  for (const [blockIndex, blockTop] of blockTops.entries()) {
+    const block = document.createElement("p");
+    block.setAttribute("data-block-index", String(blockIndex));
+    Object.defineProperty(block, "offsetTop", {
+      value: blockTop,
+      configurable: true,
+    });
+    container.appendChild(block);
+  }
+  scrollArea.appendChild(container);
+
+  const containerRef: React.RefObject<HTMLDivElement | null> = {
+    current: container,
+  };
+  return containerRef;
+}
+
+function dispatchPointerMove(clientX: number, clientY: number) {
+  const event = new Event("pointermove");
+  Object.defineProperty(event, "clientX", {
+    value: clientX,
+    configurable: true,
+  });
+  Object.defineProperty(event, "clientY", {
+    value: clientY,
+    configurable: true,
+  });
+  window.dispatchEvent(event);
+}
+
+function dispatchPointerDown(
+  element: HTMLElement,
+  clientX: number,
+  clientY: number,
+) {
+  const event = new Event("pointerdown", {
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperty(event, "button", {
+    value: 0,
+    configurable: true,
+  });
+  Object.defineProperty(event, "clientX", {
+    value: clientX,
+    configurable: true,
+  });
+  Object.defineProperty(event, "clientY", {
+    value: clientY,
+    configurable: true,
+  });
+  element.dispatchEvent(event);
+}
+
+describe("CommentMargin — add button", () => {
+  it("shows the add button when hoveredBlock is provided", () => {
     render(
       <CommentMargin
         containerRef={fakeContainerRef}
         hoveredBlock={{ index: 0, top: 0 }}
         onAddComment={vi.fn()}
       />,
-    )
-    expect(screen.getByRole('button', { name: 'Add comment' })).toBeInTheDocument()
-  })
+    );
+    expect(
+      screen.getByRole("button", { name: "Add comment" }),
+    ).toBeInTheDocument();
+  });
 
-  it('does not show the add button when hoveredBlock is null', () => {
+  it("does not show the add button when hoveredBlock is null", () => {
     render(
       <CommentMargin
         containerRef={fakeContainerRef}
         hoveredBlock={null}
         onAddComment={vi.fn()}
       />,
-    )
-    expect(screen.queryByRole('button', { name: 'Add comment' })).not.toBeInTheDocument()
-  })
+    );
+    expect(
+      screen.queryByRole("button", { name: "Add comment" }),
+    ).not.toBeInTheDocument();
+  });
 
-  it('shows the AddCommentForm after clicking the add button', async () => {
-    const user = userEvent.setup()
+  it("shows the AddCommentForm after clicking the add button", async () => {
+    const user = userEvent.setup();
     render(
       <CommentMargin
         containerRef={fakeContainerRef}
         hoveredBlock={{ index: 0, top: 0 }}
         onAddComment={vi.fn()}
       />,
-    )
-    await user.click(screen.getByRole('button', { name: 'Add comment' }))
-    expect(screen.getByPlaceholderText('Add a comment…')).toBeInTheDocument()
-  })
+    );
+    await user.click(screen.getByRole("button", { name: "Add comment" }));
+    expect(screen.getByPlaceholderText("Add a comment…")).toBeInTheDocument();
+  });
 
-  it('hides the add button while the form is open', async () => {
-    const user = userEvent.setup()
+  it("hides the add button while the form is open", async () => {
+    const user = userEvent.setup();
     render(
       <CommentMargin
         containerRef={fakeContainerRef}
         hoveredBlock={{ index: 0, top: 0 }}
         onAddComment={vi.fn()}
       />,
-    )
-    await user.click(screen.getByRole('button', { name: 'Add comment' }))
-    expect(screen.queryByRole('button', { name: 'Add comment' })).not.toBeInTheDocument()
-  })
+    );
+    await user.click(screen.getByRole("button", { name: "Add comment" }));
+    expect(
+      screen.queryByRole("button", { name: "Add comment" }),
+    ).not.toBeInTheDocument();
+  });
 
-  it('hides the add button in peer mode when content refresh is required', () => {
-    useAppStore.setState({ documentUpdateAvailable: true })
+  it("hides the add button in peer mode when content refresh is required", () => {
+    useAppStore.setState({ documentUpdateAvailable: true });
     render(
       <CommentMargin
         containerRef={fakeContainerRef}
@@ -76,70 +161,79 @@ describe('CommentMargin — add button', () => {
         peerMode
         onPostPeerComment={vi.fn()}
       />,
-    )
-    expect(screen.queryByRole('button', { name: 'Add comment' })).not.toBeInTheDocument()
-  })
-})
+    );
+    expect(
+      screen.queryByRole("button", { name: "Add comment" }),
+    ).not.toBeInTheDocument();
+  });
+});
 
-describe('CommentMargin — AddCommentForm', () => {
+describe("CommentMargin — AddCommentForm", () => {
   async function openForm(onAddComment = vi.fn()) {
-    const user = userEvent.setup()
+    const user = userEvent.setup();
     render(
       <CommentMargin
         containerRef={fakeContainerRef}
         hoveredBlock={{ index: 2, top: 0 }}
         onAddComment={onAddComment}
       />,
-    )
-    await user.click(screen.getByRole('button', { name: 'Add comment' }))
-    return { user, onAddComment }
+    );
+    await user.click(screen.getByRole("button", { name: "Add comment" }));
+    return { user, onAddComment };
   }
 
-  it('Save button is disabled when text is empty', async () => {
-    await openForm()
-    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
-  })
+  it("Save button is disabled when text is empty", async () => {
+    await openForm();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
 
-  it('Save button enables after typing text', async () => {
-    const { user } = await openForm()
-    await user.type(screen.getByPlaceholderText('Add a comment…'), 'hello')
-    expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled()
-  })
+  it("Save button enables after typing text", async () => {
+    const { user } = await openForm();
+    await user.type(screen.getByPlaceholderText("Add a comment…"), "hello");
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+  });
 
-  it('calls onAddComment with blockIndex, type, and text on submit', async () => {
-    const onAddComment = vi.fn()
-    const { user } = await openForm(onAddComment)
-    await user.type(screen.getByPlaceholderText('Add a comment…'), 'fix this please')
+  it("calls onAddComment with blockIndex, type, and text on submit", async () => {
+    const onAddComment = vi.fn();
+    const { user } = await openForm(onAddComment);
+    await user.type(
+      screen.getByPlaceholderText("Add a comment…"),
+      "fix this please",
+    );
     // Select 'fix' type
-    await user.click(screen.getByRole('button', { name: 'fix' }))
-    await user.click(screen.getByRole('button', { name: 'Save' }))
-    expect(onAddComment).toHaveBeenCalledWith(2, 'fix', 'fix this please')
-  })
+    await user.click(screen.getByRole("button", { name: "fix" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(onAddComment).toHaveBeenCalledWith(2, "fix", "fix this please");
+  });
 
   it('defaults to "note" type if no type is selected', async () => {
-    const onAddComment = vi.fn()
-    const { user } = await openForm(onAddComment)
-    await user.type(screen.getByPlaceholderText('Add a comment…'), 'a note')
-    await user.click(screen.getByRole('button', { name: 'Save' }))
-    expect(onAddComment).toHaveBeenCalledWith(2, 'note', 'a note')
-  })
+    const onAddComment = vi.fn();
+    const { user } = await openForm(onAddComment);
+    await user.type(screen.getByPlaceholderText("Add a comment…"), "a note");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(onAddComment).toHaveBeenCalledWith(2, "note", "a note");
+  });
 
-  it('hides the form when Cancel is clicked', async () => {
-    const { user } = await openForm()
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
-    expect(screen.queryByPlaceholderText('Add a comment…')).not.toBeInTheDocument()
-  })
+  it("hides the form when Cancel is clicked", async () => {
+    const { user } = await openForm();
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByPlaceholderText("Add a comment…"),
+    ).not.toBeInTheDocument();
+  });
 
-  it('hides the form after successful submit', async () => {
-    const { user } = await openForm()
-    await user.type(screen.getByPlaceholderText('Add a comment…'), 'done')
-    await user.click(screen.getByRole('button', { name: 'Save' }))
-    expect(screen.queryByPlaceholderText('Add a comment…')).not.toBeInTheDocument()
-  })
+  it("hides the form after successful submit", async () => {
+    const { user } = await openForm();
+    await user.type(screen.getByPlaceholderText("Add a comment…"), "done");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(
+      screen.queryByPlaceholderText("Add a comment…"),
+    ).not.toBeInTheDocument();
+  });
 
-  it('disables saving a peer draft after the document becomes stale', async () => {
-    const user = userEvent.setup()
-    useAppStore.setState({ isPeerMode: true })
+  it("disables saving a peer draft after the document becomes stale", async () => {
+    const user = userEvent.setup();
+    useAppStore.setState({ isPeerMode: true });
     const { rerender } = render(
       <CommentMargin
         containerRef={fakeContainerRef}
@@ -148,11 +242,11 @@ describe('CommentMargin — AddCommentForm', () => {
         peerMode
         onPostPeerComment={vi.fn()}
       />,
-    )
-    await user.click(screen.getByRole('button', { name: 'Add comment' }))
-    await user.type(screen.getByPlaceholderText('Add a comment…'), 'draft')
+    );
+    await user.click(screen.getByRole("button", { name: "Add comment" }));
+    await user.type(screen.getByPlaceholderText("Add a comment…"), "draft");
 
-    useAppStore.setState({ documentUpdateAvailable: true })
+    useAppStore.setState({ documentUpdateAvailable: true });
     rerender(
       <CommentMargin
         containerRef={fakeContainerRef}
@@ -161,8 +255,146 @@ describe('CommentMargin — AddCommentForm', () => {
         peerMode
         onPostPeerComment={vi.fn()}
       />,
-    )
+    );
 
-    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
-  })
-})
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+});
+
+describe("CommentMargin — floating comment card", () => {
+  it("opens the floating card for the active comment", async () => {
+    setTestState({
+      activeCommentId: "fix-root",
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix this paragraph",
+          blockIndex: 0,
+        }),
+      ],
+    });
+
+    render(
+      <CommentMargin
+        containerRef={createContainerRef([96])}
+        hoveredBlock={null}
+        onAddComment={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("Fix this paragraph")).toBeInTheDocument();
+  });
+
+  it("drags the floating card around the viewport", async () => {
+    setTestState({
+      activeCommentId: "fix-root",
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix this paragraph",
+          blockIndex: 0,
+        }),
+      ],
+    });
+
+    render(
+      <CommentMargin
+        containerRef={createContainerRef([96])}
+        hoveredBlock={null}
+        onAddComment={vi.fn()}
+      />,
+    );
+
+    await screen.findByText("Fix this paragraph");
+    act(() => {
+      dispatchPointerDown(screen.getByTitle("Drag comment panel"), 20, 20);
+    });
+    await waitFor(() => {
+      const card = screen
+        .getByText("Fix this paragraph")
+        .closest(".comment-thread-card");
+      expect(card).not.toBeNull();
+      if (card) {
+        expect(card).toHaveClass("comment-thread-card--dragging");
+      }
+    });
+    act(() => {
+      dispatchPointerMove(140, 180);
+    });
+    fireEvent.pointerUp(window);
+
+    const card = screen
+      .getByText("Fix this paragraph")
+      .closest(".comment-thread-card");
+    expect(card).not.toBeNull();
+    if (card) {
+      expect(card).toHaveStyle({
+        position: "fixed",
+        left: "120px",
+        top: "160px",
+      });
+    }
+  });
+
+  it("resets the dragged position when another comment opens", async () => {
+    setTestState({
+      activeCommentId: "fix-root",
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix this paragraph",
+          blockIndex: 0,
+        }),
+        makeComment({
+          id: "note-root",
+          type: "note",
+          text: "Check this paragraph",
+          blockIndex: 1,
+        }),
+      ],
+    });
+
+    render(
+      <CommentMargin
+        containerRef={createContainerRef([96, 180])}
+        hoveredBlock={null}
+        onAddComment={vi.fn()}
+      />,
+    );
+
+    await screen.findByText("Fix this paragraph");
+    act(() => {
+      dispatchPointerDown(screen.getByTitle("Drag comment panel"), 20, 20);
+    });
+    await waitFor(() => {
+      const card = screen
+        .getByText("Fix this paragraph")
+        .closest(".comment-thread-card");
+      expect(card).not.toBeNull();
+      if (card) {
+        expect(card).toHaveClass("comment-thread-card--dragging");
+      }
+    });
+    act(() => {
+      dispatchPointerMove(140, 180);
+    });
+    fireEvent.pointerUp(window);
+
+    act(() => {
+      useAppStore.getState().setActiveCommentId("note-root");
+    });
+
+    expect(await screen.findByText("Check this paragraph")).toBeInTheDocument();
+    const card = screen
+      .getByText("Check this paragraph")
+      .closest(".comment-thread-card");
+    expect(card).not.toBeNull();
+    if (card) {
+      expect(card).not.toHaveStyle({ position: "fixed" });
+      expect(card).toHaveStyle({ top: "180px" });
+    }
+  });
+});

--- a/src/ui/components/CommentMargin/CommentMargin.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.tsx
@@ -113,6 +113,16 @@ interface DotGroup {
   threads: CommentThreadGroup[];
 }
 
+interface FloatingCardPosition {
+  top: number;
+  left: number;
+}
+
+interface FloatingCardDragState {
+  offsetTop: number;
+  offsetLeft: number;
+}
+
 interface Props {
   containerRef: React.RefObject<HTMLDivElement | null>;
   hoveredBlock: { index: number; top: number } | null;
@@ -191,6 +201,10 @@ export function CommentMargin({
   );
   const [groups, setGroups] = useState<DotGroup[]>([]);
   const [floatingTop, setFloatingTop] = useState<number | null>(null);
+  const [floatingCardPosition, setFloatingCardPosition] =
+    useState<FloatingCardPosition | null>(null);
+  const [floatingCardDragState, setFloatingCardDragState] =
+    useState<FloatingCardDragState | null>(null);
   const measureRef = useRef<() => void>(() => {});
   const activeCardRef = useRef<HTMLDivElement | null>(null);
 
@@ -362,6 +376,86 @@ export function CommentMargin({
     };
   }, [activeThreadData, containerRef]);
 
+  useEffect(() => {
+    setFloatingCardPosition(null);
+    setFloatingCardDragState(null);
+  }, [activeId]);
+
+  useEffect(() => {
+    if (!floatingCardDragState) {
+      return;
+    }
+
+    function handlePointerMove(event: PointerEvent) {
+      const card = activeCardRef.current;
+      if (!card) {
+        return;
+      }
+      if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+        return;
+      }
+      const padding = 8;
+      const maxLeft = Math.max(
+        padding,
+        window.innerWidth - card.offsetWidth - padding,
+      );
+      const maxTop = Math.max(
+        padding,
+        window.innerHeight - card.offsetHeight - padding,
+      );
+      const nextLeft = Math.min(
+        Math.max(event.clientX - floatingCardDragState.offsetLeft, padding),
+        maxLeft,
+      );
+      const nextTop = Math.min(
+        Math.max(event.clientY - floatingCardDragState.offsetTop, padding),
+        maxTop,
+      );
+      setFloatingCardPosition({
+        top: nextTop,
+        left: nextLeft,
+      });
+    }
+
+    function handlePointerUp() {
+      setFloatingCardDragState(null);
+    }
+
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    };
+  }, [floatingCardDragState]);
+
+  function handleFloatingCardDragStart(event: React.PointerEvent) {
+    if (event.button > 0) {
+      return;
+    }
+    if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+      return;
+    }
+    const card = activeCardRef.current;
+    if (!card) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+
+    const rect = card.getBoundingClientRect();
+    setFloatingCardPosition({
+      top: rect.top,
+      left: rect.left,
+    });
+    setFloatingCardDragState({
+      offsetTop: event.clientY - rect.top,
+      offsetLeft: event.clientX - rect.left,
+    });
+  }
+
   return (
     <div className="comment-margin">
       {hoveredBlock &&
@@ -476,7 +570,10 @@ export function CommentMargin({
               <CommentThreadCard
                 thread={activeThread}
                 top={floatingTop ?? top}
+                dragPosition={floatingCardPosition}
+                dragging={!!floatingCardDragState}
                 cardRef={activeCardRef}
+                onDragStart={handleFloatingCardDragStart}
                 onClose={() => setActiveId(null)}
                 onEdit={(id, type, text) => {
                   editCommentAction(id, type, text).catch((error) => {

--- a/src/ui/components/CommentPanel/CommentPanel.test.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.test.tsx
@@ -142,13 +142,13 @@ describe("CommentPanel — active entry", () => {
     expect(tab?.activeCommentId).toBe("0");
   });
 
-  it("clears activeCommentId when clicking the active entry again", async () => {
+  it("keeps the active comment open when clicking the active entry again", async () => {
     const user = userEvent.setup();
     setTestState({ comments, activeCommentId: "0" });
     render(<CommentPanel />);
     await user.click(screen.getByText("fix the intro"));
     const tab = getActiveTab(useAppStore.getState());
-    expect(tab?.activeCommentId).toBeNull();
+    expect(tab?.activeCommentId).toBe("0");
   });
 
   it("keeps threaded replies out of the panel list and highlights the root entry", () => {

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -390,7 +390,7 @@ export function CommentPanel({ peerMode = false }: Props) {
   }, [isPeerMultiFile, peerCrossFileEntries, commentFilter]);
 
   function handleEntryClick(id: string, blockIndex: number | undefined) {
-    setActiveCommentId(activeCommentId === id ? null : id);
+    setActiveCommentId(id);
     scrollToBlock(blockIndex);
   }
 

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.css
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.css
@@ -14,12 +14,28 @@
   line-height: 1.5;
 }
 
+.comment-thread-card--dragging {
+  cursor: grabbing;
+  user-select: none;
+}
+
 .comment-thread-card__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   margin-bottom: 0.75rem;
+}
+
+.comment-thread-card__drag-handle {
+  min-width: 0;
+  flex: 1;
+  cursor: grab;
+  touch-action: none;
+}
+
+.comment-thread-card__drag-handle:active {
+  cursor: grabbing;
 }
 
 .comment-thread-card__title {

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
@@ -1,6 +1,6 @@
 import "./CommentThreadCard.css";
 import { useState } from "react";
-import type { RefObject } from "react";
+import type { CSSProperties, RefObject } from "react";
 import { COMMENT_TYPE_COLOR } from "../../../types/criticmarkup";
 import type { Comment, CommentType } from "../../../types/criticmarkup";
 import type { CommentThreadGroup } from "../../../markup";
@@ -234,7 +234,10 @@ function CommentRow({
 interface Props {
   thread: CommentThreadGroup;
   top: number;
+  dragPosition?: { top: number; left: number } | null;
+  dragging?: boolean;
   cardRef?: RefObject<HTMLDivElement | null>;
+  onDragStart?: (event: React.PointerEvent) => void;
   onClose: () => void;
   onEdit?: (id: string, type: CommentType, text: string) => void;
   onDelete?: (id: string) => void;
@@ -244,7 +247,10 @@ interface Props {
 export function CommentThreadCard({
   thread,
   top,
+  dragPosition = null,
+  dragging = false,
   cardRef,
+  onDragStart,
   onClose,
   onEdit,
   onDelete,
@@ -256,6 +262,13 @@ export function CommentThreadCard({
   const comments = [thread.root, ...thread.replies];
   const canReplyToThread =
     thread.root.type === "question" && !!thread.root.thread && !!onReply;
+  const cardStyle: CSSProperties = dragPosition
+    ? {
+        position: "fixed",
+        top: dragPosition.top,
+        left: dragPosition.left,
+      }
+    : { top };
 
   function handleReplySubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -271,14 +284,20 @@ export function CommentThreadCard({
   return (
     <div
       ref={cardRef}
-      className="comment-thread-card"
-      style={{ top }}
+      className={`comment-thread-card${dragging ? " comment-thread-card--dragging" : ""}`}
+      style={cardStyle}
       onClick={(event) => event.stopPropagation()}
     >
       <div className="comment-thread-card__header">
-        <span className="comment-thread-card__title">
-          {thread.replies.length > 0 ? "Thread" : "Comment"}
-        </span>
+        <div
+          className="comment-thread-card__drag-handle"
+          onPointerDown={onDragStart}
+          title="Drag comment panel"
+        >
+          <span className="comment-thread-card__title">
+            {thread.replies.length > 0 ? "Thread" : "Comment"}
+          </span>
+        </div>
         <button
           className="comment-thread-card__close"
           onClick={onClose}

--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -206,44 +206,6 @@
   border-color: var(--accent);
 }
 
-.app-header__menu-wrap {
-  position: relative;
-  display: inline-flex;
-}
-
-.app-header__menu {
-  position: fixed;
-  z-index: 80;
-  min-width: 12rem;
-  padding: 0.35rem;
-  border: 1px solid var(--border-light);
-  border-radius: 6px;
-  background: var(--surface);
-  box-shadow: var(--shadow-md);
-}
-
-.app-header__menu-item {
-  width: 100%;
-  min-height: 2rem;
-  padding: 0.4rem 0.55rem;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.78rem;
-  font-weight: 600;
-  text-align: left;
-}
-
-.app-header__menu-item:hover,
-.app-header__menu-item:focus-visible {
-  outline: none;
-  background: var(--accent-bg);
-  color: var(--accent);
-}
-
 /* ── Peer badge in header ─────────────────────────────────────── */
 .app-header__peer-badge {
   font-size: 0.6875rem;

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -1,15 +1,15 @@
 import "./Header.css";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import {
   buildAddressCommentsAgentPrompt,
-  buildAgentReplyPrompt,
   buildCommentThreadGroups,
   buildFolderAddressCommentsAgentPrompt,
 } from "../../../markup";
 import {
   getActiveAgentRunForTab,
   getAddressableCommentTargets,
-  getFolderAddressableCommentTargets,
+  getFolderReviewCommentTargets,
+  getQuestionThreadCommentIds,
 } from "../../../modules/agent-workflow";
 import { useAppStore } from "../../../store";
 import { useActiveTab } from "../../../store/selectors";
@@ -312,11 +312,6 @@ interface FileCommentEntry {
   comments: Comment[];
 }
 
-interface HeaderMenuPosition {
-  top: number;
-  right: number;
-}
-
 function getRootOnlyComments(comments: Comment[]): Comment[] {
   return buildCommentThreadGroups(comments).map((group) => group.root);
 }
@@ -408,9 +403,6 @@ export function Header({
   const startAddressCommentsAgentRun = useAppStore(
     (state) => state.startAddressCommentsAgentRun,
   );
-  const startQuestionThreadAgentRun = useAppStore(
-    (state) => state.startQuestionThreadAgentRun,
-  );
   const activeAgentRun = useAppStore((state) =>
     tab?.id ? getActiveAgentRunForTab(state, tab.id) : null,
   );
@@ -437,81 +429,59 @@ export function Header({
     }
     return getAddressableCommentTargets(comments);
   }, [comments, hasFolderComments, peerMode]);
-  const folderAddressableCommentTargets = useMemo(() => {
+  const questionThreadIds = useMemo(() => {
+    if (peerMode || hasFolderComments) {
+      return [];
+    }
+    return getQuestionThreadCommentIds(rootComments);
+  }, [hasFolderComments, peerMode, rootComments]);
+  const folderReviewCommentTargets = useMemo(() => {
     if (peerMode || !hasFolderComments) {
       return [];
     }
-    return getFolderAddressableCommentTargets(crossFileComments);
+    return getFolderReviewCommentTargets(crossFileComments);
   }, [crossFileComments, hasFolderComments, peerMode]);
   const hasAddressableComments = hasFolderComments
-    ? folderAddressableCommentTargets.length > 0
+    ? folderReviewCommentTargets.some((target) => target.comments.length > 0)
     : addressableCommentTargets.length > 0;
-  const hasQuestionThreads =
-    !peerMode &&
-    (hasFolderComments
-      ? crossFileComments.some((entry) =>
-          entry.comments.some(
-            (comment) => comment.type === "question" && !!comment.thread,
-          ),
-        )
-      : rootComments.some(
-          (comment) => comment.type === "question" && !!comment.thread,
-        ));
+  const hasQuestionThreads = hasFolderComments
+    ? folderReviewCommentTargets.some(
+        (target) => target.questionThreadIds.length > 0,
+      )
+    : questionThreadIds.length > 0;
+  const hasReviewTargets = hasAddressableComments || hasQuestionThreads;
   const activeAgentRunInProgress = Boolean(
     activeAgentRun && ACTIVE_AGENT_RUN_STATUSES.has(activeAgentRun.status),
   );
   const showAgentActions =
-    !peerMode &&
-    hasContent &&
-    !disableHostReviewActions &&
-    (hasAddressableComments || hasQuestionThreads);
+    !peerMode && hasContent && !disableHostReviewActions && hasReviewTargets;
 
-  async function handleCopyAddressCommentsPrompt() {
+  async function handleCopyReviewPrompt() {
     const targetPath = activeFilePath ?? fileName ?? "the active markdown file";
     const prompt = hasFolderComments
       ? buildFolderAddressCommentsAgentPrompt({
-          targets: folderAddressableCommentTargets,
+          targets: folderReviewCommentTargets,
         })
       : buildAddressCommentsAgentPrompt({
           targetPath,
           comments: addressableCommentTargets,
+          questionThreadIds,
         });
     try {
       await navigator.clipboard.writeText(prompt);
-      showToast("Agent review prompt copied");
+      showToast("Review prompt copied");
     } catch (error) {
       console.error("[Header] failed to copy review prompt:", error);
       showToast("Couldn't copy agent prompt");
     }
   }
 
-  async function handleCopyQuestionPrompt() {
-    try {
-      await navigator.clipboard.writeText(buildAgentReplyPrompt());
-      showToast("Agent prompt copied");
-    } catch (error) {
-      console.error("[Header] failed to copy question prompt:", error);
-      showToast("Couldn't copy agent prompt");
-    }
-  }
-
-  async function handleAddressCommentsAction() {
+  async function handleReviewAction() {
     if (!canRunAgent) {
-      await handleCopyAddressCommentsPrompt();
+      await handleCopyReviewPrompt();
       return;
     }
     const result = await startAddressCommentsAgentRun();
-    if (result.status === "unavailable") {
-      showToast(result.message);
-    }
-  }
-
-  async function handleQuestionThreadAction() {
-    if (!canRunAgent) {
-      await handleCopyQuestionPrompt();
-      return;
-    }
-    const result = await startQuestionThreadAgentRun();
     if (result.status === "unavailable") {
       showToast(result.message);
     }
@@ -675,18 +645,10 @@ export function Header({
 
           <div className="app-header__group app-header__group--review">
             {showAgentActions && (
-              <ReviewAgentMenu
+              <ReviewAgentButton
                 disabled={activeAgentRunInProgress}
-                canAddressComments={hasAddressableComments}
-                canAnswerQuestions={hasQuestionThreads}
-                addressLabel={
-                  canRunAgent ? "Address comments" : "Copy review prompt"
-                }
-                questionLabel={
-                  canRunAgent ? "Answer questions" : "Copy answer prompt"
-                }
-                onAddressComments={handleAddressCommentsAction}
-                onAnswerQuestions={handleQuestionThreadAction}
+                canRunAgent={canRunAgent}
+                onReview={handleReviewAction}
               />
             )}
             <button
@@ -739,127 +701,29 @@ export function Header({
   );
 }
 
-function ReviewAgentMenu({
+function ReviewAgentButton({
   disabled,
-  canAddressComments,
-  canAnswerQuestions,
-  addressLabel,
-  questionLabel,
-  onAddressComments,
-  onAnswerQuestions,
+  canRunAgent,
+  onReview,
 }: {
   disabled: boolean;
-  canAddressComments: boolean;
-  canAnswerQuestions: boolean;
-  addressLabel: string;
-  questionLabel: string;
-  onAddressComments: () => Promise<void>;
-  onAnswerQuestions: () => Promise<void>;
+  canRunAgent: boolean;
+  onReview: () => Promise<void>;
 }) {
-  const [open, setOpen] = useState(false);
-  const [menuPosition, setMenuPosition] = useState<HeaderMenuPosition | null>(
-    null,
-  );
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-
-  const updateMenuPosition = useCallback(() => {
-    const button = buttonRef.current;
-    if (!button) {
-      return;
-    }
-    const rect = button.getBoundingClientRect();
-    setMenuPosition({
-      top: rect.bottom + 6,
-      right: Math.max(8, window.innerWidth - rect.right),
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    function handleDocumentClick(event: MouseEvent) {
-      const targetNode = event.target;
-      if (targetNode instanceof Node && menuRef.current?.contains(targetNode)) {
-        return;
-      }
-      setOpen(false);
-    }
-
-    updateMenuPosition();
-    document.addEventListener("click", handleDocumentClick);
-    window.addEventListener("resize", updateMenuPosition);
-    window.addEventListener("scroll", updateMenuPosition, true);
-    return () => {
-      document.removeEventListener("click", handleDocumentClick);
-      window.removeEventListener("resize", updateMenuPosition);
-      window.removeEventListener("scroll", updateMenuPosition, true);
-    };
-  }, [open, updateMenuPosition]);
-
-  async function handleMenuAction(action: () => Promise<void>) {
-    setOpen(false);
-    await action();
-  }
+  const label = canRunAgent ? "Review with agent" : "Copy review prompt";
 
   return (
-    <div className="app-header__menu-wrap" ref={menuRef}>
-      <button
-        ref={buttonRef}
-        type="button"
-        className={`app-header__btn app-header__btn--icon app-header__btn--review${open ? " app-header__btn--active" : ""}`}
-        aria-label="Review actions"
-        aria-expanded={open}
-        title={
-          disabled
-            ? "Wait for the active agent run to finish"
-            : "Review actions"
-        }
-        disabled={disabled}
-        onClick={(event) => {
-          event.stopPropagation();
-          if (!open) {
-            updateMenuPosition();
-          }
-          setOpen((currentOpen) => !currentOpen);
-        }}
-      >
-        <AgentIcon />
-      </button>
-      {open && (
-        <div
-          className="app-header__menu"
-          role="menu"
-          style={{ position: "fixed", ...(menuPosition ?? {}) }}
-        >
-          {canAddressComments && (
-            <button
-              type="button"
-              className="app-header__menu-item"
-              role="menuitem"
-              onClick={() => {
-                void handleMenuAction(onAddressComments);
-              }}
-            >
-              {addressLabel}
-            </button>
-          )}
-          {canAnswerQuestions && (
-            <button
-              type="button"
-              className="app-header__menu-item"
-              role="menuitem"
-              onClick={() => {
-                void handleMenuAction(onAnswerQuestions);
-              }}
-            >
-              {questionLabel}
-            </button>
-          )}
-        </div>
-      )}
-    </div>
+    <button
+      type="button"
+      className="app-header__btn app-header__btn--icon app-header__btn--review"
+      aria-label={label}
+      title={disabled ? "Wait for the active agent run to finish" : label}
+      disabled={disabled}
+      onClick={() => {
+        void onReview();
+      }}
+    >
+      <AgentIcon />
+    </button>
   );
 }

--- a/src/ui/components/Header/HeaderShare.test.tsx
+++ b/src/ui/components/Header/HeaderShare.test.tsx
@@ -134,7 +134,7 @@ describe("Header share buttons", () => {
 });
 
 describe("Header review actions", () => {
-  it("keeps the address-comments prompt available from the toolbar menu", async () => {
+  it("copies one review prompt with comment and thread instructions", async () => {
     const user = userEvent.setup();
     const writeText = vi
       .spyOn(navigator.clipboard, "writeText")
@@ -149,23 +149,36 @@ describe("Header review actions", () => {
           type: "fix",
           text: "Fix the intro",
         }),
+        makeComment({
+          id: "question-root",
+          type: "question",
+          text: "Why is this here?",
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
       ],
     });
 
     render(<Header />);
-    await user.click(screen.getByRole("button", { name: "Review actions" }));
     await user.click(
-      screen.getByRole("menuitem", { name: "Copy review prompt" }),
+      screen.getByRole("button", { name: "Copy review prompt" }),
     );
 
     expect(writeText).toHaveBeenCalledOnce();
-    expect(writeText.mock.calls[0]?.[0]).toContain("Work only in docs/spec.md");
-    expect(writeText.mock.calls[0]?.[0]).toContain(
-      "- fix-root (fix): Fix the intro",
-    );
+    const prompt = writeText.mock.calls[0]?.[0];
+    expect(prompt).toContain("Review docs/spec.md");
+    expect(prompt).toContain("Work only in docs/spec.md");
+    expect(prompt).toContain("- fix-root (fix): Fix the intro");
+    expect(prompt).toContain("- mr-question-1");
+    expect(prompt).toContain("Question thread replies");
+    expect(
+      screen.queryByRole("button", { name: "Copy answer prompt" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("keeps the question-answer prompt available from the toolbar menu", async () => {
+  it("copies the review prompt when only question threads are present", async () => {
     const user = userEvent.setup();
     const writeText = vi
       .spyOn(navigator.clipboard, "writeText")
@@ -187,14 +200,14 @@ describe("Header review actions", () => {
     });
 
     render(<Header />);
-    await user.click(screen.getByRole("button", { name: "Review actions" }));
     await user.click(
-      screen.getByRole("menuitem", { name: "Copy answer prompt" }),
+      screen.getByRole("button", { name: "Copy review prompt" }),
     );
 
     expect(writeText).toHaveBeenCalledOnce();
-    expect(writeText.mock.calls[0]?.[0]).toContain(
-      "answer MarkReview threaded questions inline",
-    );
+    const prompt = writeText.mock.calls[0]?.[0];
+    expect(prompt).toContain("Review spec.md");
+    expect(prompt).toContain("Answer these MarkReview question threads");
+    expect(prompt).toContain("- mr-question-1");
   });
 });


### PR DESCRIPTION
## Summary
- replace the two-item review agent menu with one review action/prompt that covers edits and question threads
- make comment-panel entries open the floating comment/thread card and allow dragging that floating panel
- update docs and tests for the unified review prompt and draggable floating comments

## Verification
- npm run typecheck
- npm run lint -- --quiet
- npm test
