### PR TITLE
Fix review prompts and nested thread replies

### DIFF
--- a/docs/design/desktop-runtime-agent-architecture.md
+++ b/docs/design/desktop-runtime-agent-architecture.md
@@ -335,9 +335,12 @@ serializable run metadata and controller actions for active-file unresolved
 comments, folder-level unresolved comments, active-file threaded questions, and
 pending peer comments selected from a host share. Active-file actions build an
 `AgentRunRequest` with one tab, one target path, selected comment ids, and a
-generated prompt. Folder address-comments and pending-peer-comment actions use
-the same tab-scoped run model with a sorted, bounded set of up to five files and
-twenty-five relevant comments from the active tab. The web runtime still reports
+generated prompt. Active-file and folder prompts rely on the MarkReview comments
+already embedded in the markdown instead of duplicating their bodies. Folder
+address-comments actions use a sorted, bounded set of up to five files and all
+actionable comments and question threads in those files. Pending-peer-comment
+actions remain bounded to five files and twenty-five comments because those
+details may not yet exist in the markdown. The web runtime still reports
 `canRunAgent: false`, so the website keeps copy-prompt paths until a desktop
 runtime provides an executable `AgentRuntime`.
 The generated prompt is also stored on the serializable run record so the active
@@ -354,8 +357,8 @@ active file or folder. In the web runtime it copies a scoped review prompt that
 addresses unresolved MarkReview comments and answers question threads as needed.
 When a desktop runtime reports local agent execution, the same surface calls the
 address-comments controller action, which now carries question-thread ids in the
-generated prompt. The lower-level question-thread controller remains available
-for direct workflow use.
+run metadata without duplicating them in the generated prompt. The lower-level
+question-thread controller remains available for direct workflow use.
 
 Desktop shell implementation note: `src-tauri/` now contains the first Tauri v2
 native shell. It loads the existing Vite app in a native window and adds

--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -102,7 +102,11 @@ MarkReview extends the plain comment protocol for threaded review questions.
 - Agents reply with a separate inline `answer:` CriticMarkup comment near the same text block.
 - Users can also reply directly from the thread card; MarkReview writes the same linked `answer:` CriticMarkup reply with `author="You"`.
 - Users can switch the thread composer from `Reply` to `Action` and choose a compact action type (`fix`, `rewrite`, `expand`, `clarify`, or `remove`). MarkReview writes that action as a linked threaded CriticMarkup comment with `author="You"` instead of `answer:`.
-- The reply reuses the root `thread` value and sets `replyTo` to the root question `id`.
+- Every reply reuses the root `thread` value. Its `replyTo` can reference the
+  root question `id` or an earlier reply `id` when answering a follow-up.
+- The UI resolves reply ancestry within the same thread and renders every valid
+  descendant in document order. Broken, mismatched, or cyclic reply chains stay
+  visible as standalone comments instead of disappearing.
 - The reply can also include `author` so the UI can show `Codex`, `Cursor`, or a generic `Agent` label.
 - The Comments panel keeps replies collapsed under the root question and marks the root as `answered` once an `answer:` reply exists.
 - Agent-authored replies render as read-only comments in the UI. User-authored replies can be edited or deleted.

--- a/docs/features/desktop-agent-client.md
+++ b/docs/features/desktop-agent-client.md
@@ -210,12 +210,14 @@ Folder action:
 - active tab only
 - selected folder or workspace only
 - bounded list of files containing actionable comments
-- maximum five files and twenty-five comments per run in the first
-  implementation
+- maximum five files per run in the first implementation
+- all actionable comments and question threads in each selected file
 - no context from other open tabs
 
-The generated prompt should state the target path, task, included comments, and
-out-of-scope files.
+The generated prompt should state the target path, task, and out-of-scope files.
+It should not duplicate active-file or folder comment bodies because those
+comments are already embedded in the markdown. Pending peer comment prompts must
+still include comment details when they are not yet present in the markdown.
 
 ## Desktop Agent Actions For V1
 

