### PR TITLE
feat: apply Contrast Shell palette

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -294,7 +294,19 @@ reattaches it. Host and peer comments share this model.
 
 ### 8.4 Design
 
-Typeform-inspired: the content is the interface. Light mode default with dark mode. Neutral palette — warm grays, off-white background, single accent color for interactive elements. The document pane uses the lighter raised reading surface, while both side rails use the warm page background; the darker sunken token is reserved for wells and secondary controls. The global header uses the Lollipop Dragon mark instead of repeating whether the active tab is a file or folder review; the tab bar and file tree already provide that context. Comment indicators are subtle until hovered. Focus mode — hide sidebar and comment margin, just the rendered document. Smooth transitions and micro-animations for comment interactions. Responsive layout for desktop and tablet.
+Typeform-inspired: the content is the interface. Light mode defaults to the
+Contrast Shell palette: a charcoal header and file rail, a light raised document
+surface, and a charcoal comment rail. Dark mode keeps the same hierarchy with a
+dark document surface. Coral-red identifies primary actions, yellow identifies
+agent-authored activity, and the comment taxonomy retains distinct semantic
+colors. All literal palette values live in `src/ui/styles/tokens.css`; shell,
+document, and panel token families let those regions maintain accessible
+foreground/background pairs. The global header uses the Lollipop Dragon mark
+instead of repeating whether the active tab is a file or folder review; the tab
+bar and file tree already provide that context. Comment indicators are subtle
+until hovered. Focus mode — hide sidebar and comment margin, just the rendered
+document. Smooth transitions and micro-animations for comment interactions.
+Responsive layout for desktop and tablet.
 
 ---
 

