### PR TITLE
Show share scope selector only when a folder is open

### DIFF
--- a/src/ui/components/ShareDialog/ShareDialog.test.tsx
+++ b/src/ui/components/ShareDialog/ShareDialog.test.tsx
@@ -30,8 +30,22 @@ describe("ShareDialog - initial render", () => {
     setTestState({ directoryName: "my-project", fileName: "index.md" });
     render(<ShareDialog onClose={vi.fn()} />);
     expect(
+      screen.getByRole("button", { name: /This file/ }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: /Whole folder · 0 files/ }),
     ).toBeInTheDocument();
+  });
+
+  it("hides the file/folder scope selector when only a file is open", () => {
+    setTestState({ directoryName: null, fileName: "readme.md" });
+    render(<ShareDialog onClose={vi.fn()} />);
+    expect(
+      screen.queryByRole("button", { name: /This file/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Whole folder/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows 7 days as the default expiry tab", () => {

--- a/src/ui/components/ShareDialog/ShareDialog.tsx
+++ b/src/ui/components/ShareDialog/ShareDialog.tsx
@@ -96,7 +96,11 @@ export function ShareDialog({ onClose, scope }: Props) {
     ? buildShareUrlFromOrigin({ keyB64: preparedIdentity.keyB64, name: label })
     : null;
   const link = uploadedLink ?? preparedLink;
-  const canChooseScope = selectedScope?.kind !== "nodes" && Boolean(tab);
+  // The file/folder selector only makes sense when a folder is open — a
+  // single-file workspace has nothing to toggle to.
+  const isFolderOpen = Boolean(tab?.directoryName);
+  const canChooseScope =
+    selectedScope?.kind !== "nodes" && Boolean(tab) && isFolderOpen;
   const folderFileCount = countFiles(tab?.fileTree ?? []);
 
   useEffect(() => {


### PR DESCRIPTION
## What

The file/folder scope segmented control in the Share dialog now renders only when a folder is open.

## Why

A single-file workspace showed the segmented control with just a lone **This file** button and nothing to toggle to — the "Whole folder" option is (correctly) gated on an open folder, leaving a pointless one-option control. The selector only makes sense when there are two real choices.

## Change

- `canChooseScope` now also requires `tab?.directoryName` (an open folder). Single-file shares proceed with the file scope and no redundant control; folder workspaces keep both **This file** and **Whole folder · N files**.

## Verification

- ShareDialog + App test suites pass (45 tests), including a new test asserting the selector is hidden in single-file mode and the folder test extended to confirm both buttons show
- Typecheck (app + worker) clean, architecture validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)