### PR TITLE
Fix answered status badge alignment

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -128,6 +128,10 @@ MarkReview extends the plain comment protocol for threaded review questions.
   of disappearing.
 - The reply can also include `author` so the UI can show `Codex`, `Cursor`, or a generic `Agent` label.
 - The Comments panel always renders linked replies beneath the root question and marks the root as `answered` once an `answer:` reply exists. Selecting the root keeps the complete conversation in place and adds the reply composer and comment actions, including in folder mode where the thread remains under its file-path header.
+- The root question's `answered` badge stays aligned to the card's trailing edge.
+  When root actions appear on hover or keyboard focus, they replace that badge
+  in the same trailing slot instead of reserving separate space and pushing the
+  status toward the card center.
 - Thread rail visuals follow `docs/redesign/reference-prototype/index.html`: the
   root and replies share one standard comment card, replies use compact avatar
   rows beneath a dashed divider and answer-colored left rule, and selected

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.css
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.css
@@ -123,6 +123,18 @@
   flex: 1;
 }
 
+.comment-thread-card__trailing {
+  display: grid;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.comment-thread-card__trailing > .comment-thread-card__status,
+.comment-thread-card__trailing > .comment-thread-card__actions {
+  grid-area: 1 / 1;
+  justify-self: end;
+}
+
 .comment-thread-card__badge {
   flex-shrink: 0;
   padding: 2.5px 7px;
@@ -144,7 +156,6 @@
 }
 
 .comment-thread-card__status {
-  margin-left: auto;
   padding: 2.5px 7px;
   border-radius: 5px;
   background: var(--c-answer-soft);

--- a/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadCard.test.tsx
@@ -104,7 +104,18 @@ describe("CommentThreadCard", () => {
     expect(
       screen.queryByRole("button", { name: "Close comment" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("✓ answered · 1")).toBeInTheDocument();
+    const answeredStatus = screen.getByText("✓ answered · 1");
+    const resolveAction = screen.getByRole("button", {
+      name: "Resolve question",
+    });
+    const trailingSlot = answeredStatus.closest(
+      ".comment-thread-card__trailing",
+    );
+
+    expect(trailingSlot).toBeInTheDocument();
+    expect(resolveAction.closest(".comment-thread-card__trailing")).toBe(
+      trailingSlot,
+    );
     expect(
       container.querySelector(".comment-thread-card__thread-list"),
     ).toBeInTheDocument();

--- a/src/ui/components/CommentThreadCard/CommentThreadRow.tsx
+++ b/src/ui/components/CommentThreadCard/CommentThreadRow.tsx
@@ -373,13 +373,17 @@ export function CommentThreadRow({
         <div className="comment-thread-card__meta">
           <span className="comment-thread-card__badge">{comment.type}</span>
           <span className="comment-thread-card__author">{authorLabel}</span>
-          {answeredCount > 0 && (
-            <span className="comment-thread-card__status">
-              ✓ answered · {answeredCount}
-            </span>
-          )}
         </div>
-        {actions}
+        {(answeredCount > 0 || actionsEnabled) && (
+          <div className="comment-thread-card__trailing">
+            {answeredCount > 0 && (
+              <span className="comment-thread-card__status">
+                ✓ answered · {answeredCount}
+              </span>
+            )}
+            {actions}
+          </div>
+        )}
       </div>
       <CommentRowContent
         comment={comment}


### PR DESCRIPTION
## Summary

- keep the answered badge aligned to the comment card trailing edge
- make the badge and hover/focus actions share one trailing slot
- add regression coverage and document the layout contract

## Validation

- `npm run validate`
- browser geometry check confirmed the badge aligns with the card content edge