### PR TITLE
Hide thread reply composer while editing comments

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -101,10 +101,14 @@ MarkReview extends the plain comment protocol for threaded review questions.
 - MarkReview writes hidden `[markreview ...]` metadata into app-created `question:` comments so a raw markdown file still carries stable thread identifiers.
 - Agents reply with a separate inline `answer:` CriticMarkup comment near the same text block.
 - Users can also reply directly from the thread card; MarkReview writes the same linked `answer:` CriticMarkup reply with `author="You"`.
+- Users can switch the thread composer from `Reply` to `Action` and choose a compact action type (`fix`, `rewrite`, `expand`, `clarify`, or `remove`). MarkReview writes that action as a linked threaded CriticMarkup comment with `author="You"` instead of `answer:`.
 - The reply reuses the root `thread` value and sets `replyTo` to the root question `id`.
 - The reply can also include `author` so the UI can show `Codex`, `Cursor`, or a generic `Agent` label.
 - The Comments panel keeps replies collapsed under the root question and marks the root as `answered` once an `answer:` reply exists.
 - Agent-authored replies render as read-only comments in the UI. User-authored replies can be edited or deleted.
+- Thread cards visually distinguish user-authored answers from external or agent-authored answers so ownership is clear at a glance.
+- Threaded action replies are work instructions, not conversational answers. The review-agent prompt tells agents to apply the requested edit directly, remove the resolved thread after the edit, and avoid adding a confirmation `answer:` reply.
+- While a question, answer, or action reply in the thread card is being edited or delete-confirmed, the composer is hidden so the user sees only one active input surface.
 - Deleting a thread-root `question:` comment deletes the linked `answer:` replies in the same thread so replies never remain as orphan comments.
 
 Example root:
@@ -117,6 +121,12 @@ Example reply:
 
 ```text
 {>>answer: This section explains the reconnect fallback path after a missed live event. [markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"]<<}
+```
+
+Example action reply:
+
+```text
+{>>remove: Delete BL-2 from this section. [markreview id="mr-action-1" thread="mr-question-1" replyTo="mr-question-1" author="You"]<<}
 ```
 
 ### 6.4 Why This Works
@@ -187,7 +197,7 @@ metadata block.
 
 ### 8.3 Block-Level Commenting UI
 
