### PR TITLE
Fix code preview commenting and dark theme contrast

### DIFF
--- a/docs/features/criticmarkup-comments.md
+++ b/docs/features/criticmarkup-comments.md
@@ -226,6 +226,16 @@ Intersecting ranges render as constant-coverage segments. Shared segments stack
 their tints and underline stripes, expose all comment IDs through `data-cids`,
 and cycle the selected comment when activated repeatedly.
 
+Fenced code blocks retain their line-comment gutter after asynchronous syntax
+highlighting completes. Hovering or focusing the block reveals its line
+numbers; hovering or focusing a non-empty line changes its number to `+`, and
+activating it opens the range-aware composer for that exact line. This behavior
+applies to every supported highlighted language and to unlabelled code fences.
+Syntax-highlighted tokens carry paired light and dark palettes; the active app
+theme selects the matching foreground colors while the code container continues
+to use the semantic document background. Dark mode must not reuse light-theme
+inline token colors.
+
 ### 6.5 Why This Works
 
 For standard comments, the LLM reads the file and sees comments as part of the content — no separate protocol to learn. CriticMarkup is well-represented in LLM training data, so models already understand it. For threaded `question:` comments, MarkReview adds a small metadata extension plus the unified review prompt so replies stay linked without introducing sidecar files. Comments and content still stay in sync because everything lives in the same file. Any text editor can view and edit the annotations. No sidecar files, no sync issues, no export/import steps.

--- a/src/markup/createShikiHighlighter.test.ts
+++ b/src/markup/createShikiHighlighter.test.ts
@@ -1,0 +1,20 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { createApplicationHighlighter } from "./createShikiHighlighter";
+
+const highlighter = await createApplicationHighlighter();
+
+afterAll(() => {
+  highlighter.dispose();
+});
+
+describe("createApplicationHighlighter", () => {
+  it("emits paired light and dark token colors", () => {
+    const highlightedTree = highlighter.codeToHast("const value = 1", {
+      lang: "typescript",
+      themes: { light: "github-light", dark: "github-dark" },
+      defaultColor: false,
+    });
+
+    expect(JSON.stringify(highlightedTree)).toContain("--shiki-dark");
+  });
+});

--- a/src/markup/createShikiHighlighter.ts
+++ b/src/markup/createShikiHighlighter.ts
@@ -1,5 +1,6 @@
 import { createHighlighterCore } from "shiki/core";
 import { createOnigurumaEngine } from "shiki/engine/oniguruma";
+import githubDark from "@shikijs/themes/github-dark";
 import githubLight from "@shikijs/themes/github-light";
 import bash from "@shikijs/langs/bash";
 import c from "@shikijs/langs/c";
