### PR TITLE
Reopen restored file tabs from saved handles

### DIFF
--- a/docs/features/multi-tab.md
+++ b/docs/features/multi-tab.md
@@ -218,9 +218,10 @@ On page load:
 When a tab's file or folder cannot be accessed after a browser reopen, the UI keeps as much context visible as it safely can:
 
 - **File tab, last content available**: keep rendering the persisted markdown content
-- **Banner**: sticky restore-access banner at the top of the document with an "Open file" / "Open folder" action
+- **Banner**: sticky restore-access banner at the top of the document with a "Re-open current file" / "Re-open current folder" action
 - **Disabled actions**: comment creation, comment merge/review panels, and share-management actions stay disabled until access is restored
-- **No renderable file context**: show the full restore placeholder with an "Open file" / "Open folder" button
+- **No renderable file context**: show the full restore placeholder with a "Re-open current file" / "Re-open current folder" button
+- **Saved-target reopen**: when the user reopens a degraded tab, first reuse the saved file or folder handle/path and request permission from that button click instead of opening a picker
 - **Manual folder reopen**: when the user reopens a degraded folder tab and the last active file path still exists, restore that file immediately instead of dropping back to an empty folder view
 
 While `restoreError` is set, host-side review actions are disabled because the tab no longer has confirmed live write access.

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -424,6 +424,79 @@ function buildRestoreAccessState(message: string): Partial<TabState> {
   };
 }
 
+async function requestBrowserWritePermission(
+  handle: FileSystemHandle,
+): Promise<boolean> {
+  const writePermission = await handle.requestPermission({
+    mode: "readwrite",
+  });
+  return writePermission === "granted";
+}
+
+async function getSavedFileTarget(tab: TabState): Promise<FileTarget | null> {
+  if (tab.fileHandle) {
+    return tab.fileHandle;
+  }
+
+  const handle = await getHandle(`tab:${tab.id}:file`);
+  if (!handle || !isBrowserFileHandle(handle)) {
+    return null;
+  }
+
+  return handle;
+}
+
+async function getSavedDirectoryTarget(
+  tab: TabState,
+): Promise<DirectoryTarget | null> {
+  if (tab.directoryHandle) {
+    return tab.directoryHandle;
+  }
+
+  const handle = await getHandle(`tab:${tab.id}:directory`);
+  if (!handle || !isBrowserDirectoryHandle(handle)) {
+    return null;
+  }
+
+  return handle;
+}
+
+async function getSavedWritableFileTarget(
+  tab: TabState,
+): Promise<FileTarget | null> {
+  const target = await getSavedFileTarget(tab);
+  if (!target) {
+    return null;
+  }
+
+  if (isBrowserFileHandle(target)) {
+    const hasWriteAccess = await requestBrowserWritePermission(target);
+    if (!hasWriteAccess) {
+      return null;
+    }
+  }
+
+  return target;
+}
+
+async function getSavedWritableDirectoryTarget(
+  tab: TabState,
+): Promise<DirectoryTarget | null> {
+  const target = await getSavedDirectoryTarget(tab);
+  if (!target) {
+    return null;
+  }
+
+  if (isBrowserDirectoryHandle(target)) {
+    const hasWriteAccess = await requestBrowserWritePermission(target);
+    if (!hasWriteAccess) {
+      return null;
+    }
+  }
+
+  return target;
+}
+
 function buildFileRestoreMessage(fileName: string): string {
   return `Live access to "${fileName}" is unavailable. Open the file again to restore commenting and share review.`;
 }
@@ -863,10 +936,7 @@ export function createWorkspaceControllerActions<
           await scanAllFileComments();
         }
       } catch (error) {
-        console.error(
-          "[openDirectoryInNewTab] failed to open folder:",
-          error,
-        );
+        console.error("[openDirectoryInNewTab] failed to open folder:", error);
         showToast("Folder could not be opened. Check the terminal logs.");
       }
     },