-Every rendered block (paragraph, heading, table, code block, diagram, list item) is commentable. On hover, a visible comment icon appears in the left margin. Clicking opens a floating comment popup with a type selector and text input. Existing comments show as colored markers in the margin — color-coded by type, with a stronger selected state so their document anchor is clear. Clicking a marker expands the same floating popup with the saved comment card. Clicking a comment in the right sidebar opens the same floating popup at the related document block. The comment popup can be dragged around the viewport in both add and view modes, and it resets to its anchored position when another comment or add form opens. The right sidebar shows all comments in document order. Filters: all, by type, pending only (CriticMarkup still present), resolved (CriticMarkup removed by the LLM). Bulk deletion requires a confirmation step instead of deleting directly from the panel header.
+Every rendered block (paragraph, heading, table, code block, diagram, list item) is commentable. On hover, a visible comment icon appears in the left margin. Clicking opens a floating comment popup with a type selector and text input. Existing comments show as colored markers in the margin — color-coded by type, with a stronger selected state so their document anchor is clear. The hover comment icon and existing comment markers occupy separate margin lanes so neither control covers the other. Clicking a marker expands the same floating popup with the saved comment card. Clicking a comment in the right sidebar opens the same floating popup at the related document block. The comment popup can be dragged around the viewport in both add and view modes, and it resets to its anchored position when another comment or add form opens. The right sidebar shows all comments in document order. Filters: all, by type, pending only (CriticMarkup still present), resolved (CriticMarkup removed by the LLM). Bulk deletion requires a confirmation step instead of deleting directly from the panel header.
 
 ### 8.4 Design
 

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -42,6 +42,7 @@ function buildQuestionReplyRules(): string {
   return `Question thread replies:
 - Leave each original question comment unchanged.
 - Read the entire existing thread for each question, including human and agent answers already present.
+- If a thread contains user-authored threaded action comments (\`fix:\`, \`rewrite:\`, \`expand:\`, \`clarify:\`, or \`remove:\` with \`replyTo\` metadata), treat those as document-change instructions instead of questions to answer.
 - Reply with a separate inline CriticMarkup comment near the same text block.
 - Use the \`answer:\` prefix in every reply.
 - Keep the question's existing \`thread\` value.
@@ -49,6 +50,15 @@ function buildQuestionReplyRules(): string {
 - Give your reply its own unique \`id\`.
 - Add your agent name in \`author\` (for example \`Codex\` or \`Cursor\`).
 - Keep answers concise, specific, and grounded in the referenced text.`;
+}
+
+function buildThreadActionRules(): string {
+  return `Thread action replies:
+- A user-authored threaded action comment is a MarkReview comment with \`replyTo\` metadata and type \`fix:\`, \`rewrite:\`, \`expand:\`, \`clarify:\`, or \`remove:\`.
+- Treat these comments as instructions to change the markdown, not as messages to answer.
+- Apply the requested edit directly in the markdown.
+- After applying the edit, remove the resolved thread from the file, including the root \`question:\`, prior \`answer:\` replies, and the action comment.
+- Do not add a new \`answer:\` or confirmation comment for completed actions.`;
 }
 
 function buildCommentList(comments: AddressCommentsPromptComment[]): string {
@@ -102,6 +112,8 @@ ${questionThreadList}
 - Do not remove question comments when answering them.
 - Do not edit unrelated files or unrelated comments.
 
+${buildThreadActionRules()}
+
 ${buildQuestionReplyRules()}`;
 }
 
@@ -143,6 +155,8 @@ ${targetList}
 - Remove each addressed MarkReview comment once its requested change is applied.
 - Do not remove question comments when answering them.
 - Do not edit unrelated files or unrelated comments.
+
+${buildThreadActionRules()}
 
 ${buildQuestionReplyRules()}`;
 }

--- a/src/markup/insertComment.test.ts
+++ b/src/markup/insertComment.test.ts
@@ -228,4 +228,35 @@ describe("insertThreadReply", () => {
       /\{>>answer: Existing answer\. \[markreview id="mr-answer-1" thread="mr-question-1" replyTo="mr-question-1" author="Codex"\]<<}\{>>answer: Follow-up answer\. \[markreview id="mr-[^"]+" thread="mr-question-1" replyTo="mr-question-1" author="You"\]<<} end/,
     );
   });
+
+  it("adds a linked action reply with the selected action type", () => {
+    const questionRaw =
+      '{>>question: Why? [markreview id="mr-question-1" thread="mr-question-1"]<<}';
+    const raw = `Before ${questionRaw} after`;
+    const questionStart = raw.indexOf(questionRaw);
+    const root = makeComment({
+      id: "question-root",
+      type: "question",
+      raw: questionRaw,
+      rawStart: questionStart,
+      rawEnd: questionStart + questionRaw.length,
+      thread: {
+        commentId: "mr-question-1",
+        threadId: "mr-question-1",
+      },
+    });
+
+    const result = insertThreadReply({
+      rawContent: raw,
+      root,
+      replies: [],
+      type: "remove",
+      text: "Delete this paragraph.",
+      authorLabel: "You",
+    });
+
+    expect(result).toMatch(
+      /Before \{>>question: Why\? \[markreview id="mr-question-1" thread="mr-question-1"\]<<}\{>>remove: Delete this paragraph\. \[markreview id="mr-[^"]+" thread="mr-question-1" replyTo="mr-question-1" author="You"\]<<} after/,
+    );
+  });
 });