@@ -21,7 +22,7 @@ import yaml from "@shikijs/langs/yaml";
 
 export async function createApplicationHighlighter() {
   return createHighlighterCore({
-    themes: [githubLight],
+    themes: [githubLight, githubDark],
     langs: [
       ...bash,
       ...c,

--- a/src/markup/useShikiRehypePlugin.ts
+++ b/src/markup/useShikiRehypePlugin.ts
@@ -16,7 +16,11 @@ function getHighlighter(): Promise<HighlighterCore> {
 type RehypePlugin = [
   typeof rehypeShikiFromHighlighter,
   HighlighterCore,
-  { theme: string; missingLang: string },
+  {
+    themes: { light: string; dark: string };
+    defaultColor: boolean;
+    missingLang: string;
+  },
 ];
 
 export function useShikiRehypePlugin(): RehypePlugin | null {
@@ -46,6 +50,10 @@ export function useShikiRehypePlugin(): RehypePlugin | null {
   return [
     rehypeShikiFromHighlighter,
     highlighter,
-    { theme: "github-light", missingLang: "ignore" },
+    {
+      themes: { light: "github-light", dark: "github-dark" },
+      defaultColor: false,
+      missingLang: "ignore",
+    },
   ];
 }

--- a/src/ui/components/CodeCommentSurface/CodeCommentSurface.css
+++ b/src/ui/components/CodeCommentSurface/CodeCommentSurface.css
@@ -76,6 +76,15 @@
 .code-comment-surface__pre code {
   display: block;
   min-height: 1.65em;
+  color: var(--ink);
   font-family: var(--font-mono);
   line-height: 1.65;
+}
+
+.code-comment-surface__pre code span {
+  color: var(--shiki-light, inherit);
+}
+
+.dark .code-comment-surface__pre code span {
+  color: var(--shiki-dark, inherit);
 }

--- a/src/ui/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/ui/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -240,7 +240,7 @@ function MarkdownRendererContent({
   }, [openDirectoryInNewTab, openFileInNewTab, restoreTabState.directoryName]);
 
   const rehypePlugins: PluggableList = shikiPlugin
-    ? [rehypeBlockIndex, shikiPlugin]
+    ? [shikiPlugin, rehypeBlockIndex]
     : [rehypeBlockIndex];
 
   return (

--- a/src/ui/components/MarkdownRenderer/codeHighlighting.test.tsx
+++ b/src/ui/components/MarkdownRenderer/codeHighlighting.test.tsx
@@ -1,10 +1,23 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resetTestStore, setTestState } from "../../../testing/testHelpers";
 
+interface TestHastNode {
+  type: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: TestHastNode[];
+  value?: string;
+}
+
+interface TestHastRoot extends TestHastNode {
+  children: TestHastNode[];
+}
+
 const shikiMocks = vi.hoisted(() => {
-  const highlighter = {
-    codeToHast: vi.fn().mockReturnValue({
+  function buildHighlightedCodeTree(): TestHastRoot {
+    return {
       type: "root",
       children: [
         {
@@ -21,7 +34,18 @@ const shikiMocks = vi.hoisted(() => {
           ],
         },
       ],
-    }),
+    };
+  }
+  const highlighter = {
+    codeToHast: vi.fn(buildHighlightedCodeTree),
+  };
+  const transformCodeBlocks = (tree: TestHastRoot) => {
+    tree.children = tree.children.map((node) => {
+      if (node.type === "element" && node.tagName === "pre") {
+        return highlighter.codeToHast();
+      }
+      return node;
+    });
   };
   let resolveHighlighter: ((value: typeof highlighter) => void) | null = null;
   const highlighterPromise = new Promise<typeof highlighter>((resolve) => {
@@ -30,6 +54,7 @@ const shikiMocks = vi.hoisted(() => {
 
   return {
     createApplicationHighlighter: vi.fn(() => highlighterPromise),
+    transformCodeBlocks,
     resolve() {
       if (!resolveHighlighter) {
         throw new Error("Shiki test promise was not initialized");
@@ -44,7 +69,7 @@ vi.mock("../../../markup/createShikiHighlighter", () => ({
 }));
 
 vi.mock("@shikijs/rehype/core", () => ({
-  default: vi.fn(() => () => {}),
+  default: vi.fn(() => shikiMocks.transformCodeBlocks),
 }));
 
 beforeEach(() => {
@@ -69,6 +94,12 @@ describe("MarkdownRenderer — Shiki integration", () => {
       shikiMocks.resolve();
       await Promise.resolve();
     });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Comment on line 1" }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("applies the Shiki rehype plugin after the highlighter is ready", async () => {
@@ -80,7 +111,27 @@ describe("MarkdownRenderer — Shiki integration", () => {
     render(<MarkdownRenderer />);
 
     await waitFor(() => {
-      expect(rehypeShikiFromHighlighter).toHaveBeenCalled();
+      expect(rehypeShikiFromHighlighter).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          themes: { light: "github-light", dark: "github-dark" },
+          defaultColor: false,
+          missingLang: "ignore",
+        },
+      );
     });
+  });
+
+  it("uses Shiki's dark token colors inside dark code surfaces", () => {
+    const codeSurfaceCss = readFileSync(
+      "src/ui/components/CodeCommentSurface/CodeCommentSurface.css",
+      "utf8",
+    );
+
+    expect(codeSurfaceCss).toContain(
+      ".dark .code-comment-surface__pre code span",
+    );
+    expect(codeSurfaceCss).toContain("color: var(--shiki-light, inherit)");
+    expect(codeSurfaceCss).toContain("color: var(--shiki-dark, inherit)");
   });
 });

--- a/src/ui/components/MarkdownRenderer/rehypeBlockIndex.test.ts
+++ b/src/ui/components/MarkdownRenderer/rehypeBlockIndex.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { rehypeBlockIndex } from "./rehypeBlockIndex";
+
+describe("rehypeBlockIndex", () => {
+  it("indexes a highlighted pre nested in Shiki's root wrapper", () => {
+    const paragraph = {
+      type: "element",
+      properties: {},
+    };
+    const highlightedPre = {
+      type: "element",
+      properties: { className: ["shiki", "github-light"] },
+    };
+    const tree = {
+      children: [
+        paragraph,
+        {
+          type: "root",
+          children: [highlightedPre],
+        },
+      ],
+    };
+
+    rehypeBlockIndex()(tree);
+
+    expect(paragraph.properties["data-block-index"]).toBe(0);
+    expect(highlightedPre.properties["data-block-index"]).toBe(1);
+  });
+});

--- a/src/ui/components/MarkdownRenderer/rehypeBlockIndex.ts
+++ b/src/ui/components/MarkdownRenderer/rehypeBlockIndex.ts
@@ -1,14 +1,36 @@
+interface BlockIndexNode {
+  type: string;
+  properties?: Record<string, unknown>;
+  children?: BlockIndexNode[];
+}
+
+function findRenderedBlock(node: BlockIndexNode): BlockIndexNode | null {
+  if (node.type === "element") {
+    return node;
+  }
+  if (node.type !== "root" || !node.children) {
+    return null;
+  }
+  for (const childNode of node.children) {
+    const renderedBlock = findRenderedBlock(childNode);
+    if (renderedBlock) {
+      return renderedBlock;
+    }
+  }
+  return null;
+}
+
 export function rehypeBlockIndex() {
-  return (tree: {
-    children: Array<{ type: string; properties?: Record<string, unknown> }>;
-  }) => {
+  return (tree: { children: BlockIndexNode[] }) => {
     let blockIndex = 0;
     for (const node of tree.children) {
-      if (node.type === "element") {
-        node.properties = node.properties ?? {};
-        node.properties["data-block-index"] = blockIndex;
-        blockIndex += 1;
+      const renderedBlock = findRenderedBlock(node);
+      if (!renderedBlock) {
+        continue;
       }
+      renderedBlock.properties = renderedBlock.properties ?? {};
+      renderedBlock.properties["data-block-index"] = blockIndex;
+      blockIndex += 1;
     }
   };
 }


### PR DESCRIPTION
## Summary
- preserve code-line comment gutters after asynchronous Shiki highlighting
- emit paired light and dark syntax palettes and select the active theme in CSS
- document and regression-test highlighted code commenting and dark-mode readability

## Validation
- npm run validate
- 82 test files, 658 tests
- production build and bundle budgets passed