--- a/src/markup/agentPrompt.ts
+++ b/src/markup/agentPrompt.ts
@@ -1,19 +1,9 @@
-interface AddressCommentsPromptComment {
-  id: string;
-  type: string;
-  text: string;
-}
-
 interface AddressCommentsPromptInput {
   targetPath: string;
-  comments: AddressCommentsPromptComment[];
-  questionThreadIds?: string[];
 }
 
 interface FolderAddressCommentsPromptTarget {
   filePath: string;
-  comments: AddressCommentsPromptComment[];
-  questionThreadIds?: string[];
 }
 
 interface FolderAddressCommentsPromptInput {
@@ -46,7 +36,7 @@ function buildQuestionReplyRules(): string {
 - Reply with a separate inline CriticMarkup comment near the same text block.
 - Use the \`answer:\` prefix in every reply.
 - Keep the question's existing \`thread\` value.
-- Set \`replyTo\` to the question's \`id\`.
+- Set \`replyTo\` to the \`id\` of the question or follow-up message you are answering.
 - Give your reply its own unique \`id\`.
 - Add your agent name in \`author\` (for example \`Codex\` or \`Cursor\`).
 - Keep answers concise, specific, and grounded in the referenced text.`;
@@ -59,24 +49,6 @@ function buildThreadActionRules(): string {
 - Apply the requested edit directly in the markdown.
 - After applying the edit, remove the resolved thread from the file, including the root \`question:\`, prior \`answer:\` replies, and the action comment.
 - Do not add a new \`answer:\` or confirmation comment for completed actions.`;
-}
-
-function buildCommentList(comments: AddressCommentsPromptComment[]): string {
-  if (comments.length === 0) {
-    return "- None listed.";
-  }
-
-  return comments
-    .map((comment) => `- ${comment.id} (${comment.type}): ${comment.text}`)
-    .join("\n");
-}
-
-function buildQuestionThreadList(questionThreadIds: string[]): string {
-  if (questionThreadIds.length === 0) {
-    return "- Answer any MarkReview question threads you find as needed.";
-  }
-
-  return questionThreadIds.map((commentId) => `- ${commentId}`).join("\n");
 }
 
 export function buildAgentReplyPrompt(): string {
@@ -94,19 +66,12 @@ Example answer:
 export function buildAddressCommentsAgentPrompt(
   input: AddressCommentsPromptInput,
 ): string {
-  const commentList = buildCommentList(input.comments);
-  const questionThreadList = buildQuestionThreadList(
-    input.questionThreadIds ?? [],
-  );
-
   return `Review ${input.targetPath} and update it directly.
 
 Scope:
 - Work only in ${input.targetPath}.
-- Address these unresolved MarkReview comments:
-${commentList}
-- Answer these MarkReview question threads as needed:
-${questionThreadList}
+- Address all unresolved MarkReview comments in this file.
+- Answer its MarkReview question threads as needed.
 - Apply the requested edits directly in the markdown.
 - Remove each addressed MarkReview comment once its requested change is applied.
 - Do not remove question comments when answering them.
@@ -121,36 +86,17 @@ export function buildFolderAddressCommentsAgentPrompt(
   input: FolderAddressCommentsPromptInput,
 ): string {
   const targetList = input.targets
-    .map((target) => {
-      const commentList = target.comments
-        .map(
-          (comment) => `  - ${comment.id} (${comment.type}): ${comment.text}`,
-        )
-        .join("\n");
-      const questionThreadList = (target.questionThreadIds ?? [])
-        .map((commentId) => `  - ${commentId}`)
-        .join("\n");
-      const sections = [`- ${target.filePath}`];
-      if (commentList) {
-        sections.push("  Comments:", commentList);
-      }
-      if (questionThreadList) {
-        sections.push("  Question threads:", questionThreadList);
-      }
-      if (!commentList && !questionThreadList) {
-        sections.push("  - Review this file for any MarkReview threads.");
-      }
-      return sections.join("\n");
-    })
+    .map((target) => `- ${target.filePath}`)
     .join("\n");
 
   return `Review these markdown files and update them directly.
 
 Scope:
 - Work only in the listed markdown files.
-- Address the listed unresolved MarkReview comments.
-- Answer the listed MarkReview question threads as needed.
+- Review these files:
 ${targetList}
+- Address all unresolved MarkReview comments in those files.
+- Answer their MarkReview question threads as needed.
 - Apply the requested edits directly in the markdown files.
 - Remove each addressed MarkReview comment once its requested change is applied.
 - Do not remove question comments when answering them.

--- a/src/markup/commentProtocol.test.ts
+++ b/src/markup/commentProtocol.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { extractComments } from "./criticmarkup";
+import { buildCommentThreadGroups } from "./commentProtocol";
+
+describe("buildCommentThreadGroups", () => {
+  it("includes replies to earlier replies in the root thread", () => {
+    const comments = extractComments(
+      [
+        '{>>question: What is this and why is it needed? [markreview id="mr-question" thread="mr-question"]<<}',
+        '{>>answer: It validates the selected asset. [markreview id="mr-agent-1" thread="mr-question" replyTo="mr-question" author="Claude"]<<}',
+        '{>>answer: How does that apply when nothing is generated? [markreview id="mr-user" thread="mr-question" replyTo="mr-question" author="You"]<<}',
+        '{>>answer: It guards the selected reference rather than generated output. [markreview id="mr-agent-2" thread="mr-question" replyTo="mr-user" author="Claude"]<<}',
+      ].join(""),
+    );
+
+    const groups = buildCommentThreadGroups(comments);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.root.text).toBe("What is this and why is it needed?");
+    expect(groups[0]?.replies.map((reply) => reply.text)).toEqual([
+      "It validates the selected asset.",
+      "How does that apply when nothing is generated?",
+      "It guards the selected reference rather than generated output.",
+    ]);
+  });
+
+  it("keeps a reply with a mismatched thread visible as a standalone group", () => {
+    const comments = extractComments(
+      [
+        '{>>question: Why? [markreview id="mr-question" thread="mr-question"]<<}',
+        '{>>answer: Because. [markreview id="mr-answer" thread="mr-other" replyTo="mr-question" author="Claude"]<<}',
+      ].join(""),
+    );
+
+    const groups = buildCommentThreadGroups(comments);
+
+    expect(groups.map((group) => group.root.text)).toEqual([
+      "Why?",
+      "Because.",
+    ]);
+  });
+
+  it("keeps cyclic replies visible as standalone groups", () => {
+    const comments = extractComments(
+      [
+        '{>>answer: First. [markreview id="mr-first" thread="mr-thread" replyTo="mr-second" author="Claude"]<<}',
+        '{>>answer: Second. [markreview id="mr-second" thread="mr-thread" replyTo="mr-first" author="You"]<<}',
+      ].join(""),
+    );
+
+    const groups = buildCommentThreadGroups(comments);
+
+    expect(groups.map((group) => group.root.text)).toEqual([
+      "First.",
+      "Second.",
+    ]);
+  });
+});

--- a/src/markup/commentProtocol.ts
+++ b/src/markup/commentProtocol.ts
@@ -182,46 +182,72 @@ export interface CommentThreadGroup {
   replies: Comment[];
 }
 
+function findThreadRoot(
+  comment: Comment,
+  commentsByThreadCommentId: Map<string, Comment>,
+): Comment | null {
+  if (!isThreadReply(comment)) {
+    return comment;
+  }
+
+  const threadId = comment.thread?.threadId;
+  const commentId = comment.thread?.commentId;
+  if (!threadId || !commentId) {
+    return null;
+  }
+
+  const visitedCommentIds = new Set<string>([commentId]);
+  let currentComment = comment;
+
+  while (currentComment.thread?.replyTo) {
+    const parentCommentId = currentComment.thread.replyTo;
+    if (visitedCommentIds.has(parentCommentId)) {
+      return null;
+    }
+
+    const parentComment = commentsByThreadCommentId.get(parentCommentId);
+    if (!parentComment || parentComment.thread?.threadId !== threadId) {
+      return null;
+    }
+
+    visitedCommentIds.add(parentCommentId);
+    currentComment = parentComment;
+  }
+
+  return currentComment;
+}
+
 export function buildCommentThreadGroups(
   comments: Comment[],
 ): CommentThreadGroup[] {
   const commentsByThreadCommentId = new Map<string, Comment>();
-  const repliesByRootCommentId = new Map<string, Comment[]>();
 
   for (const comment of comments) {
     if (comment.thread?.commentId) {
       commentsByThreadCommentId.set(comment.thread.commentId, comment);
     }
-    if (comment.thread?.replyTo) {
-      const replies = repliesByRootCommentId.get(comment.thread.replyTo) ?? [];
-      replies.push(comment);
-      repliesByRootCommentId.set(comment.thread.replyTo, replies);
-    }
   }
 
   const groups: CommentThreadGroup[] = [];
+  const groupsByRoot = new Map<Comment, CommentThreadGroup>();
   for (const comment of comments) {
-    if (isThreadReply(comment)) {
-      const rootComment = commentsByThreadCommentId.get(
-        comment.thread?.replyTo ?? "",
-      );
-      if (
-        rootComment &&
-        rootComment.thread?.threadId === comment.thread?.threadId
-      ) {
-        continue;
-      }
-      groups.push({ root: comment, replies: [] });
+    const rootComment = findThreadRoot(comment, commentsByThreadCommentId);
+    if (rootComment && rootComment !== comment) {
       continue;
     }
 
-    const replies =
-      repliesByRootCommentId
-        .get(comment.thread?.commentId ?? "")
-        ?.filter(
-          (reply) => reply.thread?.threadId === comment.thread?.threadId,
-        ) ?? [];
-    groups.push({ root: comment, replies });
+    const group: CommentThreadGroup = { root: comment, replies: [] };
+    groups.push(group);
+    groupsByRoot.set(comment, group);
+  }
+
+  for (const comment of comments) {
+    const rootComment = findThreadRoot(comment, commentsByThreadCommentId);
+    if (!rootComment || rootComment === comment) {
+      continue;
+    }
+
+    groupsByRoot.get(rootComment)?.replies.push(comment);
   }
 
   return groups;

--- a/src/modules/agent-workflow/README.md
+++ b/src/modules/agent-workflow/README.md
@@ -37,8 +37,9 @@ narrow agent run request.
 - Web runtime support can expose the same metadata while reporting that local
   execution is unavailable.
 - Executable actions are scoped to the active tab.
-- Folder-level executable actions use a bounded set of scanned comments from the
-  active folder tab.
+- Folder-level executable actions use up to five scanned files from the active
+  folder tab and include all actionable comments and question threads in those
+  files.
 - Pending peer-comment executable actions use a bounded set of comments from the
   selected share on the active host tab.
 

--- a/src/modules/agent-workflow/controller.ts
+++ b/src/modules/agent-workflow/controller.ts
@@ -112,7 +112,6 @@ const SYNCABLE_AGENT_RUN_STATUSES = new Set<AgentRunStatus>([
 ]);
 const MAX_ACTIVE_AGENT_RUNS = 3;
 const MAX_FOLDER_AGENT_TARGET_FILES = 5;
-const MAX_FOLDER_AGENT_COMMENTS = 25;
 const MAX_PEER_AGENT_TARGET_FILES = 5;
 const MAX_PEER_AGENT_COMMENTS = 25;
 const ADDRESSABLE_COMMENT_TYPES = new Set<Comment["type"]>([
@@ -178,7 +177,6 @@ export function getFolderAddressableCommentTargets(
   entries: FileCommentEntry[],
 ): FolderAddressableCommentTarget[] {
   const targets: FolderAddressableCommentTarget[] = [];
-  let selectedCommentCount = 0;
 
   const sortedEntries = [...entries].sort((entryA, entryB) =>
     entryA.filePath.localeCompare(entryB.filePath),
@@ -188,16 +186,7 @@ export function getFolderAddressableCommentTargets(
     if (targets.length >= MAX_FOLDER_AGENT_TARGET_FILES) {
       break;
     }
-    if (selectedCommentCount >= MAX_FOLDER_AGENT_COMMENTS) {
-      break;
-    }
-
-    const remainingCommentCount =
-      MAX_FOLDER_AGENT_COMMENTS - selectedCommentCount;
-    const comments = getAddressableCommentTargets(entry.comments).slice(
-      0,
-      remainingCommentCount,
-    );
+    const comments = getAddressableCommentTargets(entry.comments);
     if (comments.length === 0) {
       continue;
     }
@@ -206,7 +195,6 @@ export function getFolderAddressableCommentTargets(
       filePath: entry.filePath,
       comments,
     });
-    selectedCommentCount += comments.length;
   }
 
   return targets;
@@ -216,7 +204,6 @@ export function getFolderReviewCommentTargets(
   entries: FileCommentEntry[],
 ): FolderReviewCommentTarget[] {
   const targets: FolderReviewCommentTarget[] = [];
-  let selectedCommentCount = 0;
 
   const sortedEntries = [...entries].sort((entryA, entryB) =>
     entryA.filePath.localeCompare(entryB.filePath),
@@ -226,21 +213,8 @@ export function getFolderReviewCommentTargets(
     if (targets.length >= MAX_FOLDER_AGENT_TARGET_FILES) {
       break;
     }
-    if (selectedCommentCount >= MAX_FOLDER_AGENT_COMMENTS) {
-      break;
-    }
-
-    const remainingCommentCount =
-      MAX_FOLDER_AGENT_COMMENTS - selectedCommentCount;
-    const comments = getAddressableCommentTargets(entry.comments).slice(
-      0,
-      remainingCommentCount,
-    );
-    const remainingQuestionCount = remainingCommentCount - comments.length;
-    const questionThreadIds = getQuestionThreadCommentIds(entry.comments).slice(
-      0,
-      Math.max(0, remainingQuestionCount),
-    );
+    const comments = getAddressableCommentTargets(entry.comments);
+    const questionThreadIds = getQuestionThreadCommentIds(entry.comments);
     const targetCommentCount = comments.length + questionThreadIds.length;
     if (targetCommentCount === 0) {
       continue;
@@ -251,7 +225,6 @@ export function getFolderReviewCommentTargets(
       comments,
       questionThreadIds,
     });
-    selectedCommentCount += targetCommentCount;
   }
 
   return targets;
@@ -383,8 +356,6 @@ export function buildAddressCommentsAgentRunRequest(
     workspaceRootPath: context.workspaceRootPath,
     prompt: buildAddressCommentsAgentPrompt({
       targetPath: context.targetPath,
-      comments: context.comments,
-      questionThreadIds: context.questionThreadIds,
     }),
   };
 }

--- a/src/modules/agent-workflow/test/agentWorkflowController.test.ts
+++ b/src/modules/agent-workflow/test/agentWorkflowController.test.ts
@@ -105,7 +105,7 @@ describe("address comments agent run context", () => {
           text: "Rewrite this paragraph",
         },
       ],
-      questionThreadIds: ["mr-question-1"],
+      questionThreadIds: ["mr-question-custom"],
       workspaceRootPath: "/tmp/project",
     });
 
@@ -113,26 +113,24 @@ describe("address comments agent run context", () => {
       tabId: "tab-1",
       taskKind: "address_comments",
       targetPaths: ["docs/spec.md"],
-      selectedCommentIds: ["comment-1", "comment-2", "mr-question-1"],
+      selectedCommentIds: ["comment-1", "comment-2", "mr-question-custom"],
       runnerKind: "terminal",
       workspaceRootPath: "/tmp/project",
     });
     expect(request.prompt).toContain("Work only in docs/spec.md");
-    expect(request.prompt).toContain("- comment-1 (fix): Fix the intro");
-    expect(request.prompt).toContain(
-      "- comment-2 (rewrite): Rewrite this paragraph",
-    );
-    expect(request.prompt).toContain(
-      "Answer these MarkReview question threads",
-    );
-    expect(request.prompt).toContain("- mr-question-1");
+    expect(request.prompt).not.toContain("comment-1");
+    expect(request.prompt).not.toContain("Fix the intro");
+    expect(request.prompt).not.toContain("comment-2");
+    expect(request.prompt).not.toContain("Rewrite this paragraph");
+    expect(request.prompt).not.toContain("mr-question-custom");
+    expect(request.prompt).toContain("Answer its MarkReview question threads");
     expect(request.prompt).toContain("Thread action replies");
     expect(request.prompt).toContain(
       "Do not add a new `answer:` or confirmation comment",
     );
   });
 
-  it("selects a bounded set of folder comment targets", () => {
+  it("selects a bounded set of folder target files", () => {
     const entries = Array.from({ length: 6 }, (_, index) => {
       const fileIndex = index + 1;
       return {
@@ -174,6 +172,39 @@ describe("address comments agent run context", () => {
         text: "Fix file 1",
       },
     ]);
+  });
+
+  it("keeps all review targets in each selected folder file", () => {
+    const comments = Array.from({ length: 30 }, (_unusedValue, index) =>
+      makeComment({
+        id: `fix-${index + 1}`,
+        type: "fix",
+        text: `Fix item ${index + 1}`,
+      }),
+    );
+    comments.push(
+      makeComment({
+        id: "question-root",
+        type: "question",
+        text: "Why?",
+        thread: {
+          commentId: "mr-question-custom",
+          threadId: "mr-question-custom",
+        },
+      }),
+    );
+
+    const targets = getFolderReviewCommentTargets([
+      {
+        filePath: "docs/spec.md",
+        fileName: "spec.md",
+        comments,
+      },
+    ]);
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]?.comments).toHaveLength(30);
+    expect(targets[0]?.questionThreadIds).toEqual(["mr-question-custom"]);
   });
 
   it("selects folder review targets with question threads", () => {
@@ -248,10 +279,12 @@ describe("address comments agent run context", () => {
     });
     expect(request.prompt).toContain("Work only in the listed markdown files");
     expect(request.prompt).toContain("- docs/a.md");
-    expect(request.prompt).toContain("  - fix-a (fix): Fix A");
-    expect(request.prompt).toContain("  - mr-question-a");
     expect(request.prompt).toContain("- docs/b.md");
-    expect(request.prompt).toContain("  - note-b (note): Check B");
+    expect(request.prompt).not.toContain("fix-a");
+    expect(request.prompt).not.toContain("Fix A");
+    expect(request.prompt).not.toContain("mr-question-a");
+    expect(request.prompt).not.toContain("note-b");
+    expect(request.prompt).not.toContain("Check B");
   });
 });
 
@@ -634,7 +667,7 @@ describe("address comments agent run controller", () => {
       selectedCommentIds: ["mr-question-1"],
     });
     expect(requests[0]?.prompt).toContain(
-      "Answer these MarkReview question threads",
+      "Answer its MarkReview question threads",
     );
     expect(showToastMessages).toEqual(["Agent run started"]);
   });
@@ -699,7 +732,8 @@ describe("address comments agent run controller", () => {
       workspaceRootPath: "/tmp/project",
     });
     expect(requests[0]?.prompt).toContain("- docs/spec.md");
-    expect(requests[0]?.prompt).toContain("  - fix-root (fix): Fix the intro");
+    expect(requests[0]?.prompt).not.toContain("fix-root");
+    expect(requests[0]?.prompt).not.toContain("Fix the intro");
   });
 });
 

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -464,8 +464,6 @@ export function Header({
         })
       : buildAddressCommentsAgentPrompt({
           targetPath,
-          comments: addressableCommentTargets,
-          questionThreadIds,
         });
     try {
       await navigator.clipboard.writeText(prompt);

--- a/src/ui/components/Header/HeaderShare.test.tsx
+++ b/src/ui/components/Header/HeaderShare.test.tsx
@@ -154,8 +154,8 @@ describe("Header review actions", () => {
           type: "question",
           text: "Why is this here?",
           thread: {
-            commentId: "mr-question-1",
-            threadId: "mr-question-1",
+            commentId: "mr-question-custom",
+            threadId: "mr-question-custom",
           },
         }),
       ],
