### PR TITLE
Fix host comment review regressions

### DIFF
--- a/docs/design/v2-technical-design.md
+++ b/docs/design/v2-technical-design.md
@@ -534,7 +534,8 @@ loadSharedContent: () => Promise<void>                       // peer mode init
 
 - "Merge" on a `PeerCommentCard`: find the target file and block in the local folder
 - Insert CriticMarkup at the correct block position using the existing `insertComment` service
-- Append peer attribution: ``
+- Store the peer's display name in escaped MarkReview `author` metadata while
+  keeping the original comment text unchanged
 - Write file back to disk, re-parse, update comment panel
 - Remove the merged comment from the pending review list
 - **Deliverable:** Host can merge a peer comment into the local file as CriticMarkup in one click
@@ -550,7 +551,8 @@ loadSharedContent: () => Promise<void>                       // peer mode init
 
 - Unit tests: `PeerComment` serialization, encryption round-trip for comments
 - Unit tests: comment merge → correct CriticMarkup inserted at correct block position
-- Unit tests: peer attribution suffix appended correctly
+- Unit tests: peer author metadata round-trips correctly, including names with
+  metadata delimiters
 - Integration test: peer posts comment → host fetches → host merges → verify CriticMarkup in file
 - Integration test: bulk merge writes all comments without corrupting file
 - Component tests: PeerCommentCard, PendingCommentReview, ShareDialog with badge

--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -158,7 +158,9 @@ MarkReview extends the plain comment protocol for threaded review questions.
 - Thread and sidebar comment editors keep their type chips, textarea, and
   actions aligned to the card edges without inheriting floating-composer
   margins. Save uses the accent treatment, while Cancel uses the same neutral
-  outlined treatment as confirmations.
+  outlined treatment as confirmations. Editable unanswered thread comments
+  expose the same user comment types as the sidebar editor, so the type can be
+  corrected before saving; answered threads remain immutable.
 - Threaded action replies are work instructions, not conversational answers. The review-agent prompt tells agents to apply the requested edit directly, remove the resolved thread after the edit, and avoid adding a confirmation `answer:` reply.
 - While an editable message in an unanswered thread is being edited or
   delete-confirmed, the composer is hidden so the user sees only one active input

--- a/docs/features/peer-sharing.md
+++ b/docs/features/peer-sharing.md
@@ -295,7 +295,10 @@ because the active tab's `shares`, `shareKeys`, or `activeDocId` changed.
 3. Host opens Comments. When incoming feedback exists, the panel initially
    opens **Incoming** and shows peer name, file path, quote, type, and comment
    text. Open-comment type filters keep their existing counts and selection.
-4. Host clicks "Merge" — app inserts CriticMarkup into the local files.
+   Long file names, comments, and links remain contained within both the normal
+   and narrow Comments panel widths, with review actions always reachable.
+4. Host clicks "Merge" — app inserts CriticMarkup into the local files and
+   preserves the reviewer's name as structured author metadata.
 5. Host tells LLM CLI: "Address the comments in this file."
 6. LLM reads CriticMarkup, makes fixes, removes the markup.
 7. Host clicks "Push update" in the header to push revised content to Worker. Obsolete flow: peers click "Get latest" to see the updates. Canonical flow: peers auto-refresh when it is safe, otherwise the app blocks on a refresh notice until they load the latest snapshot.

--- a/docs/features/realtime-comments/spec.md
+++ b/docs/features/realtime-comments/spec.md
@@ -22,6 +22,8 @@ Host-authored local comments remain local-only. They are merged directly into th
 - As a host reviewing feedback, I want incoming peer comments in the normal
   Comments panel so review work is not hidden inside share management.
 - As a host reviewing incoming comments, I want merge and dismiss actions to remove the comment from reconnect snapshots so it does not come back later.
+- As a host merging incoming feedback, I want the reviewer's name to remain the
+  comment author so ownership does not change to me after the file is reparsed.
 - As a peer leaving feedback, I want submitted comments to be acknowledged only after the backend stores them durably.
 - As a peer with unsent feedback, I want Submit comments to remain a prominent,
   counted primary action until my feedback is sent.

--- a/src/markup/commentProtocol.ts
+++ b/src/markup/commentProtocol.ts
@@ -19,6 +19,22 @@ const COMMENT_TYPES: ReadonlySet<string> = new Set<CommentType>([
   "remove",
 ]);
 