--- a/src/markup/insertComment.ts
+++ b/src/markup/insertComment.ts
@@ -117,6 +117,7 @@ export function insertThreadReply(input: {
   rawContent: string;
   root: Comment;
   replies: Comment[];
+  type?: CommentType;
   text: string;
   authorLabel: string;
 }): string {
@@ -144,7 +145,7 @@ export function insertThreadReply(input: {
 
   const insertPosition = latestThreadComment?.rawEnd ?? input.root.rawEnd;
   const markup = `{>>${serializeCommentBody({
-    type: "answer",
+    type: input.type ?? "answer",
     text: input.text,
     thread,
   })}<<}`;

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -123,10 +123,28 @@ const ADDRESSABLE_COMMENT_TYPES = new Set<Comment["type"]>([
   "remove",
   "note",
 ]);
+const THREAD_ACTION_COMMENT_TYPES = new Set<Comment["type"]>([
+  "fix",
+  "rewrite",
+  "expand",
+  "clarify",
+  "remove",
+]);
+
+function isThreadActionReply(comment: Comment): boolean {
+  return (
+    !!comment.thread?.replyTo && THREAD_ACTION_COMMENT_TYPES.has(comment.type)
+  );
+}
 
 export function getQuestionThreadCommentIds(comments: Comment[]): string[] {
   return buildCommentThreadGroups(comments)
-    .filter((group) => group.root.type === "question" && !!group.root.thread)
+    .filter(
+      (group) =>
+        group.root.type === "question" &&
+        !!group.root.thread &&
+        !group.replies.some(isThreadActionReply),
+    )
     .map((group) => group.root.thread?.commentId ?? group.root.id);
 }
 
@@ -143,14 +161,17 @@ function commentPromptText(comment: Comment): string {
 export function getAddressableCommentTargets(
   comments: Comment[],
 ): AddressableCommentTarget[] {
-  return buildCommentThreadGroups(comments)
-    .map((group) => group.root)
-    .filter((comment) => ADDRESSABLE_COMMENT_TYPES.has(comment.type))
-    .map((comment) => ({
+  return buildCommentThreadGroups(comments).flatMap((group) => {
+    const rootTargets = ADDRESSABLE_COMMENT_TYPES.has(group.root.type)
+      ? [group.root]
+      : [];
+    const actionReplyTargets = group.replies.filter(isThreadActionReply);
+    return [...rootTargets, ...actionReplyTargets].map((comment) => ({
       id: comment.thread?.commentId ?? comment.id,
       type: comment.type,
       text: commentPromptText(comment),
     }));
+  });
 }
 
 export function getFolderAddressableCommentTargets(

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -53,6 +53,17 @@ describe("address comments agent run context", () => {
         },
       }),
       makeComment({
+        id: "remove-reply",
+        type: "remove",
+        text: "Delete this section.",
+        thread: {
+          commentId: "mr-action-1",
+          threadId: "mr-question-1",
+          replyTo: "mr-question-1",
+          authorLabel: "You",
+        },
+      }),
+      makeComment({
         id: "note-root",
         type: "note",
         text: "Check this claim",
@@ -64,6 +75,11 @@ describe("address comments agent run context", () => {
         id: "fix-root",
         type: "fix",
         text: "Fix the intro",
+      },
+      {
+        id: "mr-action-1",
+        type: "remove",
+        text: "Delete this section.",
       },
       {
         id: "note-root",
@@ -110,6 +126,10 @@ describe("address comments agent run context", () => {
       "Answer these MarkReview question threads",
     );
     expect(request.prompt).toContain("- mr-question-1");
+    expect(request.prompt).toContain("Thread action replies");
+    expect(request.prompt).toContain(
+      "Do not add a new `answer:` or confirmation comment",
+    );
   });
 
   it("selects a bounded set of folder comment targets", () => {
@@ -262,6 +282,31 @@ describe("question thread agent run context", () => {
     ]);
 
     expect(commentIds).toEqual(["mr-question-1"]);
+  });
+
+  it("excludes question threads that contain user action replies", () => {
+    const commentIds = getQuestionThreadCommentIds([
+      makeComment({
+        id: "question-root",
+        type: "question",
+        thread: {
+          commentId: "mr-question-1",
+          threadId: "mr-question-1",
+        },
+      }),
+      makeComment({
+        id: "remove-reply",
+        type: "remove",
+        thread: {
+          commentId: "mr-action-1",
+          threadId: "mr-question-1",
+          replyTo: "mr-question-1",
+          authorLabel: "You",
+        },
+      }),
+    ]);
+
+    expect(commentIds).toEqual([]);
   });
 
   it("builds a narrow active-file request for answering questions", () => {

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -392,7 +392,7 @@ export function createHostReviewControllerActions<
       });
     },
 
-    replyToCommentThread: async (rootCommentId, text) => {
+    replyToCommentThread: async (rootCommentId, text, type = "answer") => {
       const tab = getActiveTab(get);
       if (!tab?.fileHandle) {
         return;
@@ -421,6 +421,7 @@ export function createHostReviewControllerActions<
           rawContent: tab.rawContent,
           root: selectedThread.root,
           replies: selectedThread.replies,
+          type,
           text,
           authorLabel: "You",
         }),

--- a/src/modules/host-review/test/hostReviewActions.test.ts
+++ b/src/modules/host-review/test/hostReviewActions.test.ts
@@ -275,6 +275,49 @@ describe("store.replyToCommentThread", () => {
     expect(tab?.rawContent).toBe(writtenContent);
     expect(tab?.undoState?.rawContent).toBe(rawContent);
   });
+
+  it("writes a linked user action with the selected comment type", async () => {
+    const { handle, mockWritable } = makeHandle();
+    const questionRaw =
+      '{>>question: Why? [markreview id="mr-question-1" thread="mr-question-1"]<<}';
+    const rawContent = `Before ${questionRaw} after`;
+    const questionStart = rawContent.indexOf(questionRaw);
+    setTestState({
+      fileHandle: handle,
+      rawContent,
+      comments: [
+        makeComment({
+          id: "question-root",
+          type: "question",
+          text: "Why?",
+          raw: questionRaw,
+          rawStart: questionStart,
+          rawEnd: questionStart + questionRaw.length,
+          thread: {
+            commentId: "mr-question-1",
+            threadId: "mr-question-1",
+          },
+        }),
+      ],
+    });
+
+    await useAppStore
+      .getState()
+      .replyToCommentThread(
+        "question-root",
+        "Delete this paragraph.",
+        "remove",
+      );
+
+    const writtenContent: unknown = mockWritable.write.mock.calls[0]?.[0];
+    if (typeof writtenContent !== "string") {
+      throw new Error("Expected action write to receive markdown text.");
+    }
+
+    expect(writtenContent).toMatch(
+      /Before \{>>question: Why\? \[markreview id="mr-question-1" thread="mr-question-1"\]<<}\{>>remove: Delete this paragraph\. \[markreview id="mr-[^"]+" thread="mr-question-1" replyTo="mr-question-1" author="You"\]<<} after/,
+    );
+  });
 });
 
 describe("store.undo", () => {

--- a/src/modules/host-review/types.ts
+++ b/src/modules/host-review/types.ts
@@ -56,7 +56,11 @@ export interface HostReviewActions {
   ) => Promise<void>;
   editComment: (id: string, type: CommentType, text: string) => Promise<void>;
   deleteComment: (id: string) => Promise<void>;
-  replyToCommentThread: (rootCommentId: string, text: string) => Promise<void>;
+  replyToCommentThread: (
+    rootCommentId: string,
+    text: string,
+    type?: CommentType,
+  ) => Promise<void>;
   deleteAllComments: () => Promise<void>;
   undo: () => Promise<void>;
   clearUndo: () => void;

--- a/src/ui/components/CommentMargin/CommentMargin.css
+++ b/src/ui/components/CommentMargin/CommentMargin.css
@@ -7,7 +7,7 @@
 
 .comment-margin__dots {
   position: absolute;
-  right: 0.7rem;
+  right: 0.2rem;
   display: flex;
   flex-direction: column;
   gap: 3px;
@@ -43,7 +43,7 @@
 
 .comment-margin__add-wrapper {
   position: absolute;
-  left: 0.25rem;
+  left: -0.45rem;
   margin-top: -6px;
 }
 

--- a/src/ui/components/CommentMargin/CommentMargin.test.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.test.tsx
@@ -325,6 +325,35 @@ describe("CommentMargin — AddCommentForm", () => {
     expect(screen.queryByText("Fix this paragraph")).not.toBeInTheDocument();
   });
 
+  it("keeps the add button visible alongside existing comment dots", () => {
+    setTestState({
+      activeCommentId: "fix-root",
+      comments: [
+        makeComment({
+          id: "fix-root",
+          type: "fix",
+          text: "Fix this paragraph",
+          blockIndex: 0,
+        }),
+      ],
+    });
+
+    render(
+      <CommentMargin
+        containerRef={createContainerRef([96])}
+        hoveredBlock={{ index: 0, top: 96 }}
+        onAddComment={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add comment" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /fix: Fix this paragraph/i }),
+    ).toBeInTheDocument();
+  });
+
   it("closes the add form when an existing comment opens", async () => {
     const user = userEvent.setup();
     setTestState({

--- a/src/ui/components/CommentMargin/CommentMargin.tsx
+++ b/src/ui/components/CommentMargin/CommentMargin.tsx
@@ -627,8 +627,8 @@ export function CommentMargin({
                   });
                   setActiveId(null);
                 }}
-                onReply={(rootCommentId, text) => {
-                  replyToCommentThreadAction(rootCommentId, text).catch(
+                onReply={(rootCommentId, text, type) => {
+                  replyToCommentThreadAction(rootCommentId, text, type).catch(
                     (error) => {
                       console.error(
                         "[CommentMargin] failed to reply to thread:",

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.css
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.css
@@ -77,6 +77,17 @@
   margin-left: 1rem;
 }
 
+.comment-thread-card__item--external {
+  background: color-mix(in srgb, var(--surface) 94%, var(--bg));
+  border-color: color-mix(in srgb, var(--text-muted) 24%, var(--border-light));
+}
+
+.comment-thread-card__item--mine {
+  background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+  border-color: color-mix(in srgb, var(--accent) 48%, var(--border-light));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
 .comment-thread-card__item-header {
   display: flex;
   align-items: flex-start;
@@ -89,24 +100,37 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 0.35rem;
 }
 
 .comment-thread-card__badge {
   display: inline-block;
-  padding: 0.15rem 0.5rem;
+  padding: 0.08rem 0.38rem;
   border-radius: 99px;
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1.2;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   color: #fff;
 }
 
 .comment-thread-card__author {
-  font-size: 0.72rem;
-  font-weight: 600;
+  border-radius: 999px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 0.08rem 0.38rem;
+}
+
+.comment-thread-card__author--external {
+  background: var(--surface-alt);
   color: var(--text-secondary);
+}
+
+.comment-thread-card__author--mine {
+  background: color-mix(in srgb, var(--accent) 16%, var(--surface));
+  color: var(--accent);
 }
 
 .comment-thread-card__actions {
@@ -206,8 +230,29 @@
   padding-top: 0.25rem;
 }
 
+.comment-thread-card__edit-form .comment-add-form__types,
+.comment-thread-card__edit-form .comment-add-form__input {
+  box-sizing: border-box;
+  width: 100%;
+}
+
 .comment-thread-card__edit-form .comment-add-form__input {
   min-height: 7rem;
+}
+
+.comment-thread-card__edit-form .comment-add-form__actions {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.comment-thread-card__edit-form .comment-add-form__save,
+.comment-thread-card__edit-form .comment-add-form__cancel {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-height: 3rem;
 }
 
 .comment-thread-card__empty {
@@ -222,6 +267,48 @@
   margin-top: 0.8rem;
   padding-top: 0.8rem;
   border-top: 1px solid var(--border-light);
+}
+
+.comment-thread-card__reply-toolbar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.comment-thread-card__reply-mode,
+.comment-thread-card__action-types {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.comment-thread-card__reply-mode-button,
+.comment-thread-card__action-type {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.66rem;
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 0.16rem 0.48rem;
+}
+
+.comment-thread-card__reply-mode-button--active,
+.comment-thread-card__action-type--active {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+  color: var(--accent);
+}
+
+.comment-thread-card__reply-mode-button:hover,
+.comment-thread-card__action-type:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .comment-thread-card__reply-input {

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
@@ -77,6 +77,36 @@ describe("CommentThreadCard", () => {
     expect(screen.getByText("Agent")).toBeInTheDocument();
   });
 
+  it("visually distinguishes user-authored answers from external answers", () => {
+    const { root, reply } = makeQuestionThread();
+    const userReply = makeComment({
+      id: "user-reply-comment",
+      type: "answer",
+      text: "I think we can remove this section.",
+      thread: {
+        commentId: "mr-answer-2",
+        threadId: "mr-question-1",
+        replyTo: "mr-question-1",
+        authorLabel: "You",
+      },
+    });
+
+    render(
+      <CommentThreadCard
+        thread={{ root, replies: [reply, userReply] }}
+        top={0}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Codex").closest(".comment-thread-card__item"),
+    ).toHaveClass("comment-thread-card__item--external");
+    expect(
+      screen.getByText("You").closest(".comment-thread-card__item"),
+    ).toHaveClass("comment-thread-card__item--mine");
+  });
+
   it("edits the selected user-authored thread message", async () => {
     const user = userEvent.setup();
     const onEdit = vi.fn();
@@ -101,6 +131,29 @@ describe("CommentThreadCard", () => {
       "question",
       "Updated question.",
     );
+  });
+
+  it("hides the answer composer while editing a thread comment", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onReply={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("Answer text")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit comment" }));
+
+    expect(screen.queryByLabelText("Answer text")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Send" }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not allow editing linked agent answers", () => {
@@ -175,7 +228,38 @@ describe("CommentThreadCard", () => {
     await user.type(input, "This is my answer.");
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(onReply).toHaveBeenCalledWith("root-comment", "This is my answer.");
+    expect(onReply).toHaveBeenCalledWith(
+      "root-comment",
+      "This is my answer.",
+      "answer",
+    );
+    expect(input).toHaveValue("");
+  });
+
+  it("submits a typed action from the thread composer", async () => {
+    const user = userEvent.setup();
+    const onReply = vi.fn();
+
+    render(
+      <CommentThreadCard
+        thread={makeQuestionThread().thread}
+        top={0}
+        onClose={vi.fn()}
+        onReply={onReply}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Action" }));
+    await user.click(screen.getByRole("button", { name: "remove" }));
+    const input = screen.getByLabelText("Answer text");
+    await user.type(input, "Delete BL-2.");
+    await user.click(screen.getByRole("button", { name: "Apply" }));
+
+    expect(onReply).toHaveBeenCalledWith(
+      "root-comment",
+      "Delete BL-2.",
+      "remove",
+    );
     expect(input).toHaveValue("");
   });
 

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.tsx
@@ -17,6 +17,23 @@ const EDITABLE_COMMENT_TYPES: CommentType[] = [
 ];
 
 const EDITABLE_CRITIC_TYPES: Comment["criticType"][] = ["comment", "highlight"];
+const ACTION_REPLY_TYPES: CommentType[] = [
+  "fix",
+  "rewrite",
+  "expand",
+  "clarify",
+  "remove",
+];
+
+type ThreadComposerMode = "reply" | "action";
+
+function getThreadAuthorKind(comment: Comment): "mine" | "external" | "none" {
+  if (!comment.thread?.replyTo) {
+    return "none";
+  }
+
+  return comment.thread?.authorLabel === "You" ? "mine" : "external";
+}
 
 function CommentBody({ comment }: { comment: Comment }) {
   if (comment.criticType === "addition") {
@@ -154,14 +171,23 @@ function CommentRow({
   const editable =
     canEditComment(comment) &&
     EDITABLE_CRITIC_TYPES.includes(comment.criticType);
-  const authorLabel =
-    comment.type === "answer" ? (comment.thread?.authorLabel ?? "Agent") : null;
+  const authorLabel = comment.thread?.replyTo
+    ? (comment.thread.authorLabel ??
+      (comment.type === "answer" ? "Agent" : null))
+    : null;
+  const authorKind = getThreadAuthorKind(comment);
   const deletingThreadRoot = !!comment.thread && !comment.thread.replyTo;
+  const itemClasses = [
+    "comment-thread-card__item",
+    reply ? "comment-thread-card__item--reply" : "",
+    authorKind === "mine" ? "comment-thread-card__item--mine" : "",
+    authorKind === "external" ? "comment-thread-card__item--external" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <div
-      className={`comment-thread-card__item${reply ? " comment-thread-card__item--reply" : ""}`}
-    >
+    <div className={itemClasses}>
       <div className="comment-thread-card__item-header">
         <div className="comment-thread-card__meta">
           <span
@@ -171,7 +197,11 @@ function CommentRow({
             {comment.type}
           </span>
           {authorLabel && (
-            <span className="comment-thread-card__author">{authorLabel}</span>
+            <span
+              className={`comment-thread-card__author comment-thread-card__author--${authorKind}`}
+            >
+              {authorLabel}
+            </span>
           )}
         </div>
         <div className="comment-thread-card__actions">
@@ -242,7 +272,7 @@ interface Props {
   onClose: () => void;
   onEdit?: (id: string, type: CommentType, text: string) => void;
   onDelete?: (id: string) => void;
-  onReply?: (rootCommentId: string, text: string) => void;
+  onReply?: (rootCommentId: string, text: string, type: CommentType) => void;
 }
 
 export function CommentThreadCard({
@@ -260,9 +290,15 @@ export function CommentThreadCard({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [replyText, setReplyText] = useState("");
+  const [replyMode, setReplyMode] = useState<ThreadComposerMode>("reply");
+  const [actionType, setActionType] = useState<CommentType>("remove");
   const comments = [thread.root, ...thread.replies];
+  const hasActiveInlineAction = editingId !== null || confirmingId !== null;
   const canReplyToThread =
-    thread.root.type === "question" && !!thread.root.thread && !!onReply;
+    thread.root.type === "question" &&
+    !!thread.root.thread &&
+    !!onReply &&
+    !hasActiveInlineAction;
   const cardStyle: CSSProperties = dragPosition
     ? {
         position: "fixed",
@@ -278,7 +314,11 @@ export function CommentThreadCard({
     if (!trimmedText || !onReply) {
       return;
     }
-    onReply(thread.root.id, trimmedText);
+    onReply(
+      thread.root.id,
+      trimmedText,
+      replyMode === "action" ? actionType : "answer",
+    );
     setReplyText("");
   }
 
@@ -347,10 +387,56 @@ export function CommentThreadCard({
           className="comment-thread-card__reply-form"
           onSubmit={handleReplySubmit}
         >
+          <div className="comment-thread-card__reply-toolbar">
+            <div
+              className="comment-thread-card__reply-mode"
+              aria-label="Thread response mode"
+            >
+              <button
+                type="button"
+                className={`comment-thread-card__reply-mode-button${replyMode === "reply" ? " comment-thread-card__reply-mode-button--active" : ""}`}
+                aria-pressed={replyMode === "reply"}
+                onClick={() => setReplyMode("reply")}
+              >
+                Reply
+              </button>
+              <button
+                type="button"
+                className={`comment-thread-card__reply-mode-button${replyMode === "action" ? " comment-thread-card__reply-mode-button--active" : ""}`}
+                aria-pressed={replyMode === "action"}
+                onClick={() => setReplyMode("action")}
+              >
+                Action
+              </button>
+            </div>
+            {replyMode === "action" && (
+              <div
+                className="comment-thread-card__action-types"
+                aria-label="Action type"
+              >
+                {ACTION_REPLY_TYPES.map((commentType) => (
+                  <button
+                    key={commentType}
+                    type="button"
+                    className={`comment-thread-card__action-type${actionType === commentType ? " comment-thread-card__action-type--active" : ""}`}
+                    data-comment-type={commentType}
+                    aria-pressed={actionType === commentType}
+                    onClick={() => setActionType(commentType)}
+                  >
+                    {commentType}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
           <textarea
             className="comment-thread-card__reply-input"
             aria-label="Answer text"
-            placeholder="Write an answer..."
+            placeholder={
+              replyMode === "action"
+                ? "Tell agent what to change..."
+                : "Write an answer..."
+            }
             rows={2}
             value={replyText}
             onChange={(event) => setReplyText(event.target.value)}
@@ -360,7 +446,7 @@ export function CommentThreadCard({
             className="comment-thread-card__reply-send"
             disabled={!replyText.trim()}
           >
-            Send
+            {replyMode === "action" ? "Apply" : "Send"}
           </button>
         </form>
       )}

--- a/src/utils/commentPermissions.ts
+++ b/src/utils/commentPermissions.ts
@@ -1,7 +1,10 @@
 import type { Comment } from "../types/criticmarkup";
 
 export function isAgentAuthoredComment(comment: Comment): boolean {
-  return comment.type === "answer" || Boolean(comment.thread?.authorLabel);
+  return (
+    (comment.type === "answer" && comment.thread?.authorLabel !== "You") ||
+    Boolean(comment.thread?.authorLabel && comment.thread.authorLabel !== "You")
+  );
 }
 
 export function canEditComment(comment: Comment): boolean {


### PR DESCRIPTION
﻿## Summary
- Hide the answer composer while a thread comment is being edited or delete-confirmed
- Align the thread-card edit form controls so the type selector, textarea, and buttons size consistently
- Separate comment-margin hover add icons from existing comment markers so the controls do not overlap
- Make question/answer badges smaller and visually distinguish user-authored answers from external/agent answers
- Add a compact Reply/Action mode to thread replies; action replies write typed CriticMarkup instructions such as `remove:` instead of `answer:`
- Teach agent prompts to apply threaded action replies directly, remove the resolved thread, and avoid posting confirmation answers
- Document the one-active-input, separate-margin-lane, answer ownership, and threaded action behavior

## Validation
- npm test -- src/markup/insertComment.test.ts src/modules/host-review/test/hostReviewActions.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
- npm run typecheck
- npx eslint src/utils/commentPermissions.ts src/markup/insertComment.ts src/markup/agentPrompt.ts src/modules/host-review/types.ts src/modules/host-review/controller.ts src/modules/agent-workflow/controller.ts src/ui/components/CommentThreadCard/CommentThreadCard.tsx src/ui/components/CommentMargin/CommentMargin.tsx src/markup/insertComment.test.ts src/modules/host-review/test/hostReviewActions.test.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx --quiet
- npx prettier --check docs/features/criticmarkup-comments.md src/utils/commentPermissions.ts src/markup/insertComment.ts src/markup/agentPrompt.ts src/markup/insertComment.test.ts src/modules/host-review/types.ts src/modules/host-review/controller.ts src/modules/host-review/test/hostReviewActions.test.ts src/modules/agent-workflow/controller.ts src/modules/agent-workflow/test/agentWorkflowController.test.ts src/ui/components/CommentThreadCard/CommentThreadCard.tsx src/ui/components/CommentThreadCard/CommentThreadCard.css src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx src/ui/components/CommentMargin/CommentMargin.tsx
- git diff --check