@@ -170,8 +170,9 @@ describe("Header review actions", () => {
     const prompt = writeText.mock.calls[0]?.[0];
     expect(prompt).toContain("Review docs/spec.md");
     expect(prompt).toContain("Work only in docs/spec.md");
-    expect(prompt).toContain("- fix-root (fix): Fix the intro");
-    expect(prompt).toContain("- mr-question-1");
+    expect(prompt).not.toContain("fix-root");
+    expect(prompt).not.toContain("Fix the intro");
+    expect(prompt).not.toContain("mr-question-custom");
     expect(prompt).toContain("Question thread replies");
     expect(
       screen.queryByRole("button", { name: "Copy answer prompt" }),
@@ -192,8 +193,8 @@ describe("Header review actions", () => {
           type: "question",
           text: "Why is this here?",
           thread: {
-            commentId: "mr-question-1",
-            threadId: "mr-question-1",
+            commentId: "mr-question-custom",
+            threadId: "mr-question-custom",
           },
         }),
       ],
@@ -207,7 +208,7 @@ describe("Header review actions", () => {
     expect(writeText).toHaveBeenCalledOnce();
     const prompt = writeText.mock.calls[0]?.[0];
     expect(prompt).toContain("Review spec.md");
-    expect(prompt).toContain("Answer these MarkReview question threads");
-    expect(prompt).toContain("- mr-question-1");
+    expect(prompt).toContain("Answer its MarkReview question threads");
+    expect(prompt).not.toContain("mr-question-custom");
   });
 });


### PR DESCRIPTION
## Summary
- stop duplicating inline MarkReview comment bodies and ids in active-file and folder review prompts
- keep folder review scope bounded to five files while including all review targets in those files
- resolve reply ancestry so agent answers to follow-up replies remain visible in the root thread
- preserve malformed reply chains as standalone comments and document both behaviors

## Validation
- npm test (555 tests passed)
- npm run typecheck
- targeted ESLint on all changed source and test files

## Known baseline issue
- npm run lint still reports the existing worker/src/index.ts:129 no-unsafe-return error outside this change