--- a/src/ui/components/CommentCard/CommentCard.css
+++ b/src/ui/components/CommentCard/CommentCard.css
@@ -74,7 +74,7 @@
 
 .comment-card__confirm-yes {
   background: var(--c-red, #ef4444);
-  color: var(--on-accent);
+  color: var(--on-remove);
   border: none;
   border-radius: 4px;
   padding: 0.25rem 0.75rem;

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -1,5 +1,14 @@
 /* ── Comment panel ───────────────────────────────────────────── */
 .comment-panel {
+  --bg: var(--panel-bg);
+  --bg-sunken: var(--panel-bg-sunken);
+  --surface: var(--panel-surface);
+  --surface-raised: var(--panel-surface-raised);
+  --ink: var(--panel-ink);
+  --ink-secondary: var(--panel-ink-secondary);
+  --ink-muted: var(--panel-ink-muted);
+  --line: var(--panel-line);
+  --line-strong: var(--panel-line-strong);
   width: 332px;
   flex-shrink: 0;
   display: flex;
@@ -117,7 +126,7 @@
 .comment-panel__danger-confirm-delete {
   border: 1px solid var(--c-red);
   background: var(--c-red);
-  color: var(--on-accent);
+  color: var(--on-remove);
 }
 
 .comment-panel__danger-confirm-cancel {

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.css
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.css
@@ -234,7 +234,7 @@
   flex-shrink: 0;
   border-radius: 10px;
   background: var(--avatar-neutral);
-  color: var(--on-accent);
+  color: var(--on-avatar);
   font-size: 9.5px;
   font-weight: 800;
 }
@@ -242,6 +242,7 @@
 .comment-thread-card__avatar--external {
   border-radius: 6px;
   background: var(--agent);
+  color: var(--on-agent);
 }
 
 .comment-thread-card__reply-copy {
@@ -356,7 +357,7 @@
   border: 0;
   border-radius: 4px;
   background: var(--c-remove);
-  color: var(--on-accent);
+  color: var(--on-remove);
   cursor: pointer;
   font-size: 0.75rem;
 }

--- a/src/ui/components/ShareDialog/ShareDialog.css
+++ b/src/ui/components/ShareDialog/ShareDialog.css
@@ -304,7 +304,7 @@
   place-items: center;
   border-radius: 6px;
   background: var(--agent);
-  color: var(--on-accent);
+  color: var(--on-agent);
   font: 700 11px/1 var(--font-ui);
 }
 

--- a/src/ui/styles/app-layout.css
+++ b/src/ui/styles/app-layout.css
@@ -43,6 +43,29 @@
 }
 
 .app-main {
+  --bg: var(--document-bg);
+  --bg-sunken: var(--document-bg-sunken);
+  --surface: var(--document-surface);
+  --surface-raised: var(--document-surface-raised);
+  --ink: var(--document-ink);
+  --ink-secondary: var(--document-ink-secondary);
+  --ink-muted: var(--document-ink-muted);
+  --line: var(--document-line);
+  --line-strong: var(--document-line-strong);
+  --c-fix: var(--document-c-fix);
+  --c-rewrite: var(--document-c-rewrite);
+  --c-expand: var(--document-c-expand);
+  --c-clarify: var(--document-c-clarify);
+  --c-question: var(--document-c-question);
+  --c-answer: var(--document-c-answer);
+  --c-remove: var(--document-c-remove);
+  --c-fix-soft: var(--document-c-fix-soft);
+  --c-rewrite-soft: var(--document-c-rewrite-soft);
+  --c-expand-soft: var(--document-c-expand-soft);
+  --c-clarify-soft: var(--document-c-clarify-soft);
+  --c-question-soft: var(--document-c-question-soft);
+  --c-answer-soft: var(--document-c-answer-soft);
+  --c-remove-soft: var(--document-c-remove-soft);
   flex: 1;
   overflow: hidden;
   background: var(--surface);

--- a/src/ui/styles/landing.css
+++ b/src/ui/styles/landing.css
@@ -88,14 +88,14 @@
   fill: var(--ink);
 }
 .landing-fill-paper {
-  fill: var(--surface);
+  fill: var(--document-surface);
 }
 .landing-fill-muted {
   fill: var(--ink-muted);
 }
 .landing-page {
-  fill: var(--surface);
-  stroke: var(--ink);
+  fill: var(--document-surface);
+  stroke: var(--document-ink);
 }
 .landing-well {
   fill: var(--bg-sunken);
@@ -195,7 +195,7 @@
 }
 .landing-action--agent {
   background: var(--agent);
-  color: var(--on-accent);
+  color: var(--on-agent);
 }
 .landing-action kbd,
 .landing-action__note {
@@ -400,15 +400,17 @@
   box-shadow: 8px 8px 0 var(--ink);
 }
 .landing-panel--agent {
+  --landing-panel-ink: var(--on-agent);
   background: var(--agent);
 }
 .landing-panel--accent {
+  --landing-panel-ink: var(--on-accent);
   background: var(--accent);
   transform: translateY(26px);
 }
 .landing-panel h3 {
   margin: 0 0 18px;
-  color: var(--on-accent);
+  color: var(--landing-panel-ink);
   font-size: 25px;
   font-weight: 900;
   text-transform: lowercase;
@@ -426,7 +428,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  color: color-mix(in srgb, var(--on-accent) 95%, transparent);
+  color: color-mix(in srgb, var(--landing-panel-ink) 95%, transparent);
   font-size: 14.5px;
   font-weight: 650;
   text-transform: lowercase;
@@ -627,7 +629,7 @@
 
 .landing-link-dialog__join {
   background: var(--agent);
-  color: var(--on-accent);
+  color: var(--on-agent);
   box-shadow: 4px 4px 0 var(--ink);
 }
 

--- a/src/ui/styles/surfaceParity.test.ts
+++ b/src/ui/styles/surfaceParity.test.ts
@@ -21,6 +21,7 @@ function listStylesheets(directory: string): string[] {
 
 describe("Reading Room surface parity", () => {
   it("maps the document and rails to the prototype surface hierarchy", () => {
+    const tokensCss = readStylesheet("src/ui/styles/tokens.css");
     const layoutCss = readStylesheet("src/ui/styles/app-layout.css");
     const fileTreeCss = readStylesheet(
       "src/ui/components/FileTreeSidebar/FileTreeSidebar.css",
@@ -30,14 +31,19 @@ describe("Reading Room surface parity", () => {
     );
 
     expect(layoutCss).toMatch(
-      /\.app-main\s*\{[^}]*background:\s*var\(--surface\)/s,
+      /\.app-main\s*\{[^}]*--bg:\s*var\(--document-bg\)[^}]*--surface:\s*var\(--document-surface\)[^}]*background:\s*var\(--surface\)/s,
     );
     expect(fileTreeCss).toMatch(
       /\.file-tree-sidebar\s*\{[^}]*background-color:\s*var\(--bg\)/s,
     );
     expect(commentPanelCss).toMatch(
-      /\.comment-panel\s*\{[^}]*background-color:\s*var\(--bg\)/s,
+      /\.comment-panel\s*\{[^}]*--bg:\s*var\(--panel-bg\)[^}]*--surface:\s*var\(--panel-surface\)[^}]*background-color:\s*var\(--bg\)/s,
     );
+    for (const context of ["document", "panel"]) {
+      for (const token of ["bg", "surface", "ink", "line"]) {
+        expect(tokensCss).toContain(`--${context}-${token}:`);
+      }
+    }
   });
 
   it("uses the dashed plus block-comment affordance", () => {
@@ -136,6 +142,8 @@ describe("Reading Room surface parity", () => {
     ]) {
       expect(landingCss).toContain(`var(--${themeToken})`);
     }
+    expect(landingCss).toContain("var(--document-surface)");
+    expect(landingCss).toContain("var(--document-ink)");
   });
 
   it("keeps the metadata title compact inside the document heading scope", () => {

--- a/src/ui/styles/tokens.css
+++ b/src/ui/styles/tokens.css
@@ -1,40 +1,76 @@
-/* Reading Room design tokens — Sage palette (warm oat paper + forest green).
-   The app shell and Bauhaus landing share this palette so both follow the
-   active light/dark theme. Values are set directly (no hue-named brand
-   indirection) so a palette swap is a pure value edit. Legacy aliases remain
-   while components migrate. */
+/* Reading Room design tokens — Contrast Shell palette.
+   All literal palette values live here. The default tokens describe the app
+   shell; document and panel token families provide their contextual surfaces.
+   Legacy aliases remain while components migrate. */
 :root {
-  --bg: #f1f3ea;
-  --bg-sunken: #e7ebdd;
-  --surface: #fcfdf8;
-  --surface-raised: #ffffff;
-  --ink: #1e241c;
-  --ink-secondary: #4f5748;
-  --ink-muted: #857f70;
-  --line: #dde1d1;
-  --line-strong: #cbd0bb;
-  --accent: #2f7a4f;
-  --accent-soft: rgba(47, 122, 79, 0.08);
-  --agent: #b45f2e;
-  --agent-soft: rgba(180, 95, 46, 0.1);
-  --avatar-neutral: #6e6659;
+  --bg: #1f2125;
+  --bg-sunken: #181a1e;
+  --surface: #2c2e34;
+  --surface-raised: #34363c;
+  --ink: #f1f1ec;
+  --ink-secondary: #c2c3c0;
+  --ink-muted: #969894;
+  --line: #3b3d42;
+  --line-strong: #54565c;
+  --accent: #c83a30;
+  --accent-soft: rgba(200, 58, 48, 0.15);
+  --agent: #efbd3f;
+  --agent-soft: rgba(239, 189, 63, 0.18);
+  --avatar-neutral: #686b72;
   --on-accent: #ffffff;
-  --on-rewrite: #14170f;
+  --on-agent: #1b1c1e;
+  --on-avatar: #ffffff;
+  --on-remove: #1b1c1e;
+  --on-rewrite: #1b1c1e;
 
-  --c-fix: #d93030;
-  --c-rewrite: #bb7410;
-  --c-expand: #2563eb;
-  --c-clarify: #7c4fd0;
-  --c-question: #0e8a9e;
-  --c-answer: #2e9678;
-  --c-remove: #d93030;
-  --c-fix-soft: rgba(217, 48, 48, 0.1);
-  --c-rewrite-soft: rgba(187, 116, 16, 0.12);
-  --c-expand-soft: rgba(37, 99, 235, 0.1);
-  --c-clarify-soft: rgba(124, 79, 208, 0.1);
-  --c-question-soft: rgba(14, 138, 158, 0.1);
-  --c-answer-soft: rgba(46, 150, 120, 0.12);
-  --c-remove-soft: rgba(217, 48, 48, 0.12);
+  --c-fix: #ff7668;
+  --c-rewrite: #f2c84b;
+  --c-expand: #83a8ff;
+  --c-clarify: #b79ae5;
+  --c-question: #5ac4cf;
+  --c-answer: #72cf9b;
+  --c-remove: #ff7668;
+  --c-fix-soft: rgba(255, 118, 104, 0.16);
+  --c-rewrite-soft: rgba(242, 200, 75, 0.17);
+  --c-expand-soft: rgba(131, 168, 255, 0.16);
+  --c-clarify-soft: rgba(183, 154, 229, 0.16);
+  --c-question-soft: rgba(90, 196, 207, 0.16);
+  --c-answer-soft: rgba(114, 207, 155, 0.16);
+  --c-remove-soft: rgba(255, 118, 104, 0.16);
+
+  --document-bg: #f8f7f3;
+  --document-bg-sunken: #eceae4;
+  --document-surface: #f8f7f3;
+  --document-surface-raised: #ffffff;
+  --document-ink: #1b1c1e;
+  --document-ink-secondary: #55575b;
+  --document-ink-muted: #6c6e72;
+  --document-line: #dedbd3;
+  --document-line-strong: #bdb9b0;
+  --document-c-fix: #b6322a;
+  --document-c-rewrite: #815b00;
+  --document-c-expand: #315fae;
+  --document-c-clarify: #6e4fa4;
+  --document-c-question: #087986;
+  --document-c-answer: #2d7659;
+  --document-c-remove: #b6322a;
+  --document-c-fix-soft: rgba(182, 50, 42, 0.11);
+  --document-c-rewrite-soft: rgba(129, 91, 0, 0.11);
+  --document-c-expand-soft: rgba(49, 95, 174, 0.1);
+  --document-c-clarify-soft: rgba(110, 79, 164, 0.11);
+  --document-c-question-soft: rgba(8, 121, 134, 0.11);
+  --document-c-answer-soft: rgba(45, 118, 89, 0.11);
+  --document-c-remove-soft: rgba(182, 50, 42, 0.11);
+
+  --panel-bg: #23252a;
+  --panel-bg-sunken: #1b1d21;
+  --panel-surface: #2c2e34;
+  --panel-surface-raised: #34363c;
+  --panel-ink: #f1f1ec;
+  --panel-ink-secondary: #c2c3c0;
+  --panel-ink-muted: #969894;
+  --panel-line: #3b3d42;
+  --panel-line-strong: #54565c;
 
   --font-ui: -apple-system, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
   --font-doc: ui-serif, "New York", "Iowan Old Style", Georgia, serif;
@@ -43,9 +79,8 @@
   --radius-m: 10px;
   --radius-l: 14px;
   --header-h: 52px;
-  --shadow-pop:
-    0 8px 28px rgba(30, 36, 28, 0.14), 0 2px 6px rgba(30, 36, 28, 0.08);
-  --shadow-card: 0 1px 2px rgba(30, 36, 28, 0.05);
+  --shadow-pop: 0 8px 28px rgba(0, 0, 0, 0.34), 0 2px 6px rgba(0, 0, 0, 0.22);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.24);
 
   /* Compatibility aliases for surfaces not yet migrated to canonical names. */
   --surface-alt: var(--bg-sunken);
@@ -55,7 +90,7 @@
   --text-primary: var(--ink);
   --text-secondary: var(--ink-secondary);
   --text-muted: var(--ink-muted);
-  --accent-light: #256341;
+  --accent-light: #e05b50;
   --accent-bg: var(--accent-soft);
   --c-green: var(--c-answer);
   --c-green-bg: var(--c-answer-soft);
@@ -74,38 +109,60 @@
 }
 
 .dark {
-  --bg: #141711;
-  --bg-sunken: #0e100b;
-  --surface: #1d2016;
-  --surface-raised: #23271b;
-  --ink: #e7e9dc;
-  --ink-secondary: #b0b3a2;
-  --ink-muted: #7c7a6c;
-  --line: #2c3122;
-  --line-strong: #3a4030;
-  --accent: #5aa877;
-  --accent-soft: rgba(90, 168, 119, 0.16);
-  --accent-light: #4e9c6b;
-  --agent: #d1834f;
-  --agent-soft: rgba(209, 131, 79, 0.16);
-  --avatar-neutral: #97907f;
-  --on-accent: #14170f;
-  --on-rewrite: #14170f;
+  --bg: #111215;
+  --bg-sunken: #0b0c0e;
+  --surface: #191a1d;
+  --surface-raised: #222429;
+  --ink: #f1f1ec;
+  --ink-secondary: #bfc0bd;
+  --ink-muted: #929490;
+  --line: #313338;
+  --line-strong: #4b4d53;
+  --accent: #ff7668;
+  --accent-soft: rgba(255, 118, 104, 0.16);
+  --accent-light: #ff8f84;
+  --agent: #f2c84b;
+  --agent-soft: rgba(242, 200, 75, 0.17);
+  --avatar-neutral: #686b72;
+  --on-accent: #17181a;
+  --on-agent: #17181a;
+  --on-avatar: #ffffff;
+  --on-remove: #17181a;
+  --on-rewrite: #17181a;
   --shadow-pop: 0 8px 28px rgba(0, 0, 0, 0.5), 0 2px 6px rgba(0, 0, 0, 0.35);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
 
-  --c-fix: #f07272;
-  --c-rewrite: #e0a33e;
-  --c-expand: #6d9bf5;
-  --c-clarify: #a98be8;
-  --c-question: #4fb8cb;
-  --c-answer: #4cba9a;
-  --c-remove: #f07272;
-  --c-fix-soft: rgba(240, 114, 114, 0.15);
-  --c-rewrite-soft: rgba(224, 163, 62, 0.15);
-  --c-expand-soft: rgba(109, 155, 245, 0.15);
-  --c-clarify-soft: rgba(169, 139, 232, 0.15);
-  --c-question-soft: rgba(79, 184, 203, 0.15);
-  --c-answer-soft: rgba(76, 186, 154, 0.16);
-  --c-remove-soft: rgba(240, 114, 114, 0.16);
+  --document-bg: #191a1d;
+  --document-bg-sunken: #111215;
+  --document-surface: #191a1d;
+  --document-surface-raised: #222429;
+  --document-ink: #f1f1ec;
+  --document-ink-secondary: #bfc0bd;
+  --document-ink-muted: #929490;
+  --document-line: #313338;
+  --document-line-strong: #4b4d53;
+  --document-c-fix: #ff7668;
+  --document-c-rewrite: #f2c84b;
+  --document-c-expand: #83a8ff;
+  --document-c-clarify: #b79ae5;
+  --document-c-question: #5ac4cf;
+  --document-c-answer: #72cf9b;
+  --document-c-remove: #ff7668;
+  --document-c-fix-soft: rgba(255, 118, 104, 0.16);
+  --document-c-rewrite-soft: rgba(242, 200, 75, 0.17);
+  --document-c-expand-soft: rgba(131, 168, 255, 0.16);
+  --document-c-clarify-soft: rgba(183, 154, 229, 0.16);
+  --document-c-question-soft: rgba(90, 196, 207, 0.16);
+  --document-c-answer-soft: rgba(114, 207, 155, 0.16);
+  --document-c-remove-soft: rgba(255, 118, 104, 0.16);
+
+  --panel-bg: #15171a;
+  --panel-bg-sunken: #0f1012;
+  --panel-surface: #222429;
+  --panel-surface-raised: #2a2c32;
+  --panel-ink: #f1f1ec;
+  --panel-ink-secondary: #bfc0bd;
+  --panel-ink-muted: #929490;
+  --panel-line: #34363c;
+  --panel-line-strong: #505258;
 }

--- a/src/ui/styles/tokensContrast.test.ts
+++ b/src/ui/styles/tokensContrast.test.ts
@@ -1,20 +1,29 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+interface ThemeContext {
+  background: string;
+  codeBackground: string;
+  ink: string;
+  secondaryInk: string;
+  surface: string;
+  taxonomy: string[];
+}
+
 interface ThemeColors {
   accent: string;
   agent: string;
   avatarNeutral: string;
-  background: string;
-  codeBackground: string;
-  ink: string;
+  document: ThemeContext;
   onAccent: string;
+  onAgent: string;
+  onAvatar: string;
+  onRemove: string;
   onRewrite: string;
+  panel: ThemeContext;
   remove: string;
   rewrite: string;
-  secondaryInk: string;
-  surface: string;
-  taxonomy: string[];
+  shell: ThemeContext;
 }
 
 const TOKEN_STYLESHEET = readFileSync("src/ui/styles/tokens.css", "utf8");
@@ -64,6 +73,30 @@ function getToken(
   return value;
 }
 
+function buildThemeContext(
+  tokenPrefix: string,
+  taxonomyPrefix: string,
+  rootTokens: ReadonlyMap<string, string>,
+  overrides: ReadonlyMap<string, string>,
+): ThemeContext {
+  const tokenName = (name: string) =>
+    tokenPrefix ? `--${tokenPrefix}-${name}` : `--${name}`;
+  const taxonomyTokenName = (name: string) =>
+    taxonomyPrefix ? `--${taxonomyPrefix}-${name.slice(2)}` : name;
+  const value = (name: string) =>
+    getToken(tokenName(name), rootTokens, overrides);
+  return {
+    background: value("bg"),
+    codeBackground: value("bg-sunken"),
+    ink: value("ink"),
+    secondaryInk: value("ink-secondary"),
+    surface: value("surface"),
+    taxonomy: TAXONOMY_TOKENS.map((name) =>
+      getToken(taxonomyTokenName(name), rootTokens, overrides),
+    ),
+  };
+}
+
 function buildThemeColors(
   rootTokens: ReadonlyMap<string, string>,
   overrides: ReadonlyMap<string, string>,
@@ -74,16 +107,16 @@ function buildThemeColors(
     accent: value("--accent"),
     agent: value("--agent"),
     avatarNeutral: value("--avatar-neutral"),
-    background: value("--bg"),
-    codeBackground: value("--bg-sunken"),
-    ink: value("--ink"),
+    document: buildThemeContext("document", "document", rootTokens, overrides),
     onAccent: value("--on-accent"),
+    onAgent: value("--on-agent"),
+    onAvatar: value("--on-avatar"),
+    onRemove: value("--on-remove"),
     onRewrite: value("--on-rewrite"),
+    panel: buildThemeContext("panel", "", rootTokens, overrides),
     remove: value("--c-remove"),
     rewrite: value("--c-rewrite"),
-    secondaryInk: value("--ink-secondary"),
-    surface: value("--surface"),
-    taxonomy: TAXONOMY_TOKENS.map(value),
+    shell: buildThemeContext("", "", rootTokens, overrides),
   };
 }
 
@@ -129,19 +162,21 @@ describe("Reading Room token contrast", () => {
   it.each(themes)(
     "%s theme meets text and taxonomy contrast budgets",
     (_themeName, colors) => {
-      expect(
-        contrastRatio(colors.ink, colors.background),
-      ).toBeGreaterThanOrEqual(4.5);
-      expect(
-        contrastRatio(colors.secondaryInk, colors.background),
-      ).toBeGreaterThanOrEqual(4.5);
-      for (const taxonomyColor of colors.taxonomy) {
+      for (const context of [colors.shell, colors.document, colors.panel]) {
         expect(
-          contrastRatio(taxonomyColor, colors.surface),
-        ).toBeGreaterThanOrEqual(3);
+          contrastRatio(context.ink, context.background),
+        ).toBeGreaterThanOrEqual(4.5);
         expect(
-          contrastRatio(taxonomyColor, colors.codeBackground),
-        ).toBeGreaterThanOrEqual(3);
+          contrastRatio(context.secondaryInk, context.background),
+        ).toBeGreaterThanOrEqual(4.5);
+        for (const taxonomyColor of context.taxonomy) {
+          expect(
+            contrastRatio(taxonomyColor, context.surface),
+          ).toBeGreaterThanOrEqual(3);
+          expect(
+            contrastRatio(taxonomyColor, context.codeBackground),
+          ).toBeGreaterThanOrEqual(3);
+        }
       }
     },
   );
@@ -151,13 +186,13 @@ describe("Reading Room token contrast", () => {
       contrastRatio(colors.onAccent, colors.accent),
     ).toBeGreaterThanOrEqual(4.5);
     expect(
-      contrastRatio(colors.onAccent, colors.remove),
+      contrastRatio(colors.onRemove, colors.remove),
     ).toBeGreaterThanOrEqual(4.5);
-    expect(contrastRatio(colors.onAccent, colors.agent)).toBeGreaterThanOrEqual(
+    expect(contrastRatio(colors.onAgent, colors.agent)).toBeGreaterThanOrEqual(
       4.5,
     );
     expect(
-      contrastRatio(colors.onAccent, colors.avatarNeutral),
+      contrastRatio(colors.onAvatar, colors.avatarNeutral),
     ).toBeGreaterThanOrEqual(4.5);
     expect(
       contrastRatio(colors.onRewrite, colors.rewrite),


### PR DESCRIPTION
## Summary
- replace the Sage palette with Contrast Shell semantic tokens
- scope document and comment-panel surfaces while keeping palette values centralized
- add contrast and surface coverage, and update the design spec

## Validation
- npm run validate
- visual smoke check in the real app with no console warnings
- commit hooks: Prettier, ESLint, TypeScript, and architecture validation