### PR TITLE
Style remove comment action as red

### DIFF
--- a/src/ui/components/CommentMargin/CommentMargin.css
+++ b/src/ui/components/CommentMargin/CommentMargin.css
@@ -198,9 +198,22 @@
   color: var(--accent);
 }
 
+.comment-add-form__type[data-comment-type="remove"] {
+  color: var(--c-red);
+}
+
+.comment-add-form__type[data-comment-type="remove"]:hover {
+  border-color: color-mix(in srgb, var(--c-red) 42%, var(--border));
+  color: var(--c-red);
+}
+
 .comment-add-form__type:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.comment-add-form__type[data-comment-type="remove"]:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--c-red) 30%, transparent);
 }
 
 .comment-add-form__type--active {
@@ -208,6 +221,12 @@
   border-color: var(--accent);
   color: #fff;
   box-shadow: var(--shadow-sm);
+}
+
+.comment-add-form__type--active[data-comment-type="remove"] {
+  background: var(--c-red);
+  border-color: var(--c-red);
+  color: #fff;
 }
 
 .comment-add-form__input {

--- a/src/ui/components/CommentMargin/CommentMargin.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.tsx
@@ -92,6 +92,7 @@ function AddCommentForm({
             key={t}
             type="button"
             className={`comment-add-form__type${type === t ? " comment-add-form__type--active" : ""}`}
+            data-comment-type={t}
             aria-pressed={type === t}
             onClick={() => setType(t)}
             disabled={disabled}

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -321,6 +321,18 @@
   background-color: var(--surface-alt);
 }
 
+.comment-panel__filter[data-comment-type="remove"] {
+  border-color: color-mix(in srgb, var(--c-red) 38%, var(--border));
+  color: var(--c-red);
+}
+
+.comment-panel__filter[data-comment-type="remove"]:hover,
+.comment-panel__filter--active[data-comment-type="remove"] {
+  background-color: color-mix(in srgb, var(--c-red) 10%, transparent);
+  border-color: var(--c-red);
+  color: var(--c-red);
+}
+
 .comment-panel__filter--active {
   background-color: var(--surface-alt);
   font-weight: 600;

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -866,6 +866,7 @@ export function CommentPanel({ peerMode = false }: Props) {
                 <button
                   key={type}
                   className={`comment-panel__filter${commentFilter === type ? " comment-panel__filter--active" : ""}`}
+                  data-comment-type={type}
                   style={
                     commentFilter === type
                       ? {
@@ -969,6 +970,7 @@ function InlineEditForm({
             key={commentType}
             type="button"
             className={`comment-add-form__type${editType === commentType ? " comment-add-form__type--active" : ""}`}
+            data-comment-type={commentType}
             aria-pressed={editType === commentType}
             onClick={() => setEditType(commentType)}
           >

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
@@ -90,6 +90,7 @@ function CommentEditForm({
             key={commentType}
             type="button"
             className={`comment-add-form__type${editType === commentType ? " comment-add-form__type--active" : ""}`}
+            data-comment-type={commentType}
             aria-pressed={editType === commentType}
             onClick={() => setEditType(commentType)}
           >


### PR DESCRIPTION
﻿## Summary
- Add comment type data hooks to add/edit/filter controls
- Style the remove comment action red across normal, hover, focus, and active states

## Validation
- npm test -- src/ui/components/CommentPanel/CommentPanel.test.tsx src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx src/ui/components/CommentCard/CommentCardEditDelete.test.tsx
- npm run typecheck
- npx eslint src/ui/components/CommentMargin/CommentMargin.tsx src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentThreadCard/CommentThreadCard.tsx --quiet
- npx prettier --check src/ui/components/CommentMargin/CommentMargin.tsx src/ui/components/CommentMargin/CommentMargin.css src/ui/components/CommentPanel/CommentPanel.tsx src/ui/components/CommentPanel/CommentPanel.css src/ui/components/CommentThreadCard/CommentThreadCard.tsx
- git diff --check