@@ -879,13 +949,22 @@ export function createWorkspaceControllerActions<
 
       if (tab.directoryName) {
         try {
-          const result = await openDirectory();
-          if (!result) {
+          const target = await getSavedWritableDirectoryTarget(tab);
+          if (!target) {
+            set((state) => ({
+              tabs: buildUpdatedTabs(state.tabs, tabId, () => ({
+                restoreError: buildFolderRestoreMessage({
+                  directoryName: tab.directoryName,
+                  fileName: tab.fileName,
+                }),
+              })),
+            }));
+            showToast("Folder access was not restored");
             return;
           }
 
-          await saveBrowserHandle(`tab:${tabId}:directory`, result.handle);
-          const tree = await buildFileTree(result.handle);
+          await saveBrowserHandle(`tab:${tabId}:directory`, target);
+          const tree = await buildFileTree(target);
           const restoredFile = await restoreActiveFileFromTree({
             tree,
             activeFilePath: tab.activeFilePath,
@@ -894,9 +973,9 @@ export function createWorkspaceControllerActions<
           });
           set((state) => ({
             tabs: buildUpdatedTabs(state.tabs, tabId, () => ({
-              directoryHandle: result.handle,
-              directoryName: result.name,
-              label: result.name,
+              directoryHandle: target,
+              directoryName: target.name,
+              label: target.name,
               fileTree: tree,
               fileHandle: restoredFile.fileHandle,
               fileName: restoredFile.fileName,
@@ -937,18 +1016,26 @@ export function createWorkspaceControllerActions<
       }
 
       try {
-        const result = await openFile();
-        if (!result) {
+        const target = await getSavedWritableFileTarget(tab);
+        if (!target) {
+          set((state) => ({
+            tabs: buildUpdatedTabs(state.tabs, tabId, () => ({
+              restoreError: buildFileRestoreMessage(
+                tab.fileName ?? "this file",
+              ),
+            })),
+          }));
+          showToast("File access was not restored");
           return;
         }
 
-        await saveBrowserHandle(`tab:${tabId}:file`, result.handle);
-        const rawContent = await readFile(result.handle);
+        await saveBrowserHandle(`tab:${tabId}:file`, target);
+        const rawContent = await readFile(target);
         set((state) => ({
           tabs: buildUpdatedTabs(state.tabs, tabId, () => ({
-            fileHandle: result.handle,
-            fileName: result.name,
-            label: result.name,
+            fileHandle: target,
+            fileName: target.name,
+            label: target.name,
             rawContent,
             writeAllowed: true,
             restoreError: null,

--- a/src/modules/workspace/test/tabRestore.test.ts
+++ b/src/modules/workspace/test/tabRestore.test.ts
@@ -520,10 +520,11 @@ describe("store.restoreTabs", () => {
 });
 
 describe("store.reopenTab", () => {
-  it("reopens a folder tab and restores its previous active file", async () => {
+  it("reopens a folder tab from its saved handle and restores its previous active file", async () => {
     const directoryHandle = {
       kind: "directory",
       name: "project",
+      requestPermission: vi.fn().mockResolvedValue("granted"),
     };
     const recoveredFileHandle = {
       kind: "file",
@@ -566,17 +567,17 @@ describe("store.reopenTab", () => {
       activeTabId: fileTab.id,
     });
 
-    vi.mocked(openDirectory).mockResolvedValue({
-      handle: directoryHandle,
-      name: "project",
-    });
+    vi.mocked(getHandle).mockResolvedValue(directoryHandle);
     vi.mocked(buildFileTree).mockResolvedValue(tree);
     vi.mocked(readFile).mockResolvedValue("# Updated");
 
     await useAppStore.getState().reopenTab(fileTab.id);
 
     const tab = getActiveTab(useAppStore.getState());
-    expect(openDirectory).toHaveBeenCalled();
+    expect(openDirectory).not.toHaveBeenCalled();
+    expect(directoryHandle.requestPermission).toHaveBeenCalledWith({
+      mode: "readwrite",
+    });
     expect(saveHandle).toHaveBeenCalledWith(
       `tab:${fileTab.id}:directory`,
       directoryHandle,
@@ -590,6 +591,82 @@ describe("store.reopenTab", () => {
     expect(tab?.sharedPanelOpen).toBe(true);
     expect(tab?.restoreError).toBeNull();
     expect(tab?.writeAllowed).toBe(true);
+  });
+
+  it("reopens a file tab from its saved handle without opening a picker", async () => {
+    const fileHandle = {
+      kind: "file",
+      name: "notes.md",
+      requestPermission: vi.fn().mockResolvedValue("granted"),
+    };
+    const fileTab = createDefaultTab({
+      id: "file-tab",
+      label: "notes.md",
+      fileName: "notes.md",
+      rawContent: "# Persisted",
+      restoreError:
+        'Live access to "notes.md" is unavailable. Open the file again to restore commenting and share review.',
+      writeAllowed: false,
+    });
+
+    useAppStore.setState({
+      tabs: [fileTab],
+      activeTabId: fileTab.id,
+    });
+
+    vi.mocked(getHandle).mockResolvedValue(fileHandle);
+    vi.mocked(readFile).mockResolvedValue("# Updated");
+
+    await useAppStore.getState().reopenTab(fileTab.id);
+
+    const tab = getActiveTab(useAppStore.getState());
+    expect(openFile).not.toHaveBeenCalled();
+    expect(fileHandle.requestPermission).toHaveBeenCalledWith({
+      mode: "readwrite",
+    });
+    expect(saveHandle).toHaveBeenCalledWith(
+      `tab:${fileTab.id}:file`,
+      fileHandle,
+    );
+    expect(tab?.fileHandle).toBe(fileHandle);
+    expect(tab?.fileName).toBe("notes.md");
+    expect(tab?.rawContent).toBe("# Updated");
+    expect(tab?.restoreError).toBeNull();
+    expect(tab?.writeAllowed).toBe(true);
+  });
+
+  it("keeps a file tab in restore state when saved handle permission is denied", async () => {
+    const fileHandle = {
+      kind: "file",
+      name: "notes.md",
+      requestPermission: vi.fn().mockResolvedValue("denied"),
+    };
+    const fileTab = createDefaultTab({
+      id: "file-tab",
+      label: "notes.md",
+      fileName: "notes.md",
+      rawContent: "# Persisted",
+      restoreError:
+        'Live access to "notes.md" is unavailable. Open the file again to restore commenting and share review.',
+      writeAllowed: false,
+    });
+
+    useAppStore.setState({
+      tabs: [fileTab],
+      activeTabId: fileTab.id,
+    });
+
+    vi.mocked(getHandle).mockResolvedValue(fileHandle);
+
+    await useAppStore.getState().reopenTab(fileTab.id);
+
+    const tab = getActiveTab(useAppStore.getState());
+    expect(openFile).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(saveHandle).not.toHaveBeenCalled();
+    expect(tab?.restoreError).toContain("notes.md");
+    expect(tab?.writeAllowed).toBe(false);
+    expect(useAppStore.getState().toast).toBe("File access was not restored");
   });
 });
 

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -86,8 +86,8 @@ export function getRestoreAccessActionLabel(
   tab: RestoreStateTab | null,
 ): string {
   if (tab?.directoryName) {
-    return "Open folder";
+    return "Re-open current folder";
   }
 
-  return "Open file";
+  return "Re-open current file";
 }

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -274,9 +274,9 @@ describe("App — folder open", () => {
     expect(
       screen.getByRole("heading", { name: "Folder access needed" }),
     ).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Open folder" })).toHaveLength(
-      2,
-    );
+    expect(
+      screen.getByRole("button", { name: "Re-open current folder" }),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("markdown-renderer")).not.toBeInTheDocument();
   });
 

--- a/src/ui/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/src/ui/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -181,7 +181,9 @@ describe("MarkdownRenderer — metadata", () => {
 
     const { container } = render(<MarkdownRenderer />);
 
-    expect(screen.getByRole("region", { name: "Metadata" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Metadata" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("id")).toBeInTheDocument();
     expect(
       screen.getByText("DEC-retrieval-fast-paths-use-generated-metadata"),
@@ -194,9 +196,9 @@ describe("MarkdownRenderer — metadata", () => {
         name: "Decision: Retrieval Fast Paths",
       }),
     ).toBeInTheDocument();
-    expect(container.querySelector(".markdown-body")?.textContent).not.toContain(
-      "participants:",
-    );
+    expect(
+      container.querySelector(".markdown-body")?.textContent,
+    ).not.toContain("participants:");
   });
 });
 
@@ -231,7 +233,7 @@ describe("MarkdownRenderer — read-only banner", () => {
 
     expect(screen.getByRole("status").textContent).toMatch(/live access/i);
     expect(
-      screen.getByRole("button", { name: "Open file" }),
+      screen.getByRole("button", { name: "Re-open current file" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("status").textContent).not.toMatch(/read-only/i);
   });


### PR DESCRIPTION
﻿## Summary
- Reopen restored file and folder tabs from their saved handle/path instead of opening a picker
- Request readwrite permission from the restore button path and keep restore state when access is not restored
- Rename restore actions to "Re-open current file/folder" and update restore docs/tests

## Validation
- npm test -- src/ui/App.test.tsx src/ui/components/MarkdownRenderer/MarkdownRenderer.test.tsx src/modules/workspace/test/tabRestore.test.ts
- npm run typecheck
- npx eslint src/modules/workspace/controller.ts src/modules/workspace/test/tabRestore.test.ts src/types/tab.ts src/ui/App.test.tsx src/ui/components/MarkdownRenderer/MarkdownRenderer.test.tsx --quiet
- npx prettier --check src/modules/workspace/controller.ts src/modules/workspace/test/tabRestore.test.ts src/types/tab.ts src/ui/App.test.tsx src/ui/components/MarkdownRenderer/MarkdownRenderer.test.tsx docs/features/multi-tab.md
- git diff --check

Note: full npm run lint -- --quiet still fails on pre-existing worker/src/index.ts:129 @typescript-eslint/no-unsafe-return, outside this patch.
