### PR TITLE
Fix Mermaid labels and add reviewer name editing

### DIFF
--- a/docs/design/v2-technical-design.md
+++ b/docs/design/v2-technical-design.md
@@ -400,7 +400,7 @@ In **peer mode** (URL has `#share=...&key=...`):
 ```typescript
 // New state
 shares: ShareRecord[]              // persisted to localStorage
-peerName: string | null            // peer's self-declared name (sessionStorage)
+peerName: string | null            // peer's self-declared name (persisted to localStorage)
 isPeerMode: boolean                // true when viewing a shared link
 sharedContent: SharePayload | null // decrypted content in peer mode
 
@@ -464,7 +464,8 @@ loadSharedContent: () => Promise<void>                       // peer mode init
 
 - On app init, check `location.hash` for `share=` and `key=` params
 - If present: enter peer mode — fetch and decrypt content from Worker, reconstruct folder tree
-- Show `PeerNamePrompt` to collect display name (stored in sessionStorage)
+- Show `PeerNamePrompt` to collect the initial display name (stored in
+  localStorage); the peer header identity can reopen a compact editor later
 - Render decrypted content using the full v1 reading UI (sidebar + markdown renderer)
 - All write actions disabled silently
 - If fetch fails (expired/revoked): show "This document is no longer available"

--- a/docs/features/peer-sharing.md
+++ b/docs/features/peer-sharing.md
@@ -187,7 +187,8 @@ Acceptance criteria:
 
 - Shared Markdown and Mermaid source are treated as untrusted input.
 - Mermaid loads only when a Mermaid block is rendered and runs with strict
-  security and HTML labels disabled.
+  security and both global and flowchart HTML labels disabled, preserving SVG
+  text labels across supported Mermaid versions.
 - The rendered SVG is sanitized before insertion into the DOM.
 - Diagram node and edge labels remain visible as SVG text after sanitization.
 - Scripts, embedded HTML, event-handler attributes, external resource URLs,

--- a/docs/features/peer-sharing.md
+++ b/docs/features/peer-sharing.md
@@ -189,6 +189,7 @@ Acceptance criteria:
 - Mermaid loads only when a Mermaid block is rendered and runs with strict
   security and HTML labels disabled.
 - The rendered SVG is sanitized before insertion into the DOM.
+- Diagram node and edge labels remain visible as SVG text after sanitization.
 - Scripts, embedded HTML, event-handler attributes, external resource URLs,
   unsafe CSS imports, expressions, and JavaScript URLs are removed.
 - Fragment-only SVG references remain available for local markers and fills.
@@ -210,6 +211,14 @@ and header-rail action show the incoming count. The host can navigate to,
 merge, or dismiss each comment without opening share management.
 
 Peers can always comment, regardless of whether the host is online.
+
+The peer header identity is interactive. Selecting it opens a compact reviewer
+name editor prefilled with the current browser-local name. Saving a trimmed,
+non-empty name updates the header immediately and applies across shared links in
+that browser. Existing unsent comments are renamed so they submit under the new
+identity; comments already acknowledged by the relay keep the author name they
+were submitted with. Cancel, Escape, or an outside click dismisses the editor
+without changing the name.
 
 ### 7.4 Push Updates to Peers
 
@@ -284,9 +293,12 @@ because the active tab's `shares`, `shareKeys`, or `activeDocId` changed.
 1. Peer opens link in browser. App prompts for their display name.
 2. App fetches encrypted blob from Worker, decrypts, renders.
 3. Peer reads the document in the clean rendered view.
-4. Peer hovers over a block, clicks comment icon, selects type, writes comment.
-5. Comment is encrypted and POSTed to the Worker.
-6. Peer sees confirmation: "Comment saved."
+4. If needed, the peer selects their header identity and changes the reviewer
+   name. The name persists across shared links in the same browser; unsent
+   comments adopt it and submitted comments retain their original author.
+5. Peer hovers over a block, clicks comment icon, selects type, writes comment.
+6. Comment is encrypted and POSTed to the Worker.
+7. Peer sees confirmation: "Comment saved."
 
 ### 8.3 Host Receives Feedback
 
@@ -399,7 +411,9 @@ If the storage backend needs to change in the future, only the implementation of
 - **Blob size limit.** KV values max out at 25MB. Sufficient for hundreds of markdown files. If exceeded, the app splits across multiple KV entries.
 - **Free tier limits.** 100K requests/day and 1K writes/day. More than enough for 2–5 peers. If exceeded, Cloudflare's paid tier is $5/month.
 - **No real-time sync.** Comments are async. Host must manually check for new comments. Acceptable for the review workflow. Real-time sync is planned for v3.
-- **No persistent identity.** Peers self-declare their name. No accounts. For 2–5 trusted peers this is acceptable.
+- **No authenticated identity.** Peers self-declare a browser-local display
+  name that persists in localStorage. There are no accounts. For 2–5 trusted
+  peers this is acceptable.
 
 ---
 

--- a/src/modules/peer-review/README.md
+++ b/src/modules/peer-review/README.md
@@ -60,6 +60,10 @@ Owns peer-mode shared content state and peer-authored draft/submission logic.
 
 - peer mode must not read host tab state as its source of truth
 - submitted IDs are ack-driven and must stay separate from local drafts
+- changing `peerName` renames unsent peer comments but preserves the author on
+  comments whose IDs have already been acknowledged as submitted
+- `peerName` is global peer state persisted through the root Zustand store, so
+  it applies across shared links in the same browser
 
 ## Common Failure Modes
 

--- a/src/modules/peer-review/state.ts
+++ b/src/modules/peer-review/state.ts
@@ -79,7 +79,17 @@ export function createPeerReviewActions<
 > {
   return {
     setPeerName: (name) => {
-      set({ peerName: name });
+      set((state) => {
+        const submittedCommentIds = new Set(state.submittedPeerCommentIds);
+        return {
+          peerName: name,
+          myPeerComments: state.myPeerComments.map((comment) =>
+            submittedCommentIds.has(comment.id)
+              ? comment
+              : { ...comment, peerName: name },
+          ),
+        };
+      });
     },
 
     setPeerDraftCommentOpen: (open) => {

--- a/src/modules/peer-review/test/peerState.test.ts
+++ b/src/modules/peer-review/test/peerState.test.ts
@@ -1,14 +1,42 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useAppStore } from "../../../store";
-import { resetTestStore } from "../../../testing/testHelpers";
+import { makePeerComment, resetTestStore } from "../../../testing/testHelpers";
 
 describe("peer-review state actions", () => {
   beforeEach(() => {
     resetTestStore();
   });
 
-  it("sets peerName in state", () => {
+  it("sets peerName and renames unsent comments", () => {
+    useAppStore.setState({
+      peerName: "Alice",
+      myPeerComments: [makePeerComment({ id: "draft-1", peerName: "Alice" })],
+    });
+
     useAppStore.getState().setPeerName("Bob");
+
     expect(useAppStore.getState().peerName).toBe("Bob");
+    expect(useAppStore.getState().myPeerComments[0]?.peerName).toBe("Bob");
+    expect(localStorage.getItem("markreview-store")).toContain(
+      '"peerName":"Bob"',
+    );
+  });
+
+  it("preserves submitted comment authors when the reviewer name changes", () => {
+    useAppStore.setState({
+      peerName: "Alice",
+      myPeerComments: [
+        makePeerComment({ id: "submitted-1", peerName: "Alice" }),
+        makePeerComment({ id: "draft-1", peerName: "Alice" }),
+      ],
+      submittedPeerCommentIds: ["submitted-1"],
+    });
+
+    useAppStore.getState().setPeerName("Bob");
+
+    expect(useAppStore.getState().myPeerComments).toEqual([
+      expect.objectContaining({ id: "submitted-1", peerName: "Alice" }),
+      expect.objectContaining({ id: "draft-1", peerName: "Bob" }),
+    ]);
   });
 });

--- a/src/ui/components/Header/Header.css
+++ b/src/ui/components/Header/Header.css
@@ -386,37 +386,6 @@
     display: none;
   }
 }
-.app-header__identity {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.25rem 0.5rem;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface-alt);
-}
-.app-header__identity-avatar {
-  display: grid;
-  place-items: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: var(--accent-soft);
-  color: var(--accent);
-  font: 700 0.62rem/1 var(--font-mono);
-}
-.app-header__identity > span:last-child {
-  display: grid;
-  line-height: 1.05;
-}
-.app-header__identity strong {
-  color: var(--text);
-  font-size: 0.68rem;
-}
-.app-header__identity small {
-  color: var(--text-muted);
-  font-size: 0.58rem;
-}
 .app-header__btn--guarded,
 .app-header__btn[aria-disabled="true"] {
   opacity: 0.48;

--- a/src/ui/components/Header/Header.tsx
+++ b/src/ui/components/Header/Header.tsx
@@ -18,12 +18,12 @@ import { selectUnsubmittedPeerComments } from "../../../modules/peer-review";
 import { selectDocumentUpdateAvailable } from "../../../modules/relay";
 import { SunIcon, MoonIcon } from "../Icons";
 import { ConnectionStatus } from "../ConnectionStatus";
+import { ReviewerIdentity } from "../ReviewerIdentity";
 import { TabBar } from "../TabBar";
 import { syncActiveShares } from "../../../modules/sharing";
 import { canRunAgent } from "../../../runtime";
 import { downloadActiveFile } from "./downloadActiveFile";
 import { tabRequiresRestoreAccess } from "../../../types/tab";
-import { initials } from "../../../utils/peerDisplay";
 import type { Comment } from "../../../types/criticmarkup";
 import type { TabState } from "../../../types/tab";
 import {
@@ -283,21 +283,11 @@ export function Header({
           {peerMode && (
             <div className="app-header__group app-header__group--peer">
               {peerName && (
-                <div
-                  className="app-header__identity"
-                  title={`Reviewing as ${peerName}`}
-                >
-                  <span className="app-header__identity-avatar">
-                    {initials(peerName)}
-                  </span>
-                  <span>
-                    <strong>{peerName}</strong>
-                    <small>
-                      {Object.keys(sharedContent?.tree ?? {}).length} shared
-                      files
-                    </small>
-                  </span>
-                </div>
+                <ReviewerIdentity
+                  sharedFileCount={
+                    Object.keys(sharedContent?.tree ?? {}).length
+                  }
+                />
               )}
               {unsubmittedPeerCount > 0 && (
                 <button

--- a/src/ui/components/MermaidBlock/MermaidBlock.test.tsx
+++ b/src/ui/components/MermaidBlock/MermaidBlock.test.tsx
@@ -47,6 +47,9 @@ describe("MermaidBlock", () => {
       expect(mermaid.initialize).toHaveBeenCalledWith(
         expect.objectContaining({
           htmlLabels: false,
+          flowchart: {
+            htmlLabels: false,
+          },
           suppressErrorRendering: true,
         }),
       );

--- a/src/ui/components/MermaidBlock/MermaidBlock.test.tsx
+++ b/src/ui/components/MermaidBlock/MermaidBlock.test.tsx
@@ -35,7 +35,7 @@ describe("MermaidBlock", () => {
   // first render in this module. Suppressing mermaid's built-in error graphic
   // stops the default "Syntax error" bomb SVG from being orphaned in <body> on
   // a parse failure — the block shows its own source + error message instead.
-  it("initializes mermaid with its built-in error graphic suppressed", async () => {
+  it("initializes mermaid with safe SVG text labels", async () => {
     vi.mocked(mermaid.render).mockResolvedValue({
       svg: "<svg></svg>",
       bindFunctions: undefined,
@@ -45,7 +45,10 @@ describe("MermaidBlock", () => {
 
     await waitFor(() => {
       expect(mermaid.initialize).toHaveBeenCalledWith(
-        expect.objectContaining({ suppressErrorRendering: true }),
+        expect.objectContaining({
+          htmlLabels: false,
+          suppressErrorRendering: true,
+        }),
       );
     });
   });

--- a/src/ui/components/MermaidBlock/MermaidBlock.tsx
+++ b/src/ui/components/MermaidBlock/MermaidBlock.tsx
@@ -30,6 +30,9 @@ function loadMermaid(): Promise<MermaidApi> {
           securityLevel: "strict",
           suppressErrorRendering: true,
           htmlLabels: false,
+          flowchart: {
+            htmlLabels: false,
+          },
         });
         return module.default;
       })

--- a/src/ui/components/MermaidBlock/MermaidBlock.tsx
+++ b/src/ui/components/MermaidBlock/MermaidBlock.tsx
@@ -29,7 +29,7 @@ function loadMermaid(): Promise<MermaidApi> {
           startOnLoad: false,
           securityLevel: "strict",
           suppressErrorRendering: true,
-          flowchart: { htmlLabels: false },
+          htmlLabels: false,
         });
         return module.default;
       })

--- a/src/ui/components/MermaidBlock/mermaidRendering.test.ts
+++ b/src/ui/components/MermaidBlock/mermaidRendering.test.ts
@@ -45,6 +45,9 @@ describe("Mermaid SVG rendering", () => {
       securityLevel: "strict",
       suppressErrorRendering: true,
       htmlLabels: false,
+      flowchart: {
+        htmlLabels: false,
+      },
     });
 
     const { svg } = await mermaid.render(

--- a/src/ui/components/MermaidBlock/mermaidRendering.test.ts
+++ b/src/ui/components/MermaidBlock/mermaidRendering.test.ts
@@ -1,0 +1,72 @@
+import mermaid from "mermaid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { sanitizeMermaidSvg } from "./mermaidSecurity";
+
+const getBBoxDescriptor = Object.getOwnPropertyDescriptor(
+  SVGElement.prototype,
+  "getBBox",
+);
+const getComputedTextLengthDescriptor = Object.getOwnPropertyDescriptor(
+  SVGElement.prototype,
+  "getComputedTextLength",
+);
+
+function restoreSvgMethod(
+  methodName: string,
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(SVGElement.prototype, methodName, descriptor);
+    return;
+  }
+  Reflect.deleteProperty(SVGElement.prototype, methodName);
+}
+
+describe("Mermaid SVG rendering", () => {
+  beforeAll(() => {
+    Object.defineProperty(SVGElement.prototype, "getBBox", {
+      configurable: true,
+      value: () => new DOMRect(0, 0, 100, 20),
+    });
+    Object.defineProperty(SVGElement.prototype, "getComputedTextLength", {
+      configurable: true,
+      value: () => 100,
+    });
+  });
+
+  afterAll(() => {
+    restoreSvgMethod("getBBox", getBBoxDescriptor);
+    restoreSvgMethod("getComputedTextLength", getComputedTextLengthDescriptor);
+  });
+
+  it("keeps flowchart node labels after sanitization", async () => {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      suppressErrorRendering: true,
+      htmlLabels: false,
+    });
+
+    const { svg } = await mermaid.render(
+      "visible-node-labels",
+      "flowchart LR\n  Start[Start] --> Choice{Existing?}\n  Choice -->|Generate new| Generate[Generate]",
+    );
+    const sanitized = sanitizeMermaidSvg(svg);
+    const svgDocument = new DOMParser().parseFromString(
+      sanitized,
+      "image/svg+xml",
+    );
+    const nodeLabels = Array.from(
+      svgDocument.querySelectorAll("g.node text"),
+      (label) => label.textContent,
+    );
+    const edgeLabels = Array.from(
+      svgDocument.querySelectorAll("g.edgeLabel text"),
+      (label) => label.textContent ?? "",
+    ).filter((label) => label.length > 0);
+
+    expect(sanitized).not.toContain("foreignObject");
+    expect(nodeLabels).toEqual(["Start", "Existing?", "Generate"]);
+    expect(edgeLabels).toEqual(["Generate new"]);
+  });
+});

--- a/src/ui/components/ReviewerIdentity/ReviewerIdentity.css
+++ b/src/ui/components/ReviewerIdentity/ReviewerIdentity.css
@@ -1,0 +1,161 @@
+.reviewer-identity {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.45rem 0.25rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-alt);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.reviewer-identity:hover {
+  border-color: var(--text-muted);
+  background: var(--surface);
+}
+
+.reviewer-identity:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.reviewer-identity__avatar {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font: 700 0.62rem/1 var(--font-mono);
+}
+
+.reviewer-identity__details {
+  display: grid;
+  min-width: 0;
+  line-height: 1.05;
+}
+
+.reviewer-identity__details strong {
+  max-width: 10rem;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reviewer-identity__details small {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.reviewer-identity__chevron {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: transform 120ms ease;
+}
+
+.reviewer-identity[aria-expanded="true"] .reviewer-identity__chevron {
+  transform: rotate(180deg);
+}
+
+.reviewer-identity__popover {
+  position: fixed;
+  z-index: 1000;
+  width: min(19rem, calc(100vw - 1rem));
+  padding: 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--surface);
+  box-shadow: 0 14px 36px rgb(0 0 0 / 16%);
+}
+
+.reviewer-identity__label {
+  display: block;
+  margin-bottom: 0.4rem;
+  color: var(--text);
+  font-size: 0.74rem;
+  font-weight: 650;
+}
+
+.reviewer-identity__input {
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 0.45rem;
+  background: var(--surface-alt);
+  color: var(--text);
+  font: 0.8rem/1.2 var(--font-ui);
+}
+
+.reviewer-identity__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.reviewer-identity__help {
+  margin: 0.45rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.64rem;
+  line-height: 1.35;
+}
+
+.reviewer-identity__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.reviewer-identity__cancel,
+.reviewer-identity__save {
+  min-height: 1.9rem;
+  padding: 0 0.7rem;
+  border-radius: 0.4rem;
+  font: 650 0.68rem/1 var(--font-ui);
+  cursor: pointer;
+}
+
+.reviewer-identity__cancel {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.reviewer-identity__save {
+  border: 1px solid var(--text);
+  background: var(--text);
+  color: var(--surface);
+}
+
+.reviewer-identity__cancel:hover {
+  border-color: var(--text-muted);
+  color: var(--text);
+}
+
+.reviewer-identity__save:hover:not(:disabled) {
+  opacity: 0.84;
+}
+
+.reviewer-identity__cancel:focus-visible,
+.reviewer-identity__save:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.reviewer-identity__save:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/ui/components/ReviewerIdentity/ReviewerIdentity.test.tsx
+++ b/src/ui/components/ReviewerIdentity/ReviewerIdentity.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "../../../store";
+import { resetTestStore } from "../../../testing/testHelpers";
+import { ReviewerIdentity } from "./ReviewerIdentity";
+
+describe("ReviewerIdentity", () => {
+  beforeEach(() => {
+    resetTestStore();
+    useAppStore.setState({ peerName: "Ivan T." });
+  });
+
+  it("opens a focused input prefilled with the current name", async () => {
+    const user = userEvent.setup();
+    render(<ReviewerIdentity sharedFileCount={1} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /change reviewer name/i }),
+    );
+
+    const input = screen.getByRole("textbox", { name: "Reviewer name" });
+    expect(input).toHaveValue("Ivan T.");
+    expect(input).toHaveFocus();
+  });
+
+  it("trims and saves the name with Enter", async () => {
+    const user = userEvent.setup();
+    render(<ReviewerIdentity sharedFileCount={1} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /change reviewer name/i }),
+    );
+    const input = screen.getByRole("textbox", { name: "Reviewer name" });
+    await user.clear(input);
+    await user.type(input, "  Ivan Tester  {Enter}");
+
+    expect(useAppStore.getState().peerName).toBe("Ivan Tester");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /currently Ivan Tester/i }),
+    ).toHaveFocus();
+  });
+
+  it("does not allow an empty reviewer name", async () => {
+    const user = userEvent.setup();
+    render(<ReviewerIdentity sharedFileCount={1} />);
+
+    await user.click(
+      screen.getByRole("button", { name: /change reviewer name/i }),
+    );
+    await user.clear(screen.getByRole("textbox", { name: "Reviewer name" }));
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("cancels with Escape and preserves the current name", async () => {
+    const user = userEvent.setup();
+    render(<ReviewerIdentity sharedFileCount={1} />);
+    const identityButton = screen.getByRole("button", {
+      name: /change reviewer name/i,
+    });
+
+    await user.click(identityButton);
+    await user.clear(screen.getByRole("textbox", { name: "Reviewer name" }));
+    await user.type(
+      screen.getByRole("textbox", { name: "Reviewer name" }),
+      "Different name",
+    );
+    await user.keyboard("{Escape}");
+
+    expect(useAppStore.getState().peerName).toBe("Ivan T.");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(identityButton).toHaveFocus();
+  });
+
+  it("dismisses when clicking outside", async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <ReviewerIdentity sharedFileCount={1} />
+        <button type="button">Outside</button>
+      </div>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /change reviewer name/i }),
+    );
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(useAppStore.getState().peerName).toBe("Ivan T.");
+  });
+});

--- a/src/ui/components/ReviewerIdentity/ReviewerIdentity.tsx
+++ b/src/ui/components/ReviewerIdentity/ReviewerIdentity.tsx
@@ -1,0 +1,232 @@
+import "./ReviewerIdentity.css";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useAppStore } from "../../../store";
+import { initials } from "../../../utils/peerDisplay";
+
+const POPOVER_WIDTH = 304;
+const POPOVER_GAP = 8;
+const VIEWPORT_PADDING = 8;
+
+interface PopoverPosition {
+  left: number;
+  top: number;
+}
+
+interface Props {
+  sharedFileCount: number;
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      className="reviewer-identity__chevron"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="m3.5 4.5 2.5 2.5 2.5-2.5"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function ReviewerIdentity({ sharedFileCount }: Props) {
+  const peerName = useAppStore((state) => state.peerName);
+  const setPeerName = useAppStore((state) => state.setPeerName);
+  const [isOpen, setIsOpen] = useState(false);
+  const [draftName, setDraftName] = useState("");
+  const [popoverPosition, setPopoverPosition] =
+    useState<PopoverPosition | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setPopoverPosition(null);
+      return;
+    }
+
+    function updatePopoverPosition() {
+      const button = buttonRef.current;
+      if (!button) {
+        return;
+      }
+
+      const buttonRect = button.getBoundingClientRect();
+      const popoverWidth = Math.min(
+        POPOVER_WIDTH,
+        window.innerWidth - VIEWPORT_PADDING * 2,
+      );
+      const maximumLeft = Math.max(
+        VIEWPORT_PADDING,
+        window.innerWidth - popoverWidth - VIEWPORT_PADDING,
+      );
+      const preferredLeft = buttonRect.right - popoverWidth;
+
+      setPopoverPosition({
+        left: Math.min(Math.max(preferredLeft, VIEWPORT_PADDING), maximumLeft),
+        top: buttonRect.bottom + POPOVER_GAP,
+      });
+    }
+
+    updatePopoverPosition();
+    window.addEventListener("resize", updatePopoverPosition);
+    window.addEventListener("scroll", updatePopoverPosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePopoverPosition);
+      window.removeEventListener("scroll", updatePopoverPosition, true);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleMouseDown(event: MouseEvent) {
+      if (!(event.target instanceof Node)) {
+        return;
+      }
+      const clickedButton = buttonRef.current?.contains(event.target);
+      const clickedPopover = popoverRef.current?.contains(event.target);
+      if (!clickedButton && !clickedPopover) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") {
+        return;
+      }
+      event.preventDefault();
+      setIsOpen(false);
+      buttonRef.current?.focus();
+    }
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  if (!peerName) {
+    return null;
+  }
+
+  function openPopover() {
+    setDraftName(peerName ?? "");
+    setIsOpen(true);
+  }
+
+  function closePopover() {
+    setIsOpen(false);
+    buttonRef.current?.focus();
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedName = draftName.trim();
+    if (!trimmedName) {
+      return;
+    }
+    setPeerName(trimmedName);
+    closePopover();
+  }
+
+  const popover =
+    isOpen && popoverPosition
+      ? createPortal(
+          <div
+            className="reviewer-identity__popover"
+            ref={popoverRef}
+            role="dialog"
+            aria-labelledby="reviewer-name-title"
+            style={popoverPosition}
+          >
+            <form onSubmit={handleSubmit}>
+              <label
+                className="reviewer-identity__label"
+                id="reviewer-name-title"
+                htmlFor="reviewer-name-input"
+              >
+                Reviewer name
+              </label>
+              <input
+                className="reviewer-identity__input"
+                id="reviewer-name-input"
+                type="text"
+                autoComplete="name"
+                autoFocus
+                value={draftName}
+                onChange={(event) => {
+                  setDraftName(event.target.value);
+                }}
+              />
+              <p className="reviewer-identity__help">
+                Updates unsent drafts. Submitted comments keep their original
+                name.
+              </p>
+              <div className="reviewer-identity__actions">
+                <button
+                  className="reviewer-identity__cancel"
+                  type="button"
+                  onClick={closePopover}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="reviewer-identity__save"
+                  type="submit"
+                  disabled={!draftName.trim()}
+                >
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        className="reviewer-identity"
+        type="button"
+        title={`Change reviewer name (currently ${peerName})`}
+        aria-label={`Change reviewer name. Currently ${peerName}`}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls="reviewer-name-input"
+        onClick={() => {
+          if (isOpen) {
+            closePopover();
+            return;
+          }
+          openPopover();
+        }}
+      >
+        <span className="reviewer-identity__avatar">{initials(peerName)}</span>
+        <span className="reviewer-identity__details">
+          <strong>{peerName}</strong>
+          <small>
+            {sharedFileCount} shared {sharedFileCount === 1 ? "file" : "files"}
+          </small>
+        </span>
+        <ChevronIcon />
+      </button>
+      {popover}
+    </>
+  );
+}

--- a/src/ui/components/ReviewerIdentity/index.ts
+++ b/src/ui/components/ReviewerIdentity/index.ts
@@ -1,0 +1,1 @@
+export { ReviewerIdentity } from "./ReviewerIdentity";


### PR DESCRIPTION
## Summary
- keep Mermaid node and edge labels visible after SVG sanitization
- let peer reviewers change their browser-local display name from the header
- rename unsent drafts while preserving submitted comment authors
- align peer-sharing documentation with localStorage behavior

## Validation
- npm run validate
- 80 test files, 654 tests passed
- production build and bundle budgets passed