+function escapeMetadataAuthor(authorLabel: string): string {
+  return authorLabel
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function decodeMetadataAuthor(authorLabel: string): string {
+  return authorLabel
+    .replaceAll("&quot;", '"')
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&amp;", "&");
+}
+
 export function isCommentType(value: string): value is CommentType {
   return COMMENT_TYPES.has(value);
 }
@@ -82,7 +98,7 @@ export function parseThreadMetadata(text: string): {
     thread.replyTo = attributes.replyTo;
   }
   if (attributes.author) {
-    thread.authorLabel = attributes.author;
+    thread.authorLabel = decodeMetadataAuthor(attributes.author);
   }
 
   return {
@@ -115,7 +131,7 @@ function serializeThreadMetadata(thread: CommentThreadMetadata): string {
     attributes.push(`replyTo="${thread.replyTo}"`);
   }
   if (thread.authorLabel) {
-    attributes.push(`author="${thread.authorLabel}"`);
+    attributes.push(`author="${escapeMetadataAuthor(thread.authorLabel)}"`);
   }
 
   return `[markreview ${attributes.join(" ")}]`;
@@ -144,12 +160,18 @@ function createRandomCommentId(): string {
   return `${THREAD_COMMENT_PREFIX}${timeSuffix}-${randomSuffix}`;
 }
 
-export function createQuestionThreadMetadata(): CommentThreadMetadata {
+export function createQuestionThreadMetadata(
+  authorLabel?: string,
+): CommentThreadMetadata {
   const commentId = createRandomCommentId();
-  return {
+  const thread: CommentThreadMetadata = {
     commentId,
     threadId: commentId,
   };
+  if (authorLabel) {
+    thread.authorLabel = authorLabel;
+  }
+  return thread;
 }
 
 export function createThreadReplyMetadata(input: {

--- a/src/markup/insertComment.ts
+++ b/src/markup/insertComment.ts
@@ -115,6 +115,7 @@ export function insertComment(input: {
   blockIndex: number;
   type: CommentType;
   text: string;
+  authorLabel?: string;
   anchor?: Pick<CommentAnchor, "quote" | "occurrence" | "start" | "end">;
 }): string {
   const blocks = getBlockPositions(input.cleanMarkdown);
@@ -131,7 +132,9 @@ export function insertComment(input: {
   const segments = buildSegments(input.rawContent, input.existingComments);
 
   const thread =
-    input.type === "question" ? createQuestionThreadMetadata() : undefined;
+    input.type === "question" || input.authorLabel
+      ? createQuestionThreadMetadata(input.authorLabel)
+      : undefined;
   const body = serializeCommentBody({
     type: input.type,
     text: input.text,

--- a/src/modules/sharing/controller.ts
+++ b/src/modules/sharing/controller.ts
@@ -362,7 +362,8 @@ export function buildMergedPeerCommentContent(
     cleanMarkdown: parsed.cleanMarkdown,
     blockIndex: comment.blockRef.blockIndex,
     type: comment.commentType,
-    text: `${comment.text} — ${comment.peerName}`,
+    text: comment.text,
+    authorLabel: comment.peerName,
     anchor: peerAnchor?.orphaned ? undefined : peerAnchor,
   });
   return rawContent.slice(0, document.bodyStart) + newBody;

--- a/src/modules/sharing/test/peerRangeMerge.test.ts
+++ b/src/modules/sharing/test/peerRangeMerge.test.ts
@@ -18,9 +18,11 @@ describe("peer range comment merge", () => {
         },
       }),
     );
+    const parsed = parseCriticMarkup(result);
 
     expect(result).toContain("{==selected sentence==}");
-    expect(result).toContain("A comment — Alice");
+    expect(parsed.comments[0]?.text).toBe("A comment");
+    expect(parsed.comments[0]?.thread?.authorLabel).toBe("Alice");
   });
 
   it("keeps overlapping peer ranges as standalone anchored comments", () => {
@@ -43,6 +45,24 @@ describe("peer range comment merge", () => {
     expect(result.match(/\{==selected sentence==\}/g)).toHaveLength(1);
     expect(parsed.comments).toHaveLength(2);
     expect(parsed.comments[1].anchor?.quote).toBe("selected sentence");
-    expect(parsed.comments[1].text).toContain("Explain the wording — Alice");
+    expect(parsed.comments[1].text).toBe("Explain the wording");
+    expect(parsed.comments[1].thread?.authorLabel).toBe("Alice");
+  });
+
+  it("preserves reviewer names containing metadata delimiters", () => {
+    const result = buildMergedPeerCommentContent(
+      "A paragraph for review.\n",
+      makePeerComment({
+        peerName: 'Alice "QA" & Bob <ops>',
+      }),
+    );
+    const parsed = parseCriticMarkup(result);
+
+    expect(result).toContain(
+      'author="Alice &quot;QA&quot; &amp; Bob &lt;ops&gt;"',
+    );
+    expect(parsed.comments[0]?.thread?.authorLabel).toBe(
+      'Alice "QA" & Bob <ops>',
+    );
   });
 });

--- a/src/ui/components/CommentPanel/CommentPanel.css
+++ b/src/ui/components/CommentPanel/CommentPanel.css
@@ -440,13 +440,21 @@
 
 .comment-panel__list {
   flex: 1;
+  min-width: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   padding: 6px 12px 12px;
 }
 
 .comment-panel__incoming {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 12px;
+  min-width: 0;
+}
+
+.comment-panel__incoming-group {
+  min-width: 0;
 }
 
 .comment-panel__incoming-group h3 {

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
@@ -214,7 +214,7 @@ describe("CommentThreadCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("edits the selected user-authored thread message", async () => {
+  it("changes the type while editing a user-authored thread message", async () => {
     const user = userEvent.setup();
     const onEdit = vi.fn();
 
@@ -229,13 +229,14 @@ describe("CommentThreadCard", () => {
 
     await user.click(screen.getByRole("button", { name: "Edit comment" }));
     const textarea = screen.getByDisplayValue("Why is this section needed?");
+    await user.click(screen.getByRole("button", { name: "rewrite" }));
     await user.clear(textarea);
     await user.type(textarea, "Updated question.");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(onEdit).toHaveBeenCalledWith(
       "root-comment",
-      "question",
+      "rewrite",
       "Updated question.",
     );
   });

--- a/src/ui/components/CommentThreadCard/CommentThreadRow.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadRow.tsx
@@ -107,9 +107,7 @@ function CommentEditForm({
   );
   const [editText, setEditText] = useState(comment.text);
   const availableTypes =
-    comment.thread || comment.type === "answer"
-      ? [comment.type]
-      : USER_COMMENT_TYPES;
+    comment.type === "answer" ? [comment.type] : USER_COMMENT_TYPES;
 
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault();

--- a/src/ui/components/PeerCommentCard/PeerCommentCard.css
+++ b/src/ui/components/PeerCommentCard/PeerCommentCard.css
@@ -2,6 +2,9 @@
 .peer-card {
   --comment-color: var(--accent);
   --comment-soft: var(--accent-bg);
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   margin-bottom: 8px;
   padding: 10px 12px;
   background: var(--surface);
@@ -44,6 +47,7 @@
 .peer-card__meta {
   display: flex;
   align-items: center;
+  min-width: 0;
   gap: 0.5rem;
   margin-bottom: 6px;
   font-size: 11.5px;
@@ -102,10 +106,12 @@
   color: var(--ink);
   font-size: 12.5px;
   line-height: 1.55;
+  overflow-wrap: anywhere;
 }
 
 .peer-card__actions {
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   gap: 6px;
 }

--- a/src/ui/components/PendingCommentReview/PendingCommentReview.css
+++ b/src/ui/components/PendingCommentReview/PendingCommentReview.css
@@ -1,4 +1,9 @@
 /* ── Pending review toolbar ───────────────────────────────────── */
+.pending-review,
+.pending-review__list {
+  min-width: 0;
+}
+
 .pending-review__toolbar {
   display: flex;
   flex-wrap: wrap;

--- a/src/ui/styles/surfaceParity.test.ts
+++ b/src/ui/styles/surfaceParity.test.ts
@@ -65,6 +65,31 @@ describe("Reading Room surface parity", () => {
     );
   });
 
+  it("keeps incoming review cards inside the comment rail", () => {
+    const commentPanelCss = readStylesheet(
+      "src/ui/components/CommentPanel/CommentPanel.css",
+    );
+    const pendingReviewCss = readStylesheet(
+      "src/ui/components/PendingCommentReview/PendingCommentReview.css",
+    );
+    const peerCommentCardCss = readStylesheet(
+      "src/ui/components/PeerCommentCard/PeerCommentCard.css",
+    );
+
+    expect(commentPanelCss).toMatch(
+      /\.comment-panel__incoming\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)[^}]*min-width:\s*0/s,
+    );
+    expect(pendingReviewCss).toMatch(
+      /\.pending-review,\s*\.pending-review__list\s*\{[^}]*min-width:\s*0/s,
+    );
+    expect(peerCommentCardCss).toMatch(
+      /\.peer-card\s*\{[^}]*width:\s*100%[^}]*min-width:\s*0[^}]*max-width:\s*100%/s,
+    );
+    expect(peerCommentCardCss).toMatch(
+      /\.peer-card__text\s*\{[^}]*overflow-wrap:\s*anywhere/s,
+    );
+  });
+
   it("styles thread confirmation actions as compact app controls", () => {
     const commentThreadCss = readStylesheet(
       "src/ui/components/CommentThreadCard/CommentThreadCard.css",


### PR DESCRIPTION
## Summary
- keep incoming review cards and actions inside the Comments panel at normal and narrow widths
- preserve the original reviewer as structured author metadata when merging peer comments
- allow editable unanswered threaded comments to change type
- document the corrected review behavior and add regression coverage

## Validation
- npm run validate (76 files, 637 tests, build and bundle budgets)
- browser layout check with long reviewer name, filename, comment, and unbroken URL
- verified panel/list scroll width equals client width and all card actions stay within the rail