### PR TITLE
fix: suppress mermaid's built-in error graphic on parse failure

### DIFF
--- a/src/ui/components/MermaidBlock/MermaidBlock.test.tsx
+++ b/src/ui/components/MermaidBlock/MermaidBlock.test.tsx
@@ -31,6 +31,25 @@ describe("MermaidBlock", () => {
     vi.clearAllMocks();
   });
 
+  // Keep this first: loadMermaid() memoizes, so initialize() only runs on the
+  // first render in this module. Suppressing mermaid's built-in error graphic
+  // stops the default "Syntax error" bomb SVG from being orphaned in <body> on
+  // a parse failure — the block shows its own source + error message instead.
+  it("initializes mermaid with its built-in error graphic suppressed", async () => {
+    vi.mocked(mermaid.render).mockResolvedValue({
+      svg: "<svg></svg>",
+      bindFunctions: undefined,
+    });
+
+    render(<MermaidBlock code="graph TD; A-->B" />);
+
+    await waitFor(() => {
+      expect(mermaid.initialize).toHaveBeenCalledWith(
+        expect.objectContaining({ suppressErrorRendering: true }),
+      );
+    });
+  });
+
   it("renders the SVG returned by mermaid", async () => {
     vi.mocked(mermaid.render).mockResolvedValue({
       svg: '<svg data-testid="diagram"></svg>',

--- a/src/ui/components/MermaidBlock/MermaidBlock.tsx
+++ b/src/ui/components/MermaidBlock/MermaidBlock.tsx
@@ -28,6 +28,7 @@ function loadMermaid(): Promise<MermaidApi> {
         module.default.initialize({
           startOnLoad: false,
           securityLevel: "strict",
+          suppressErrorRendering: true,
           flowchart: { htmlLabels: false },
         });
         return module.default;


### PR DESCRIPTION
## Problem

Failed mermaid diagrams render a **default mermaid "Syntax error" bomb graphic** ("Syntax error in text / mermaid version 11.12.3") orphaned at the bottom of the page — not the app's intended error UI.

## Root cause

`MermaidBlock` calls `mermaid.render(id, code)` with **no container element**, so mermaid appends its temporary render node straight to `document.body` (`mermaid.core.mjs` → `root = select("body")`).

On a parse failure, mermaid draws its bomb error diagram into that temp node and then re-throws the parse exception **before** it reaches `removeTempElements()`. Cleanup never runs, so every failed diagram leaves one bomb permanently stuck at the bottom of `<body>`.

The block already has proper inline error handling — the `catch` flips to the **source view + a red "Mermaid error: …" message**. The bombs were just mermaid's leftover garbage layered on top of it.

## Fix

Add `suppressErrorRendering: true` to the mermaid `initialize()` config. On the error path this makes mermaid call `removeTempElements()` and throw cleanly — no bomb, no orphan — and the block's own error UI still fires as designed.

Confirmed valid for this version (`config.type.d.ts` declares `suppressErrorRendering?: boolean`, added in v11).

## Tests

- Added a regression test asserting mermaid is initialized with `suppressErrorRendering: true`.
- Full MermaidBlock suite passes (15/15); typecheck clean.

> Note: this suite fully mocks mermaid, so the test locks in the config contract that suppresses the bomb rather than the DOM cleanup itself (which lives in real mermaid internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)