### PR TITLE
Harden real-time review comment infrastructure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,6 +84,7 @@ Host mode state is tab-scoped.
 
 Each `TabState` may include:
 
+- a stable `workspaceId` independent of its display name
 - file or directory session handles
 - file tree and active file path
 - raw markdown content
@@ -105,6 +106,7 @@ This includes:
 - peer draft comments
 - submitted peer comment ids
 - peer name and panel state
+- the current peer submission subscription generation and phase
 
 Peer mode should read directly from root `peer*` fields, not from tabs.
 
@@ -235,6 +237,8 @@ Owns host-side sharing lifecycle:
 - active share selection
 - pending incoming peer comments
 - queued resolve ids
+- stable share-to-workspace ownership
+- per-share incoming subscription and quarantine state
 
 ### `peer-review`
 
@@ -254,6 +258,8 @@ Owns relay transport runtime:
 - document update availability
 - subscribe and unsubscribe orchestration
 - reconnect and resend behavior
+- subscription-generation filtering and ordered event application
+- external payload validation and bounded content-free diagnostics
 
 ## Controller vs State
 
@@ -349,14 +355,20 @@ entire store.
 
 ## Persistence
 
-Persistence remains centralized in the root store for now.
+Serializable UI/session metadata remains in the root store. Large document text
+is persisted separately per stable workspace, so an inbox update does not
+serialize every open document. Share ownership has its own registry keyed by
+workspace ID, and resolve intent has a dedicated outbox that is written before
+an incoming item is hidden.
 
-The persisted store contains app state and migrations, while mutable runtime
-objects such as WebSocket instances, timers, and DOM references stay outside the
-store.
+Mutable runtime objects such as WebSocket instances, event queues, timers, and
+DOM references stay outside the store. Local persistence adapters contain
+storage availability and quota failures at their boundary instead of allowing
+them to crash relay processing or rendering.
 
-Modules may own their own local persistence adapters when the persistence is
-part of the feature itself, such as share records or file-session handles.
+The share-registry migration is additive: a legacy display-name binding is
+copied only when exactly one workspace matches. Ambiguous records stay unbound,
+and the legacy registry remains available during the compatibility window.
 
 Backward-compatibility logic for persisted state should stay intentional.
 Migrations and legacy restore behavior should not be removed casually.

--- a/docs/features/peer-sharing.md
+++ b/docs/features/peer-sharing.md
@@ -1,8 +1,8 @@
-# MarkReview v2 — Peer Sharing & Async Collaboration
+# MarkReview v2 — Peer Sharing & Durable Review
 
 ## 1. Overview
 
-MarkReview v2 adds the ability to share documents with 2–5 remote peers for review and commenting. The architecture uses a single Cloudflare Worker + KV as an encrypted blob store for both content delivery and comment collection. All content is encrypted client-side before leaving the browser. Peers need nothing but a browser and a link.
+MarkReview v2 adds the ability to share documents with 2–5 remote peers for review and commenting. A Cloudflare Worker stores encrypted document content in KV and routes encrypted unresolved comments through a SQLite-backed Durable Object. All content is encrypted client-side before leaving the browser. Peers need nothing but a browser and a link.
 
 ---
 
@@ -31,45 +31,45 @@ v1 is single-user. This release adds peer sharing.
 
 ```
 ┌─────────────────────────────────────────────────┐
-│            Cloudflare Worker + KV                │
-│        (async encrypted blob storage)            │
+│      Cloudflare Worker + KV + Durable Object     │
 │                                                  │
 │  Content:                                        │
 │  - Host encrypts files client-side (AES-256)     │
-│  - Uploads encrypted blob → Worker stores in KV  │
+│  - Uploads encrypted blob → KV                   │
 │  - Peers fetch blob, decrypt in browser          │
 │  - Works anytime, host doesn't need to be online │
 │                                                  │
 │  Comments:                                       │
 │  - Peers encrypt comments client-side            │
-│  - POST to Worker → stored in KV                 │
-│  - Host fetches and merges into local files      │
+│  - WebSocket relay → Durable Object SQLite       │
+│  - Host receives live, then merges locally       │
 │  - No auth needed from peers                     │
 │                                                  │
-│  Auto-purge via KV TTL (default 7 days)          │
+│  KV TTL + Durable Object alarms purge expired data│
 └─────────────────────────────────────────────────┘
 ```
 
-The entire sharing flow is async. Host uploads, peers read and comment on their own time, host checks comments when ready. No one needs to be online simultaneously.
+Document access and unresolved comments are durable, so host and peers do not
+need to be online simultaneously. When they are online, WebSocket subscriptions
+deliver comment and document-update notifications immediately.
 
 ### 4.2 Cloudflare Worker API
 
-A single Cloudflare Worker (~30 lines) backed by one KV namespace. Six endpoints:
+A single Cloudflare Worker exposes encrypted share-content endpoints and a
+WebSocket relay:
 
 ```
-POST   /share                 ← host uploads encrypted content blob → returns doc-id
+POST   /share/{doc-id}        ← host uploads encrypted content
+HEAD   /share/{doc-id}        ← client checks whether content changed
 GET    /share/{doc-id}        ← anyone fetches encrypted content (no auth)
-DELETE /share/{doc-id}        ← host deletes content (requires host-secret header)
-
-POST   /comments/{doc-id}    ← anyone posts encrypted comment blob (no auth)
-GET    /comments/{doc-id}    ← anyone fetches all pending comments (no auth)
-DELETE /comments/{doc-id}    ← host clears comments (requires host-secret header)
+DELETE /share/{doc-id}        ← host revokes content and comments
+GET    /relay                 ← host/peer WebSocket transport
 ```
 
-- All blobs are opaque encrypted binary. The Worker never sees plaintext.
+- Content and comment payloads are opaque encrypted values. The Worker never sees plaintext.
 - `doc-id` is a random UUID generated client-side.
 - `host-secret` is a random token generated at share time, stored only in the host's browser. Used for delete operations.
-- KV TTL handles auto-expiry. Default: 7 days. Configurable per share.
+- KV TTL and Durable Object alarms handle auto-expiry. Default: 7 days.
 - No authentication, no accounts, no user data stored.
 
 ### 4.3 Shareable Link Structure
@@ -100,7 +100,8 @@ The URL fragment (`#`) is never sent in HTTP requests. GitHub Pages, Cloudflare,
 
 - Comments are encrypted with the same AES-256-GCM key as the content.
 - Peers have the key from the URL fragment.
-- Each comment is a separate encrypted blob stored under the doc-id.
+- Each unresolved comment is an encrypted payload stored under the document and
+  comment IDs in Durable Object SQLite.
 - Cloudflare cannot read comment content.
 
 ---
@@ -198,13 +199,13 @@ Acceptance criteria:
 - Hostile SVG fixtures cover script, event, URL, embedded-content, and CSS
   payloads.
 
-### 7.3 Async Commenting
+### 7.3 Durable Commenting
 
 Peers can comment on any block or a selection of at least 3 characters within
-one rendered block, just like the host. There is no maximum selection length.
-The app encrypts the block reference and optional durable range anchor, then
-POSTs the comment to the Worker's comment endpoint. No auth or account is
-needed.
+one rendered block, just like the host. Comment and quote fields are bounded at
+400 KiB each so a malicious or accidental payload cannot exhaust a receiving
+tab. The app encrypts the block reference and optional durable range anchor,
+then sends the comment through the relay. No account is needed.
 
 The host receives pending comments through the relay, decrypts them, and sees
 them in the **Incoming** view of the normal Comments panel. The Comments header
@@ -245,7 +246,8 @@ The host has one Share sheet for creation and management. It shows all active sh
 - "Copy link" button — reconstructs and copies that existing share URL without
   uploading content again or changing the selected creation scope.
 - "Revoke" button — deletes the content and comments from the Worker immediately.
-- Share metadata (doc-id, host-secret) is stored in the host's browser localStorage.
+- Share metadata is bound to a stable workspace ID in the host's browser. A
+  same-named workspace cannot silently claim another workspace's link.
 
 Comment review is intentionally absent from the Share sheet. Incoming feedback
 belongs to the host Comments panel; the Share sheet only manages links.
@@ -324,6 +326,8 @@ because the active tab's `shares`, `shareKeys`, or `activeDocId` changed.
 
 - One Cloudflare Worker (free tier: 100K requests/day).
 - One KV namespace (free tier: 10GB storage, 100K reads/day, 1K writes/day).
+- One SQLite-backed Durable Object relay for unresolved comments and live
+  routing.
 - Deployed once via `wrangler deploy`. No ongoing maintenance.
 
 ### 9.2 KV Key Schema
@@ -331,19 +335,26 @@ because the active tab's `shares`, `shareKeys`, or `activeDocId` changed.
 ```
 share:{doc-id}                    → encrypted content blob (TTL: 7 days default)
 share:{doc-id}:meta               → { host_secret_hash, created_at, ttl } (plaintext metadata)
-comments:{doc-id}:{comment-id}    → encrypted comment blob (TTL: 7 days)
 ```
+
+Unresolved encrypted comments live in the Durable Object's `comments` table,
+keyed by `(doc_id, cmt_id)`. `doc_meta` carries the verified host-secret hash
+and expiry used by relay subscriptions.
 
 ### 9.3 Security
 
 - `host-secret` is generated client-side at share time and hashed (SHA-256) before storing in KV metadata.
-- DELETE operations require the raw `host-secret` in a header. The Worker hashes it and compares.
+- Host relay subscriptions and delete operations require the raw `host-secret`.
+  The Worker hashes it and compares it with stored metadata.
 - No other authentication exists. Content security relies entirely on client-side encryption.
 - The Worker never decrypts anything. It is a dumb blob store.
 
 ### 9.4 Rate Limiting
 
-- The Worker should enforce basic rate limiting to prevent abuse: max 100 writes per IP per hour, max 10MB per blob.
+- Relay comment writes are limited to 60 per socket per minute. Plain relay
+  frames are limited to 1.5 MiB and encrypted comment payloads to 1 MiB.
+- Reconnect snapshots are chunked below the frame limit. One document can hold
+  at most 500 unresolved comments and 8 MiB of encoded encrypted payloads.
 - Cloudflare's free tier limits provide a natural ceiling.
 
 ### 9.5 CORS
@@ -355,20 +366,22 @@ comments:{doc-id}:{comment-id}    → encrypted comment blob (TTL: 7 days)
 ## 10. Technical Stack
 
 - **Encryption:** Web Crypto API (AES-256-GCM, native browser implementation)
-- **Async storage:** Cloudflare Worker + KV (encrypted blob store)
+- **Durable storage:** Cloudflare KV for encrypted content; Durable Object
+  SQLite for encrypted unresolved comments
+- **Live transport:** Durable Object WebSocket relay
 - **Hosting:** GitHub Pages (static site)
 
 ---
 
 ## 11. Security Model
 
-| Layer                 | What's protected               | How                                   |
-| --------------------- | ------------------------------ | ------------------------------------- |
-| Content at rest (KV)  | File content                   | AES-256-GCM, key in URL fragment only |
-| Comments at rest (KV) | Peer comments                  | AES-256-GCM, same key                 |
-| Content in transit    | Worker requests                | TLS (Cloudflare)                      |
-| Cloudflare Worker/KV  | Cannot read anything           | Only stores encrypted blobs           |
-| Delete operations     | Prevents unauthorized deletion | host-secret header, hashed in KV      |
+| Layer                 | What's protected            | How                                   |
+| --------------------- | --------------------------- | ------------------------------------- |
+| Content at rest (KV)  | File content                | AES-256-GCM, key in URL fragment only |
+| Comments at rest (DO) | Unresolved peer comments    | AES-256-GCM, same key                 |
+| Content in transit    | Worker and relay requests   | TLS (Cloudflare)                      |
+| Cloudflare services   | Cannot read review content  | Only store/route encrypted payloads   |
+| Host operations       | Resolve, update, and revoke | Verified host secret                  |
 
 **What an attacker would need to compromise content:** The full URL including the fragment. The fragment is never logged by any server, never appears in HTTP requests, and is only shared directly between host and peers.
 
@@ -376,11 +389,12 @@ comments:{doc-id}:{comment-id}    → encrypted comment blob (TTL: 7 days)
 
 ## 12. Purge & Lifecycle
 
-- Every blob in KV has a TTL (default 7 days, configurable at share time).
-- KV auto-deletes expired blobs. No cron jobs, no manual cleanup.
+- Every content blob in KV has a TTL (default 7 days, configurable at share time).
+- Durable Object alarms remove expired comment rows and metadata.
 - Host can manually revoke any share via the "Revoke" button, which calls DELETE on the Worker.
 - After deletion, peers with the link see: "This document is no longer available."
-- No data persists anywhere after purge. Cloudflare deletes the encrypted blobs. The decryption key only existed in the URL and the host's browser.
+- No review data persists after both stores complete purge. The decryption key
+  only existed in the URL and the host's browser.
 
 ---
 
@@ -395,13 +409,11 @@ interface ShareStorage {
   ): Promise<{ docId: string; hostSecret: string }>;
   fetchContent(docId: string): Promise<ArrayBuffer>;
   deleteContent(docId: string, hostSecret: string): Promise<void>;
-  postComment(docId: string, blob: ArrayBuffer): Promise<string>;
-  fetchComments(docId: string): Promise<ArrayBuffer[]>;
-  deleteComments(docId: string, hostSecret: string): Promise<void>;
 }
 ```
 
-If the storage backend needs to change in the future, only the implementation of this interface changes. The rest of the app is unaffected.
+Comment persistence and delivery are a separate relay module contract rather
+than methods on content storage.
 
 ---
 
@@ -411,7 +423,9 @@ If the storage backend needs to change in the future, only the implementation of
 - **Worker is a single point of failure for sharing.** If Cloudflare is down, sharing doesn't work. Local editing is unaffected.
 - **Blob size limit.** KV values max out at 25MB. Sufficient for hundreds of markdown files. If exceeded, the app splits across multiple KV entries.
 - **Free tier limits.** 100K requests/day and 1K writes/day. More than enough for 2–5 peers. If exceeded, Cloudflare's paid tier is $5/month.
-- **No real-time sync.** Comments are async. Host must manually check for new comments. Acceptable for the review workflow. Real-time sync is planned for v3.
+- **Relay dependency for new submissions.** A peer draft stays local until its
+  document subscription is confirmed. Previously stored unresolved comments
+  remain durable during disconnects.
 - **No authenticated identity.** Peers self-declare a browser-local display
   name that persists in localStorage. There are no accounts. For 2–5 trusted
   peers this is acceptable.
@@ -428,19 +442,27 @@ If the storage backend needs to change in the future, only the implementation of
 - Shared panel for host to manage, update, and revoke shares.
 - Auto-purge via KV TTL.
 
-### Phase 2b — Async Commenting
+### Phase 2b — Durable Commenting
 
-- Peers can post encrypted comments to the Worker.
-- Host can fetch, decrypt, review, and merge comments into local files.
+- Peers can post encrypted comments through the relay.
+- Host receives, decrypts, reviews, and merges comments into local files.
 - Comment merge inserts CriticMarkup into the appropriate file locations.
 - Incoming review workflow in the host Comments panel.
 - Numeric incoming badge on the Comments header action.
 
+### Phase 2c — Review Reliability
+
+- Generation-scoped, ordered relay subscriptions.
+- Stable workspace ownership and additive legacy registry migration.
+- Durable resolve outbox and scoped document-content persistence.
+- Fail-closed, idempotent merge with anchor and content checks.
+- Payload validation, rate limits, quarantine, and per-document render recovery.
+
 ---
 
-## 16. Future (v3) — Real-Time Collaboration
+## 16. Future (v3) — Collaborative Editing
 
-If the async workflow proves insufficient, v3 adds real-time sync:
+Live comment delivery exists in v2. A future collaborative-editing phase may add:
 
 - WebRTC via Trystero for peer discovery and direct browser-to-browser connections.
 - Yjs + y-webrtc-trystero for CRDT-based conflict-free comment sync.

--- a/docs/features/realtime-comments/spec.md
+++ b/docs/features/realtime-comments/spec.md
@@ -28,6 +28,15 @@ Host-authored local comments remain local-only. They are merged directly into th
 - As a peer with unsent feedback, I want Submit comments to remain a prominent,
   counted primary action until my feedback is sent.
 - As a host reconnecting after a disconnect, I want the current unresolved comment set restored from the backend without merge-by-ID heuristics.
+- As a host receiving a snapshot while comments are also arriving live, I want
+  both inputs applied in relay order so a late snapshot cannot erase newer
+  feedback.
+- As a host with two workspaces that have the same display name, I want each
+  share to stay attached to the workspace that created it.
+- As a host merging feedback after the file changed, I want the merge to stop
+  instead of writing a comment onto the wrong text or wrong tab.
+- As a host receiving malformed or oversized feedback, I want that item isolated
+  while the rest of the review session remains usable.
 - As a peer reopening a shared document, I want the document content to reload cleanly and I want previously submitted comments to avoid duplicate submission.
 - As a peer reconnecting with unsent comments on multiple shared files, I want all unsent comments retried instead of only the currently open file.
 - As a peer viewing a shared document with no local comment work in progress, I want newer shared content to load automatically so I stay on the latest version.
@@ -118,11 +127,11 @@ Key decisions:
 
 ### Plaintext control frames
 
-- `subscribe { docId, role, hostSecret? }`
-- `unsubscribe { docId }`
+- `subscribe { docId, role, hostSecret?, subscriptionId? }`
+- `unsubscribe { docId, subscriptionId? }`
 - `ping`
-- `comment:add { docId, cmtId, payload }`
-- `comment:resolve { docId, cmtId }`
+- `comment:add { docId, cmtId, payload, subscriptionId? }`
+- `comment:resolve { docId, cmtId, subscriptionId? }`
 
 ### DO responses
 
@@ -134,6 +143,23 @@ Key decisions:
 - `comments:snapshot`
 - `comment:added`
 - `comment:resolved`
+
+`subscriptionId` identifies one client-side subscription generation. The DO
+echoes it on subscription responses, snapshots, acknowledgements, forwarded
+events, and subscription-scoped errors. Clients ignore responses for older
+generations. It remains optional so clients and Durable Objects can be deployed
+independently during the compatibility window.
+
+For generation-aware clients, `comments:snapshot` also carries `snapshotId`,
+`chunkIndex`, and `chunkCount`. The host buffers bounded chunks and applies the
+snapshot only after all chunks arrive. Legacy clients without a subscription ID
+continue to receive the original single-frame snapshot during the compatibility
+window.
+
+Errors distinguish `scope: "subscription"` from `scope: "operation"`.
+Subscription errors fail that document subscription. An operation error rejects
+only the referenced comment operation, is shown to the initiating user, and does
+not tear down an otherwise live subscription.
 
 ### Encrypted relay payloads
 
@@ -167,15 +193,20 @@ Opening the host share dialog is not part of share creation itself. For folder s
 2. DO verifies `hostSecret`.
 3. DO replies with `subscribe:ok`.
 4. DO sends `comments:snapshot` containing the full unresolved set for that `docId`.
-5. Host replaces pending comments for that share with the snapshot, filtered against locally queued resolves.
+5. Host applies the snapshot on the subscription's ordered event queue, filtered
+   against locally queued resolves. Later `comment:added` events cannot be
+   overtaken by a slow snapshot decrypt.
 
 ### Host merge / dismiss
 
 1. Host opens the Comments panel. Incoming feedback is the initial view when
    unresolved peer comments exist.
 2. Host merges or dismisses a peer comment from its incoming card.
-3. Host removes it from current pending UI state.
-4. Host queues the resolve locally and flushes `comment:resolve`.
+3. For a merge, the host verifies the owning workspace, file target, current
+   content hash, and anchor before writing. The deterministic embedded comment
+   ID makes retry idempotent.
+4. Host durably queues the resolve locally before removing it from current
+   pending UI state, then flushes `comment:resolve`.
 5. DO deletes the comment row from SQLite.
 6. DO sends `comment:resolve:ack` to the host.
 7. DO broadcasts `comment:resolved` to subscribers.
@@ -213,6 +244,22 @@ Obsolete note:
 11. When unsent peer comments exist, Submit comments uses the primary button
     treatment, shows a separate count, and remains labeled through the tablet
     header breakpoint.
+12. `ConnectionStatus` reports Live only after the visible document's current
+    subscription generation is confirmed; a connected socket alone is not Live.
+13. A slow snapshot cannot erase a later live comment from the same subscription.
+14. Two same-named workspaces keep distinct share ownership through stable
+    workspace IDs. An ambiguous legacy name-based share is left unbound.
+15. Merge targets the share-owning tab and fails closed if its file, content, or
+    anchor changed while the operation was pending. Retrying a completed merge
+    does not insert a duplicate comment.
+16. A resolve is persisted locally before its comment disappears from the UI, so
+    reload or reconnect cannot resurrect a locally completed review action.
+17. One invalid encrypted comment is quarantined and surfaced as a bounded
+    notice; valid comments and the rest of the application remain usable.
+18. Relay frames, IDs, encrypted payloads, comment text, and quote text are
+    bounded and malformed values are rejected at the network boundary.
+19. A reconnect snapshot larger than one safe relay frame is delivered in
+    ordered chunks and applied atomically before later live events.
 
 ## 9. Limitations
 
@@ -222,6 +269,15 @@ Obsolete note:
 - A single relay hub is sufficient for the current scale but not intended for large fan-out.
 - `document:updated` is a live notification, not a durable event log. Share content itself remains durable in KV.
 - Peer comment submission depends on relay connectivity. Unsynced peer drafts stay local until relay subscribe succeeds.
+- Plain relay frames are capped at 1.5 MiB and encrypted comment payloads at
+  1 MiB. New peer comment and quote fields are capped at 400 KiB each. The
+  earlier peer-sharing statement that selection length had no maximum is no
+  longer valid because an unbounded client payload can crash a host tab.
+- The relay rate-limits comment writes per socket. This is abuse containment,
+  not peer identity or account authentication.
+- Each document is bounded to 500 unresolved comments and 8 MiB of encoded
+  encrypted comment payloads. A peer receives an operation error when the inbox
+  is full; the confirmed subscription remains live.
 
 ## 10. Why This Replaced The Old Model
 

--- a/docs/features/realtime-comments/technical-design.md
+++ b/docs/features/realtime-comments/technical-design.md
@@ -116,27 +116,69 @@ This is lightweight role enforcement, not a full identity system.
 
 The relay also validates that the decrypted peer comment payload `id` matches the frame `cmtId`. That keeps frame identity authoritative and prevents ID drift.
 
+Every new client subscription has a generated `subscriptionId`. The client adds
+it to subscribe and comment operations; the Durable Object echoes the recipient's
+ID on responses, snapshots, and forwarded events. A response carrying an older
+ID is ignored. Missing IDs remain accepted for the deployment compatibility
+window.
+
+The client serializes all snapshot and live-event work per
+`(docId, subscriptionId)`. Decryption may be asynchronous, but later events do
+not commit before earlier ones. Worker errors are scoped to either the whole
+subscription or one operation so one rejected comment cannot falsely take the
+document offline.
+
+Generation-aware snapshots are chunked below the inbound frame ceiling. Each
+chunk carries `snapshotId`, `chunkIndex`, and `chunkCount`; the client applies
+the reassembled bounded snapshot atomically. The Durable Object also caps one
+document at 500 unresolved rows and 8 MiB of encoded payload text, preventing a
+valid collection of rows from becoming an unbounded reconnect allocation.
+
 ## 6. Client State Shape
 
 ### Host tab state
 
 Existing `TabState` fields remain the source of host review state:
 
+- `workspaceId`
 - `pendingComments`
 - `pendingResolveCommentIds`
 - `shares`
 - `shareKeys`
+- `incomingReviewSessions`
+
+`incomingReviewSessions[docId]` records the owning workspace, current host
+subscription generation and phase, and bounded quarantine notices. Share
+ownership is keyed by `workspaceId`, not a display name or whichever tab happens
+to be active.
 
 ### Global store state
 
 - `relayStatus`
 - `documentUpdateAvailable`
+- `peerSubmissionSubscription`
 - peer-mode share content fields
 - `peerDraftCommentOpen`
 - `myPeerComments`
 - `submittedPeerCommentIds`
 
-The WebSocket instance and timers stay in `src/services/relay.ts`, not in the Zustand store.
+The WebSocket instance, reconnect timer, ordered event queues, and bounded
+content-free diagnostics stay in `src/modules/relay/controller.ts` and
+`src/modules/relay/diagnostics.ts`, not in the Zustand store.
+
+### Local persistence boundaries
+
+- `markreview-shares-v2` binds each `docId` to its stable `workspaceId`. Legacy
+  name-based records are copied only when ownership is unambiguous; ambiguous
+  records remain unbound and the old registry is retained.
+- `markreview-resolve-outbox-v1` is a dedicated durable outbox. Merge, dismiss,
+  clear, and quarantine dismissal persist a resolve ID before hiding the item.
+- document text is stored in a per-workspace content cache instead of the root
+  Zustand blob. Relay inbox updates therefore do not rewrite every open
+  document's content.
+- all local-storage adapters contain quota and availability failures. A storage
+  exception becomes an explicit failed action or warning, not an uncaught render
+  failure.
 
 ## 7. Core Interaction Flows
 
@@ -161,21 +203,41 @@ The WebSocket instance and timers stay in `src/services/relay.ts`, not in the Zu
 
 1. Host opens relay and subscribes with `hostSecret`.
 2. DO verifies host role and responds `subscribe:ok`.
-3. DO immediately sends `comments:snapshot`.
-4. Client decrypts each entry and calls `replaceCommentsSnapshot`.
+3. DO immediately sends `comments:snapshot` carrying that subscription's ID.
+4. Client decrypts and applies it on that subscription's ordered queue before
+   processing later live events.
 5. Locally queued resolve IDs are filtered out so reconnect does not resurrect comments already removed in this session.
 
 ### 7.3 Host merge / dismiss
 
-1. Host removes the comment from pending review state.
-2. Host queues the comment ID in `pendingResolveCommentIds`.
-3. `flushPendingCommentResolves()` sends `comment:resolve` for queued IDs once the relay is confirmed.
-4. DO deletes the row from SQLite.
-5. DO replies with `comment:resolve:ack`.
-6. Client removes the queued resolve entry.
-7. DO broadcasts `comment:resolved` to subscribers.
+1. For merge, the client resolves the share's exact owning tab and captures its
+   file target, path, content, and SHA-256 hash.
+2. It builds a merge only if the current block/range anchor is still valid. A
+   deterministic `mr-peer-{commentId}` metadata ID makes retries idempotent.
+3. Immediately before writing, it rereads the file and rechecks the captured
+   owner/path/target and hash. Any mismatch fails closed.
+4. After a successful write, or before a dismiss/clear, the client persists the
+   comment ID to the resolve outbox. Only then does it remove the item from the
+   visible pending state.
+5. The ID is also represented in `pendingResolveCommentIds` for compatibility
+   with older persisted state.
+6. `flushPendingCommentResolves()` sends `comment:resolve` for queued IDs once the relay is confirmed.
+7. DO deletes the row from SQLite.
+8. DO replies with `comment:resolve:ack`.
+9. Client durably removes the outbox entry, then removes the compatibility queue entry.
+10. DO broadcasts `comment:resolved` to subscribers.
 
-### 7.4 Peer content refresh
+### 7.4 Invalid input containment
+
+1. The Worker rejects oversized frames, invalid IDs, unauthorized role actions,
+   and rate-limit excess before storage or fan-out.
+2. The client validates decrypted external data once at the relay boundary.
+3. An invalid host item becomes a bounded, content-free quarantine record for
+   its document; valid items in the same snapshot still apply.
+4. Review surfaces are wrapped per document/group so one render failure exposes
+   a retry fallback without replacing the whole tab.
+
+### 7.5 Peer content refresh
 
 1. Host updates encrypted share content through `updateShare()`.
 2. Host sends encrypted `document:updated`.
@@ -207,16 +269,22 @@ Obsolete note:
 
 ### Client
 
-- [src/services/relay.ts](../../../src/services/relay.ts)
+- [src/modules/relay/controller.ts](../../../src/modules/relay/controller.ts)
   - WebSocket lifecycle
   - subscribe resend
   - ping/pong
   - ACK handling
-  - snapshot decrypt / dispatch
+  - generation filtering and ordered snapshot/live dispatch
+- [src/modules/relay/diagnostics.ts](../../../src/modules/relay/diagnostics.ts)
+  - bounded content-free relay diagnostics
 - [src/store/index.ts](../../../src/store/index.ts)
-  - host pending comment state
-  - queued resolve state
-  - peer submission state
+  - module composition and compatible root-state migration
+- [src/modules/sharing/registry.ts](../../../src/modules/sharing/registry.ts)
+  - stable workspace-to-share ownership and additive legacy migration
+- [src/modules/sharing/resolveOutbox.ts](../../../src/modules/sharing/resolveOutbox.ts)
+  - durable resolve intent before UI removal
+- [src/modules/workspace/contentCache.ts](../../../src/modules/workspace/contentCache.ts)
+  - per-workspace document-content persistence
 - [src/services/shareStorage.ts](../../../src/services/shareStorage.ts)
   - share content CRUD only
 - [src/services/shareSync.ts](../../../src/services/shareSync.ts)
@@ -229,6 +297,11 @@ Obsolete note:
 - peer drafts remain local if relay subscribe is not yet confirmed
 - host-authored local comments stay outside this system entirely
 - WebSocket keep-alive is still application-level ping/pong every 30 seconds
+- plain WebSocket frames are capped at 1.5 MiB; encrypted comment payloads are
+  capped at 1 MiB; comment text and quote text are capped at 400 KiB each
+- comment writes are rate-limited per socket
+- generation-aware snapshots are chunked below the frame limit and one
+  document's unresolved inbox is capped at 500 rows / 8 MiB encoded payload
 
 ## 10. Non-Goals
 

--- a/src/markup/commentProtocol.ts
+++ b/src/markup/commentProtocol.ts
@@ -162,8 +162,9 @@ function createRandomCommentId(): string {
 
 export function createQuestionThreadMetadata(
   authorLabel?: string,
+  stableCommentId?: string,
 ): CommentThreadMetadata {
-  const commentId = createRandomCommentId();
+  const commentId = stableCommentId ?? createRandomCommentId();
   const thread: CommentThreadMetadata = {
     commentId,
     threadId: commentId,

--- a/src/markup/insertComment.ts
+++ b/src/markup/insertComment.ts
@@ -116,6 +116,7 @@ export function insertComment(input: {
   type: CommentType;
   text: string;
   authorLabel?: string;
+  stableCommentId?: string;
   anchor?: Pick<CommentAnchor, "quote" | "occurrence" | "start" | "end">;
 }): string {
   const blocks = getBlockPositions(input.cleanMarkdown);
@@ -133,7 +134,7 @@ export function insertComment(input: {
 
   const thread =
     input.type === "question" || input.authorLabel
-      ? createQuestionThreadMetadata(input.authorLabel)
+      ? createQuestionThreadMetadata(input.authorLabel, input.stableCommentId)
       : undefined;
   const body = serializeCommentBody({
     type: input.type,

--- a/src/modules/host-review/README.md
+++ b/src/modules/host-review/README.md
@@ -43,6 +43,7 @@ Current side effects:
 
 - writing merged content to host files
 - comment scanning and refresh coordination
+- owner-tab-specific writes used by incoming peer-comment merge
 
 ## Related Docs
 
@@ -52,6 +53,8 @@ Current side effects:
 
 - host review state must remain separate from peer review state
 - merge logic must preserve current durable share update behavior
+- a delayed incoming merge must write only the captured owner tab and file
+  target; active-tab changes cannot retarget it
 
 ## Common Failure Modes
 

--- a/src/modules/host-review/controller.ts
+++ b/src/modules/host-review/controller.ts
@@ -134,6 +134,44 @@ export async function writeAndUpdate<
   }
 }
 
+export async function writeAndUpdateTab<
+  StoreState extends ActiveTabStoreState,
+>(input: {
+  set: SetState<StoreState>;
+  buildUpdatedTabs: (
+    tabs: TabState[],
+    tabId: string,
+    updater: (tab: TabState) => Partial<TabState>,
+  ) => TabState[];
+  tabId: string;
+  fileHandle: FileTarget;
+  expectedRawContent: string;
+  newRawContent: string;
+}): Promise<boolean> {
+  try {
+    await writeFile(input.fileHandle, input.newRawContent);
+    input.set((state) => ({
+      tabs: input.buildUpdatedTabs(state.tabs, input.tabId, () => ({
+        rawContent: input.newRawContent,
+        writeAllowed: true,
+        undoState: { rawContent: input.expectedRawContent },
+      })),
+    }));
+    return true;
+  } catch (error) {
+    if (isPermissionError(error)) {
+      input.set((state) => ({
+        tabs: input.buildUpdatedTabs(state.tabs, input.tabId, () => ({
+          writeAllowed: false,
+        })),
+      }));
+    } else {
+      console.error("[writeAndUpdateTab] write failed:", error);
+    }
+    return false;
+  }
+}
+
 export async function scanAllTabFileComments(
   tab: TabState,
   getLiveFileTree: (tab: TabState) => FileTreeNode[],

--- a/src/modules/peer-review/README.md
+++ b/src/modules/peer-review/README.md
@@ -13,6 +13,7 @@ Owns peer-mode shared content state and peer-authored draft/submission logic.
 - peer draft comments
 - submitted peer comment IDs
 - peer comment panel state
+- peer submission subscription generation and phase
 
 ## Does not own
 
@@ -36,6 +37,7 @@ Owns peer-mode shared content state and peer-authored draft/submission logic.
 - `peerResolvedComments`
 - `peerComments`
 - `peerCommentPanelOpen`
+- `peerSubmissionSubscription`
 
 ## Public API
 
@@ -64,6 +66,8 @@ Owns peer-mode shared content state and peer-authored draft/submission logic.
   comments whose IDs have already been acknowledged as submitted
 - `peerName` is global peer state persisted through the root Zustand store, so
   it applies across shared links in the same browser
+- leaving a shared-link route clears peer-mode state and its relay subscription
+- newly authored comment and quote fields are bounded before encryption
 
 ## Common Failure Modes
 

--- a/src/modules/peer-review/controller.ts
+++ b/src/modules/peer-review/controller.ts
@@ -64,7 +64,7 @@ export async function loadPeerSharedContent<StoreState extends PeerReviewState>(
         : state.myPeerComments,
     }));
 
-    startRelayForDoc(docId);
+    startRelayForDoc(docId, "peer");
   } catch (error) {
     if (!hadLoadedContent) {
       set({

--- a/src/modules/peer-review/state.ts
+++ b/src/modules/peer-review/state.ts
@@ -2,10 +2,13 @@ import type { StoreApi } from "zustand";
 import type { CommentType } from "../../types/criticmarkup";
 import type { PeerComment } from "../../types/share";
 import type { RelayState } from "../relay";
+import { getBlockPlainTextMap, parseCriticMarkup } from "../../markup";
 import type { PeerReviewActions, PeerReviewState } from "./types";
 
 type SetState<StoreState> = StoreApi<StoreState>["setState"];
 type GetState<StoreState> = StoreApi<StoreState>["getState"];
+
+const MAX_PEER_COMMENT_INPUT_LENGTH = 400 * 1024;
 
 function createPeerComment(input: {
   peerName: string | null;
@@ -17,14 +20,17 @@ function createPeerComment(input: {
     quote: string;
     occurrence: number;
   };
+  rawContent: string;
 }): PeerComment {
+  const parsed = parseCriticMarkup(input.rawContent);
+  const blockMap = getBlockPlainTextMap(parsed.cleanMarkdown, input.blockIndex);
   return {
     id: `c_${crypto.randomUUID()}`,
     peerName: input.peerName ?? "Anonymous",
     path: input.path,
     blockRef: {
       blockIndex: input.blockIndex,
-      contentPreview: "",
+      contentPreview: blockMap?.plainText.slice(0, 80) ?? "",
       ...(input.anchor
         ? {
             anchorVersion: 1,
@@ -57,6 +63,7 @@ export function createPeerReviewState(): PeerReviewState {
     peerComments: [],
     peerCommentPanelOpen: false,
     peerActiveCommentId: null,
+    peerSubmissionSubscription: null,
   };
 }
 
@@ -68,6 +75,7 @@ export function createPeerReviewActions<
   get: GetState<StoreState>,
 ): Pick<
   PeerReviewActions,
+  | "leavePeerMode"
   | "setPeerName"
   | "selectPeerFile"
   | "postPeerComment"
@@ -76,8 +84,15 @@ export function createPeerReviewActions<
   | "setPeerDraftCommentOpen"
   | "discardUnsubmittedPeerComments"
   | "confirmPeerCommentSubmitted"
+  | "setPeerSubmissionSubscription"
 > {
   return {
+    leavePeerMode: () => {
+      set({
+        isPeerMode: false,
+        peerSubmissionSubscription: null,
+      });
+    },
     setPeerName: (name) => {
       set((state) => {
         const submittedCommentIds = new Set(state.submittedPeerCommentIds);
@@ -118,16 +133,24 @@ export function createPeerReviewActions<
 
     postPeerComment: (input) => {
       if (get().documentUpdateAvailable) {
-        return;
+        return false;
+      }
+      if (
+        input.text.length > MAX_PEER_COMMENT_INPUT_LENGTH ||
+        (input.anchor?.quote.length ?? 0) > MAX_PEER_COMMENT_INPUT_LENGTH
+      ) {
+        return false;
       }
       const comment = createPeerComment({
         ...input,
         peerName: get().peerName,
+        rawContent: get().peerRawContent,
       });
       set((state) => ({
         myPeerComments: [comment, ...state.myPeerComments],
         peerDraftCommentOpen: false,
       }));
+      return true;
     },
 
     deletePeerComment: (commentId) => {
@@ -146,6 +169,9 @@ export function createPeerReviewActions<
     },
 
     editPeerComment: (commentId, type, text) => {
+      if (text.length > MAX_PEER_COMMENT_INPUT_LENGTH) {
+        return;
+      }
       set((state) => ({
         myPeerComments: state.myPeerComments.map((comment) =>
           comment.id === commentId
@@ -174,6 +200,9 @@ export function createPeerReviewActions<
           submittedPeerCommentIds: [...state.submittedPeerCommentIds, cmtId],
         };
       });
+    },
+    setPeerSubmissionSubscription: (subscription) => {
+      set({ peerSubmissionSubscription: subscription });
     },
   };
 }

--- a/src/modules/peer-review/test/peerState.test.ts
+++ b/src/modules/peer-review/test/peerState.test.ts
@@ -39,4 +39,16 @@ describe("peer-review state actions", () => {
       expect.objectContaining({ id: "draft-1", peerName: "Bob" }),
     ]);
   });
+
+  it("rejects an edited peer comment that exceeds the input safety limit", () => {
+    useAppStore.setState({
+      myPeerComments: [makePeerComment({ id: "draft-1", text: "Original" })],
+    });
+
+    useAppStore
+      .getState()
+      .editPeerComment("draft-1", "fix", "x".repeat(400 * 1024 + 1));
+
+    expect(useAppStore.getState().myPeerComments[0]?.text).toBe("Original");
+  });
 });

--- a/src/modules/peer-review/types.ts
+++ b/src/modules/peer-review/types.ts
@@ -1,5 +1,6 @@
 import type { Comment, CommentType } from "../../types/criticmarkup";
 import type { PeerComment, SharePayload } from "../../types/share";
+import type { RelaySubscriptionState } from "../../types/relay";
 
 export interface PeerReviewState {
   isPeerMode: boolean;
@@ -18,9 +19,11 @@ export interface PeerReviewState {
   peerComments: Comment[];
   peerCommentPanelOpen: boolean;
   peerActiveCommentId: string | null;
+  peerSubmissionSubscription: RelaySubscriptionState | null;
 }
 
 export interface PeerReviewActions {
+  leavePeerMode: () => void;
   setPeerName: (name: string) => void;
   loadSharedContent: (options?: {
     discardUnsubmitted?: boolean;
@@ -35,11 +38,14 @@ export interface PeerReviewActions {
       quote: string;
       occurrence: number;
     };
-  }) => void;
+  }) => boolean;
   deletePeerComment: (commentId: string) => void;
   editPeerComment: (commentId: string, type: CommentType, text: string) => void;
   setPeerDraftCommentOpen: (open: boolean) => void;
   discardUnsubmittedPeerComments: () => void;
   syncPeerComments: () => Promise<void>;
   confirmPeerCommentSubmitted: (cmtId: string) => void;
+  setPeerSubmissionSubscription: (
+    subscription: RelaySubscriptionState | null,
+  ) => void;
 }

--- a/src/modules/relay/README.md
+++ b/src/modules/relay/README.md
@@ -11,6 +11,9 @@ Owns relay runtime state and relay transport orchestration.
 - subscribe and unsubscribe orchestration
 - reconnect and resend behavior
 - inbound relay frame handling
+- generation-scoped subscription state
+- ordered snapshot/live-event application
+- external payload validation and content-free diagnostics
 
 ## Does not own
 
@@ -23,6 +26,9 @@ Owns relay runtime state and relay transport orchestration.
 
 - `relayStatus`
 - `documentUpdateAvailable`
+
+Per-document host subscription state and the peer submission subscription are
+owned by their feature states; relay updates them through the application port.
 
 ## Public API
 
@@ -40,6 +46,8 @@ This module owns the relay transport side effects in `controller.ts`:
 - relay subscribe and unsubscribe
 - ping and reconnect
 - relay message decrypt and dispatch
+- stale-generation rejection and per-subscription event queues
+- boundary validation, quarantine dispatch, and bounded diagnostics
 
 ## Related Docs
 
@@ -53,8 +61,14 @@ This module owns the relay transport side effects in `controller.ts`:
 - relay runtime objects must stay outside persisted Zustand state
 - relay code must not import the composed store; it reads application commands
   through `RelayApplicationPort`
+- a connected socket is not a live document; Live requires a confirmed current
+  subscription generation
+- snapshot and later live events for one generation commit in receive order
 
 ## Common Failure Modes
 
 - letting relay transport mutate feature internals directly
 - mixing transport orchestration into the central store
+- treating an operation-scoped rejection as a subscription failure
+- routing by whichever runtime mode happens to be visible instead of the
+  subscription's recorded role

--- a/src/modules/relay/applicationPort.ts
+++ b/src/modules/relay/applicationPort.ts
@@ -1,4 +1,5 @@
 import type { PeerReviewActions, PeerReviewState } from "../peer-review/types";
+import type { AppShellActions } from "../app-shell/types";
 import type { SharingActions } from "../sharing/types";
 import type { WorkspaceState } from "../workspace/types";
 import type { RelayActions, RelayState } from "./types";
@@ -19,6 +20,7 @@ export type RelayApplicationState = Pick<WorkspaceState, "tabs"> &
     | "confirmPeerCommentSubmitted"
     | "deletePeerComment"
     | "loadSharedContent"
+    | "setPeerSubmissionSubscription"
     | "syncPeerComments"
   > &
   Pick<
@@ -26,9 +28,12 @@ export type RelayApplicationState = Pick<WorkspaceState, "tabs"> &
     | "addPendingComment"
     | "confirmPendingResolve"
     | "flushPendingCommentResolves"
+    | "quarantinePendingComment"
     | "replaceCommentsSnapshot"
+    | "setIncomingReviewSubscription"
   > &
   Pick<RelayState, "documentUpdateAvailable"> &
+  Pick<AppShellActions, "showToast"> &
   RelayActions;
 
 export interface RelayApplicationPort {

--- a/src/modules/relay/controller.ts
+++ b/src/modules/relay/controller.ts
@@ -3,12 +3,21 @@ import type {
   CommentsSnapshotEntry,
   RelayEvent,
   RelayMessage,
+  RelaySubscriptionRole,
+  RelaySubscriptionState,
 } from "../../types/relay";
 import type { PeerComment } from "../../types/share";
+import { isCommentType } from "../../markup/commentProtocol";
 import { WORKER_URL } from "../../config";
 import { ShareStorage } from "../sharing/storage";
 import { selectHasPeerLocalCommentWork } from "../peer-review/selectors";
 import { getRelayApplicationState } from "./applicationPort";
+import { recordRelayDiagnostic } from "./diagnostics";
+
+interface RelayEventContext {
+  role: RelaySubscriptionRole;
+  subscriptionId: string;
+}
 
 export interface RelayConnection {
   subscribe(
@@ -16,7 +25,7 @@ export interface RelayConnection {
     key: CryptoKey,
     role: "host" | "peer",
     hostSecret?: string,
-  ): void;
+  ): string;
   unsubscribe(docId: string): void;
   sendCommentAdd(docId: string, cmtId: string, payload: string): void;
   sendCommentResolve(docId: string, cmtId: string): void;
@@ -30,38 +39,96 @@ const VALID_RELAY_TYPES = new Set(["document:updated"]);
 const PING_INTERVAL_MS = 30_000;
 const SUBSCRIPTION_RETRY_DELAY_MS = 5_000;
 const BASE64_CHUNK_SIZE = 8192;
+const MAX_INBOUND_FRAME_BYTES = 1_500_000;
+const MAX_ENCRYPTED_COMMENT_BYTES = 1024 * 1024;
+const MAX_COMMENT_ID_LENGTH = 256;
+const MAX_PEER_NAME_LENGTH = 160;
+const MAX_PATH_LENGTH = 4096;
+const MAX_COMMENT_TEXT_LENGTH = 512 * 1024;
+const MAX_CONTENT_PREVIEW_LENGTH = 512;
+const MAX_ANCHOR_QUOTE_LENGTH = 512 * 1024;
+const MAX_SNAPSHOT_ENTRIES = 500;
+const MAX_SNAPSHOT_PAYLOAD_CHARS = 8 * 1024 * 1024;
+const MAX_ENCRYPTED_COMMENT_BASE64_CHARS = 1_400_000;
+const COMMENT_ID_RE = /^[A-Za-z0-9_-]+$/;
 
 type ParsedFrame =
   | { kind: "pong" }
-  | { kind: "error"; docId: string; message: string }
-  | { kind: "subscribeOk"; docId: string }
-  | { kind: "commentAddAck"; docId: string; cmtId: string }
-  | { kind: "commentResolveAck"; docId: string; cmtId: string }
+  | {
+      kind: "error";
+      docId: string;
+      message: string;
+      subscriptionId?: string;
+      scope: "subscription" | "operation";
+      cmtId?: string;
+    }
+  | { kind: "subscribeOk"; docId: string; subscriptionId?: string }
+  | {
+      kind: "commentAddAck";
+      docId: string;
+      cmtId: string;
+      subscriptionId?: string;
+    }
+  | {
+      kind: "commentResolveAck";
+      docId: string;
+      cmtId: string;
+      subscriptionId?: string;
+    }
   | {
       kind: "commentsSnapshot";
       docId: string;
       comments: CommentsSnapshotEntry[];
+      subscriptionId?: string;
+      snapshotId?: string;
+      chunkIndex?: number;
+      chunkCount?: number;
     }
-  | { kind: "commentAdded"; docId: string; cmtId: string; payload: string }
-  | { kind: "commentResolved"; docId: string; cmtId: string }
-  | { kind: "relay"; docId: string; payload: string }
+  | {
+      kind: "commentAdded";
+      docId: string;
+      cmtId: string;
+      payload: string;
+      subscriptionId?: string;
+    }
+  | {
+      kind: "commentResolved";
+      docId: string;
+      cmtId: string;
+      subscriptionId?: string;
+    }
+  | {
+      kind: "relay";
+      docId: string;
+      payload: string;
+      subscriptionId?: string;
+    }
   | { kind: "unknown" };
 
-interface RelayContext {
-  subscriptions: Set<string>;
-  confirmed: Set<string>;
-  socket: WebSocket | null;
-  retrySubscribe: (docId: string) => void;
-  onSubscribeOk: (docId: string) => void;
-  onCommentAddAck: (docId: string, cmtId: string) => void;
-  onCommentResolveAck: (docId: string, cmtId: string) => void;
-  onSnapshot: (docId: string, comments: CommentsSnapshotEntry[]) => void;
-  onCommentAdded: (docId: string, cmtId: string, payload: string) => void;
-  onCommentResolved: (docId: string, cmtId: string) => void;
+interface SubscriptionMeta {
+  role: RelaySubscriptionRole;
+  subscriptionId: string;
+  hostSecret?: string;
+}
+
+interface SnapshotAssembly {
+  chunkCount: number;
+  chunks: Map<number, CommentsSnapshotEntry[]>;
+  entryCount: number;
+  payloadChars: number;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isValidRelayIdentifier(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_COMMENT_ID_LENGTH &&
+    COMMENT_ID_RE.test(value)
+  );
 }
 
 function isCommentsSnapshotEntries(
@@ -70,12 +137,16 @@ function isCommentsSnapshotEntries(
   if (!Array.isArray(value)) {
     return false;
   }
+  if (value.length > MAX_SNAPSHOT_ENTRIES) {
+    return false;
+  }
   return value.every((entry) => {
     if (!isRecord(entry)) {
       return false;
     }
     return (
-      typeof entry["cmtId"] === "string" && typeof entry["payload"] === "string"
+      isValidRelayIdentifier(entry["cmtId"]) &&
+      isBoundedString(entry["payload"], MAX_ENCRYPTED_COMMENT_BASE64_CHARS)
     );
   });
 }
@@ -89,6 +160,38 @@ function isValidRelayMessage(value: unknown): value is RelayMessage {
   );
 }
 
+function getSubscriptionId(frame: Record<string, unknown>): string | undefined {
+  return isValidRelayIdentifier(frame["subscriptionId"])
+    ? frame["subscriptionId"]
+    : undefined;
+}
+
+function getSnapshotChunkMetadata(frame: Record<string, unknown>):
+  | {
+      snapshotId: string;
+      chunkIndex: number;
+      chunkCount: number;
+    }
+  | undefined {
+  const snapshotId = frame["snapshotId"];
+  const chunkIndex = frame["chunkIndex"];
+  const chunkCount = frame["chunkCount"];
+  if (
+    !isValidRelayIdentifier(snapshotId) ||
+    !Number.isInteger(chunkIndex) ||
+    !Number.isInteger(chunkCount) ||
+    typeof chunkIndex !== "number" ||
+    typeof chunkCount !== "number" ||
+    chunkCount <= 0 ||
+    chunkCount > MAX_SNAPSHOT_ENTRIES ||
+    chunkIndex < 0 ||
+    chunkIndex >= chunkCount
+  ) {
+    return undefined;
+  }
+  return { snapshotId, chunkIndex, chunkCount };
+}
+
 function parseInboundFrame(raw: unknown): ParsedFrame {
   if (!isRecord(raw)) {
     return { kind: "unknown" };
@@ -96,151 +199,111 @@ function parseInboundFrame(raw: unknown): ParsedFrame {
   if (raw.type === "pong") {
     return { kind: "pong" };
   }
-  if (raw.type === "error" && typeof raw.docId === "string") {
+  if (raw.type === "error" && isValidRelayIdentifier(raw.docId)) {
     return {
       kind: "error",
       docId: raw.docId,
       message: typeof raw.message === "string" ? raw.message : "Relay error",
+      subscriptionId: getSubscriptionId(raw),
+      scope: raw.scope === "operation" ? "operation" : "subscription",
+      cmtId: isValidRelayIdentifier(raw.cmtId) ? raw.cmtId : undefined,
     };
   }
-  if (raw.type === "subscribe:ok" && typeof raw.docId === "string") {
-    return { kind: "subscribeOk", docId: raw.docId };
+  if (raw.type === "subscribe:ok" && isValidRelayIdentifier(raw.docId)) {
+    return {
+      kind: "subscribeOk",
+      docId: raw.docId,
+      subscriptionId: getSubscriptionId(raw),
+    };
   }
   if (
     raw.type === "comment:add:ack" &&
-    typeof raw.docId === "string" &&
-    typeof raw.cmtId === "string"
+    isValidRelayIdentifier(raw.docId) &&
+    isValidRelayIdentifier(raw.cmtId)
   ) {
-    return { kind: "commentAddAck", docId: raw.docId, cmtId: raw.cmtId };
+    return {
+      kind: "commentAddAck",
+      docId: raw.docId,
+      cmtId: raw.cmtId,
+      subscriptionId: getSubscriptionId(raw),
+    };
   }
   if (
     raw.type === "comment:resolve:ack" &&
-    typeof raw.docId === "string" &&
-    typeof raw.cmtId === "string"
+    isValidRelayIdentifier(raw.docId) &&
+    isValidRelayIdentifier(raw.cmtId)
   ) {
     return {
       kind: "commentResolveAck",
       docId: raw.docId,
       cmtId: raw.cmtId,
+      subscriptionId: getSubscriptionId(raw),
     };
   }
   if (
     raw.type === "comments:snapshot" &&
-    typeof raw.docId === "string" &&
+    isValidRelayIdentifier(raw.docId) &&
     isCommentsSnapshotEntries(raw.comments)
   ) {
+    const hasChunkMetadata =
+      "snapshotId" in raw || "chunkIndex" in raw || "chunkCount" in raw;
+    const chunkMetadata = getSnapshotChunkMetadata(raw);
+    if (hasChunkMetadata && !chunkMetadata) {
+      return { kind: "unknown" };
+    }
     return {
       kind: "commentsSnapshot",
       docId: raw.docId,
       comments: raw.comments,
+      subscriptionId: getSubscriptionId(raw),
+      ...chunkMetadata,
     };
   }
   if (
     raw.type === "comment:added" &&
-    typeof raw.docId === "string" &&
-    typeof raw.cmtId === "string" &&
-    typeof raw.payload === "string"
+    isValidRelayIdentifier(raw.docId) &&
+    isValidRelayIdentifier(raw.cmtId) &&
+    isBoundedString(raw.payload, MAX_ENCRYPTED_COMMENT_BASE64_CHARS)
   ) {
     return {
       kind: "commentAdded",
       docId: raw.docId,
       cmtId: raw.cmtId,
       payload: raw.payload,
+      subscriptionId: getSubscriptionId(raw),
     };
   }
   if (
     raw.type === "comment:resolved" &&
-    typeof raw.docId === "string" &&
-    typeof raw.cmtId === "string"
+    isValidRelayIdentifier(raw.docId) &&
+    isValidRelayIdentifier(raw.cmtId)
   ) {
     return {
       kind: "commentResolved",
       docId: raw.docId,
       cmtId: raw.cmtId,
+      subscriptionId: getSubscriptionId(raw),
     };
   }
   if (
     raw.version === 1 &&
-    typeof raw.docId === "string" &&
+    isValidRelayIdentifier(raw.docId) &&
     typeof raw.payload === "string"
   ) {
-    return { kind: "relay", docId: raw.docId, payload: raw.payload };
+    return {
+      kind: "relay",
+      docId: raw.docId,
+      payload: raw.payload,
+      subscriptionId: getSubscriptionId(raw),
+    };
   }
   return { kind: "unknown" };
 }
 
-function scheduleSubscriptionRetry(context: RelayContext, docId: string): void {
-  if (!context.subscriptions.has(docId)) {
-    return;
-  }
-  const retryDocId = docId;
-  setTimeout(() => {
-    if (
-      context.socket?.readyState === WebSocket.OPEN &&
-      context.subscriptions.has(retryDocId)
-    ) {
-      context.retrySubscribe(retryDocId);
-    }
-  }, SUBSCRIPTION_RETRY_DELAY_MS);
-}
-
-function handleControlFrame(
-  frame: ParsedFrame,
-  context: RelayContext,
-): boolean {
-  if (frame.kind === "pong") {
-    return true;
-  }
-  if (frame.kind === "error") {
-    console.warn(
-      "[relay] server error for docId",
-      frame.docId,
-      ":",
-      frame.message,
-    );
-    scheduleSubscriptionRetry(context, frame.docId);
-    return true;
-  }
-  if (frame.kind === "subscribeOk") {
-    context.confirmed.add(frame.docId);
-    context.onSubscribeOk(frame.docId);
-    return true;
-  }
-  if (frame.kind === "commentAddAck") {
-    context.onCommentAddAck(frame.docId, frame.cmtId);
-    return true;
-  }
-  if (frame.kind === "commentResolveAck") {
-    context.onCommentResolveAck(frame.docId, frame.cmtId);
-    return true;
-  }
-  if (frame.kind === "commentsSnapshot") {
-    context.onSnapshot(frame.docId, frame.comments);
-    return true;
-  }
-  if (frame.kind === "commentAdded") {
-    context.onCommentAdded(frame.docId, frame.cmtId, frame.payload);
-    return true;
-  }
-  if (frame.kind === "commentResolved") {
-    context.onCommentResolved(frame.docId, frame.cmtId);
-    return true;
-  }
-  return false;
-}
-
-async function decryptAndDispatch(
-  frame: ParsedFrame,
-  encryptionKeys: Map<string, CryptoKey>,
-  onMessage: (docId: string, event: RelayEvent) => void,
-): Promise<void> {
-  if (frame.kind !== "relay") {
-    return;
-  }
-  const key = encryptionKeys.get(frame.docId);
-  if (!key) {
-    return;
-  }
+async function decryptRelayMessage(
+  frame: Extract<ParsedFrame, { kind: "relay" }>,
+  key: CryptoKey,
+): Promise<RelayMessage | null> {
   const raw = Uint8Array.from(atob(frame.payload), (char) =>
     char.charCodeAt(0),
   );
@@ -248,9 +311,9 @@ async function decryptAndDispatch(
   const parsed: unknown = JSON.parse(new TextDecoder().decode(decrypted));
   if (!isValidRelayMessage(parsed)) {
     console.warn("[relay] invalid message shape, discarding");
-    return;
+    return null;
   }
-  onMessage(frame.docId, parsed);
+  return parsed;
 }
 
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
@@ -263,26 +326,47 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return btoa(binary);
 }
 
+function encryptedPayloadByteLength(payload: string): number {
+  const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+  return Math.floor((payload.length * 3) / 4) - padding;
+}
+
+function isBoundedString(
+  value: unknown,
+  maximumLength: number,
+): value is string {
+  return typeof value === "string" && value.length <= maximumLength;
+}
+
 function isPeerComment(value: unknown): value is PeerComment {
   if (!isRecord(value)) {
     return false;
   }
-  if (typeof value["id"] !== "string") {
+  if (
+    !isBoundedString(value["id"], MAX_COMMENT_ID_LENGTH) ||
+    !COMMENT_ID_RE.test(value["id"])
+  ) {
     return false;
   }
-  if (typeof value["peerName"] !== "string") {
+  if (!isBoundedString(value["peerName"], MAX_PEER_NAME_LENGTH)) {
     return false;
   }
-  if (typeof value["path"] !== "string") {
+  if (!isBoundedString(value["path"], MAX_PATH_LENGTH)) {
     return false;
   }
-  if (typeof value["commentType"] !== "string") {
+  if (
+    typeof value["commentType"] !== "string" ||
+    !isCommentType(value["commentType"])
+  ) {
     return false;
   }
-  if (typeof value["text"] !== "string") {
+  if (!isBoundedString(value["text"], MAX_COMMENT_TEXT_LENGTH)) {
     return false;
   }
-  if (typeof value["createdAt"] !== "string") {
+  if (
+    typeof value["createdAt"] !== "string" ||
+    Number.isNaN(Date.parse(value["createdAt"]))
+  ) {
     return false;
   }
   if (!isRecord(value["blockRef"])) {
@@ -292,7 +376,8 @@ function isPeerComment(value: unknown): value is PeerComment {
   const hasValidAnchorVersion =
     blockRef["anchorVersion"] === undefined || blockRef["anchorVersion"] === 1;
   const hasValidQuote =
-    blockRef["quote"] === undefined || typeof blockRef["quote"] === "string";
+    blockRef["quote"] === undefined ||
+    isBoundedString(blockRef["quote"], MAX_ANCHOR_QUOTE_LENGTH);
   const hasValidOccurrence =
     blockRef["occurrence"] === undefined ||
     (typeof blockRef["occurrence"] === "number" &&
@@ -300,7 +385,10 @@ function isPeerComment(value: unknown): value is PeerComment {
       blockRef["occurrence"] > 0);
   return (
     typeof blockRef["blockIndex"] === "number" &&
-    typeof blockRef["contentPreview"] === "string" &&
+    Number.isFinite(blockRef["blockIndex"]) &&
+    Number.isInteger(blockRef["blockIndex"]) &&
+    blockRef["blockIndex"] >= 0 &&
+    isBoundedString(blockRef["contentPreview"], MAX_CONTENT_PREVIEW_LENGTH) &&
     hasValidAnchorVersion &&
     hasValidQuote &&
     hasValidOccurrence
@@ -323,17 +411,19 @@ class RelayConnectionImpl implements RelayConnection {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private pingInterval: ReturnType<typeof setInterval> | null = null;
   private closedIntentionally = false;
-  private subscriptions = new Set<string>();
-  private confirmedSubscriptions = new Set<string>();
-  private subscriptionMeta = new Map<
-    string,
-    { role: "host" | "peer"; hostSecret?: string }
-  >();
+  private confirmedSubscriptions = new Map<string, string>();
+  private subscriptionMeta = new Map<string, SubscriptionMeta>();
   private encryptionKeys = new Map<string, CryptoKey>();
+  private messageQueues = new Map<string, Promise<void>>();
+  private snapshotAssemblies = new Map<string, SnapshotAssembly>();
   private wsUrl: string;
 
   constructor(
-    private onMessage: (docId: string, event: RelayEvent) => void,
+    private onMessage: (
+      docId: string,
+      event: RelayEvent,
+      context: RelayEventContext,
+    ) => Promise<void> | void,
     private onStatusChange: (
       status: "connecting" | "connected" | "disconnected",
     ) => void,
@@ -345,28 +435,172 @@ class RelayConnectionImpl implements RelayConnection {
     this.openConnection();
   }
 
-  private sendSubscribeFrame(
+  private notifySubscription(
     docId: string,
-    role: "host" | "peer",
-    hostSecret?: string,
+    meta: SubscriptionMeta,
+    phase: RelaySubscriptionState["phase"],
+    lastError: string | null,
   ): void {
+    handleSubscriptionState(docId, meta.role, {
+      subscriptionId: meta.subscriptionId,
+      phase,
+      lastError,
+    });
+    recordRelayDiagnostic({
+      kind: "subscription",
+      docId,
+      subscriptionId: meta.subscriptionId,
+      role: meta.role,
+      frameType: null,
+      frameBytes: null,
+      phase,
+      reason: lastError,
+    });
+  }
+
+  private sendSubscribeFrame(docId: string, meta: SubscriptionMeta): void {
+    this.notifySubscription(docId, meta, "subscribing", null);
     if (this.socket?.readyState !== WebSocket.OPEN) {
       return;
     }
-    const frame: Record<string, string> = { type: "subscribe", docId, role };
-    if (hostSecret) {
-      frame.hostSecret = hostSecret;
+    const frame: Record<string, string> = {
+      type: "subscribe",
+      docId,
+      role: meta.role,
+      subscriptionId: meta.subscriptionId,
+    };
+    if (meta.hostSecret) {
+      frame.hostSecret = meta.hostSecret;
     }
     this.socket.send(JSON.stringify(frame));
   }
 
-  private retrySubscribe = (docId: string): void => {
-    const meta = this.subscriptionMeta.get(docId);
-    if (!meta) {
-      return;
+  private beginNewGeneration(docId: string): SubscriptionMeta | null {
+    const previous = this.subscriptionMeta.get(docId);
+    if (!previous) {
+      return null;
     }
-    this.sendSubscribeFrame(docId, meta.role, meta.hostSecret);
-  };
+    const next: SubscriptionMeta = {
+      ...previous,
+      subscriptionId: crypto.randomUUID(),
+    };
+    this.subscriptionMeta.set(docId, next);
+    this.confirmedSubscriptions.delete(docId);
+    this.clearSnapshotAssemblies(docId);
+    this.sendSubscribeFrame(docId, next);
+    return next;
+  }
+
+  private scheduleSubscriptionRetry(
+    docId: string,
+    failedSubscriptionId: string,
+  ): void {
+    setTimeout(() => {
+      const current = this.subscriptionMeta.get(docId);
+      if (
+        this.socket?.readyState !== WebSocket.OPEN ||
+        current?.subscriptionId !== failedSubscriptionId
+      ) {
+        return;
+      }
+      this.beginNewGeneration(docId);
+    }, SUBSCRIPTION_RETRY_DELAY_MS);
+  }
+
+  private isCurrentGeneration(docId: string, subscriptionId: string): boolean {
+    return this.subscriptionMeta.get(docId)?.subscriptionId === subscriptionId;
+  }
+
+  private clearSnapshotAssemblies(docId: string): void {
+    const prefix = `${docId}:`;
+    for (const key of this.snapshotAssemblies.keys()) {
+      if (key.startsWith(prefix)) {
+        this.snapshotAssemblies.delete(key);
+      }
+    }
+  }
+
+  private collectSnapshot(
+    frame: Extract<ParsedFrame, { kind: "commentsSnapshot" }>,
+    context: RelayEventContext,
+  ): CommentsSnapshotEntry[] | null {
+    if (
+      frame.snapshotId === undefined ||
+      frame.chunkIndex === undefined ||
+      frame.chunkCount === undefined
+    ) {
+      return frame.comments;
+    }
+    const assemblyKey = `${frame.docId}:${context.subscriptionId}:${frame.snapshotId}`;
+    const existing = this.snapshotAssemblies.get(assemblyKey);
+    const assembly =
+      existing?.chunkCount === frame.chunkCount
+        ? existing
+        : {
+            chunkCount: frame.chunkCount,
+            chunks: new Map<number, CommentsSnapshotEntry[]>(),
+            entryCount: 0,
+            payloadChars: 0,
+          };
+    if (!assembly.chunks.has(frame.chunkIndex)) {
+      assembly.chunks.set(frame.chunkIndex, frame.comments);
+      assembly.entryCount += frame.comments.length;
+      assembly.payloadChars += frame.comments.reduce(
+        (total, entry) => total + entry.payload.length,
+        0,
+      );
+    }
+    if (
+      assembly.entryCount > MAX_SNAPSHOT_ENTRIES ||
+      assembly.payloadChars > MAX_SNAPSHOT_PAYLOAD_CHARS
+    ) {
+      this.snapshotAssemblies.delete(assemblyKey);
+      throw new Error("Snapshot exceeds the client safety limit");
+    }
+    this.snapshotAssemblies.set(assemblyKey, assembly);
+    if (assembly.chunks.size !== assembly.chunkCount) {
+      return null;
+    }
+    const comments: CommentsSnapshotEntry[] = [];
+    for (
+      let chunkIndex = 0;
+      chunkIndex < assembly.chunkCount;
+      chunkIndex += 1
+    ) {
+      const chunk = assembly.chunks.get(chunkIndex);
+      if (!chunk) {
+        return null;
+      }
+      comments.push(...chunk);
+    }
+    this.snapshotAssemblies.delete(assemblyKey);
+    return comments;
+  }
+
+  private getFrameContext(frame: ParsedFrame): RelayEventContext | null {
+    if (frame.kind === "pong" || frame.kind === "unknown") {
+      return null;
+    }
+    const meta = this.subscriptionMeta.get(frame.docId);
+    if (!meta) {
+      return null;
+    }
+    const subscriptionId = frame.subscriptionId ?? meta.subscriptionId;
+    if (subscriptionId !== meta.subscriptionId) {
+      recordRelayDiagnostic({
+        kind: "rejection",
+        docId: frame.docId,
+        subscriptionId,
+        role: meta.role,
+        frameType: frame.kind,
+        frameBytes: null,
+        phase: null,
+        reason: "stale subscription generation",
+      });
+      return null;
+    }
+    return { role: meta.role, subscriptionId };
+  }
 
   private startPingInterval(): void {
     this.stopPingInterval();
@@ -391,50 +625,206 @@ class RelayConnectionImpl implements RelayConnection {
     }
     this.backoff = 1000;
     this.confirmedSubscriptions.clear();
-    this.onStatusChange("connected");
+    this.onStatusChange("connecting");
     this.startPingInterval();
     this.resubscribeAll();
   };
 
   private resubscribeAll(): void {
-    for (const docId of this.subscriptions) {
-      const meta = this.subscriptionMeta.get(docId);
-      if (meta) {
-        this.sendSubscribeFrame(docId, meta.role, meta.hostSecret);
-      }
+    for (const docId of this.subscriptionMeta.keys()) {
+      this.beginNewGeneration(docId);
     }
   }
 
-  private handleSocketMessage = async (event: MessageEvent): Promise<void> => {
-    try {
-      const rawData: unknown = JSON.parse(
-        typeof event.data === "string" ? event.data : "",
+  private processFrame = async (
+    frame: ParsedFrame,
+    context: RelayEventContext,
+  ): Promise<void> => {
+    if (frame.kind === "pong" || frame.kind === "unknown") {
+      return;
+    }
+    if (!this.isCurrentGeneration(frame.docId, context.subscriptionId)) {
+      return;
+    }
+    const meta = this.subscriptionMeta.get(frame.docId);
+    if (!meta) {
+      return;
+    }
+
+    if (frame.kind === "error") {
+      console.warn(
+        "[relay] server error for docId",
+        frame.docId,
+        ":",
+        frame.message,
       );
+      if (frame.scope === "operation") {
+        recordRelayDiagnostic({
+          kind: "rejection",
+          docId: frame.docId,
+          subscriptionId: context.subscriptionId,
+          role: context.role,
+          frameType: "error",
+          frameBytes: null,
+          phase: null,
+          reason: frame.message,
+        });
+        getRelayApplicationState().showToast(frame.message);
+        return;
+      }
+      this.confirmedSubscriptions.delete(frame.docId);
+      this.notifySubscription(frame.docId, meta, "failed", frame.message);
+      this.onStatusChange(
+        this.confirmedSubscriptions.size > 0 ? "connected" : "disconnected",
+      );
+      this.scheduleSubscriptionRetry(frame.docId, context.subscriptionId);
+      return;
+    }
+    if (frame.kind === "subscribeOk") {
+      this.confirmedSubscriptions.set(frame.docId, context.subscriptionId);
+      this.onStatusChange("connected");
+      this.notifySubscription(
+        frame.docId,
+        meta,
+        context.role === "host" ? "syncing" : "live",
+        null,
+      );
+      handleSubscribeConfirmed(frame.docId, context);
+      return;
+    }
+    if (frame.kind === "commentAddAck") {
+      await this.onMessage(
+        frame.docId,
+        { type: "comment:add:ack", cmtId: frame.cmtId },
+        context,
+      );
+      return;
+    }
+    if (frame.kind === "commentResolveAck") {
+      await this.onMessage(
+        frame.docId,
+        { type: "comment:resolve:ack", cmtId: frame.cmtId },
+        context,
+      );
+      return;
+    }
+    if (frame.kind === "commentsSnapshot") {
+      const comments = this.collectSnapshot(frame, context);
+      if (!comments) {
+        return;
+      }
+      await this.onMessage(
+        frame.docId,
+        { type: "comments:snapshot", comments },
+        context,
+      );
+      if (this.isCurrentGeneration(frame.docId, context.subscriptionId)) {
+        this.notifySubscription(frame.docId, meta, "live", null);
+      }
+      return;
+    }
+    if (frame.kind === "commentAdded") {
+      await this.onMessage(
+        frame.docId,
+        { type: "comment:added", cmtId: frame.cmtId, payload: frame.payload },
+        context,
+      );
+      return;
+    }
+    if (frame.kind === "commentResolved") {
+      await this.onMessage(
+        frame.docId,
+        { type: "comment:resolved", cmtId: frame.cmtId },
+        context,
+      );
+      return;
+    }
+    if (frame.kind === "relay") {
+      const key = this.encryptionKeys.get(frame.docId);
+      if (!key) {
+        return;
+      }
+      const message = await decryptRelayMessage(frame, key);
+      if (
+        message &&
+        this.isCurrentGeneration(frame.docId, context.subscriptionId)
+      ) {
+        await this.onMessage(frame.docId, message, context);
+      }
+    }
+  };
+
+  private enqueueFrame(frame: ParsedFrame): void {
+    if (frame.kind === "pong") {
+      return;
+    }
+    const context = this.getFrameContext(frame);
+    if (!context || frame.kind === "unknown") {
+      return;
+    }
+    const queueKey = `${frame.docId}:${context.subscriptionId}`;
+    const previous = this.messageQueues.get(queueKey) ?? Promise.resolve();
+    const next = previous
+      .catch((error: unknown) => {
+        console.warn("[relay] previous queued frame failed:", error);
+      })
+      .then(() => this.processFrame(frame, context));
+    this.messageQueues.set(queueKey, next);
+    void next
+      .catch((error: unknown) => {
+        console.warn("[relay] failed to process queued frame:", error);
+      })
+      .finally(() => {
+        if (this.messageQueues.get(queueKey) === next) {
+          this.messageQueues.delete(queueKey);
+        }
+      });
+  }
+
+  private handleSocketMessage = (event: MessageEvent): void => {
+    try {
+      const rawText = typeof event.data === "string" ? event.data : "";
+      const frameBytes = new TextEncoder().encode(rawText).byteLength;
+      if (frameBytes > MAX_INBOUND_FRAME_BYTES) {
+        recordRelayDiagnostic({
+          kind: "rejection",
+          docId: null,
+          subscriptionId: null,
+          role: null,
+          frameType: null,
+          frameBytes,
+          phase: null,
+          reason: "inbound frame too large",
+        });
+        return;
+      }
+      const rawData: unknown = JSON.parse(rawText);
       const frame = parseInboundFrame(rawData);
       if (frame.kind === "unknown") {
+        recordRelayDiagnostic({
+          kind: "rejection",
+          docId: null,
+          subscriptionId: null,
+          role: null,
+          frameType: null,
+          frameBytes,
+          phase: null,
+          reason: "invalid frame shape",
+        });
         return;
       }
-      const context: RelayContext = {
-        subscriptions: this.subscriptions,
-        confirmed: this.confirmedSubscriptions,
-        socket: this.socket,
-        retrySubscribe: this.retrySubscribe,
-        onSubscribeOk: (docId) => handleSubscribeConfirmed(docId),
-        onCommentAddAck: (docId, cmtId) =>
-          this.onMessage(docId, { type: "comment:add:ack", cmtId }),
-        onCommentResolveAck: (docId, cmtId) =>
-          this.onMessage(docId, { type: "comment:resolve:ack", cmtId }),
-        onSnapshot: (docId, comments) =>
-          this.onMessage(docId, { type: "comments:snapshot", comments }),
-        onCommentAdded: (docId, cmtId, payload) =>
-          this.onMessage(docId, { type: "comment:added", cmtId, payload }),
-        onCommentResolved: (docId, cmtId) =>
-          this.onMessage(docId, { type: "comment:resolved", cmtId }),
-      };
-      if (handleControlFrame(frame, context)) {
-        return;
-      }
-      await decryptAndDispatch(frame, this.encryptionKeys, this.onMessage);
+      const context = this.getFrameContext(frame);
+      recordRelayDiagnostic({
+        kind: "frame",
+        docId: frame.kind === "pong" ? null : frame.docId,
+        subscriptionId: context?.subscriptionId ?? null,
+        role: context?.role ?? null,
+        frameType: frame.kind,
+        frameBytes,
+        phase: null,
+        reason: null,
+      });
+      this.enqueueFrame(frame);
     } catch (error) {
       console.warn("[relay] failed to process message:", error);
     }
@@ -443,6 +833,9 @@ class RelayConnectionImpl implements RelayConnection {
   private handleSocketClose = (): void => {
     this.stopPingInterval();
     this.onStatusChange("disconnected");
+    for (const [docId, meta] of this.subscriptionMeta) {
+      this.notifySubscription(docId, meta, "failed", "Connection lost");
+    }
     if (!this.closedIntentionally) {
       this.scheduleReconnect();
     }
@@ -477,21 +870,31 @@ class RelayConnectionImpl implements RelayConnection {
     key: CryptoKey,
     role: "host" | "peer",
     hostSecret?: string,
-  ): void {
+  ): string {
+    const subscriptionId = crypto.randomUUID();
+    const meta: SubscriptionMeta = {
+      role,
+      subscriptionId,
+      ...(hostSecret ? { hostSecret } : {}),
+    };
     this.encryptionKeys.set(docId, key);
-    this.subscriptions.add(docId);
-    this.subscriptionMeta.set(docId, { role, hostSecret });
-    this.sendSubscribeFrame(docId, role, hostSecret);
+    this.subscriptionMeta.set(docId, meta);
+    this.confirmedSubscriptions.delete(docId);
+    this.sendSubscribeFrame(docId, meta);
+    return subscriptionId;
   }
 
   unsubscribe(docId: string): void {
     if (this.socket?.readyState === WebSocket.OPEN) {
-      this.socket.send(JSON.stringify({ type: "unsubscribe", docId }));
+      const subscriptionId = this.subscriptionMeta.get(docId)?.subscriptionId;
+      this.socket.send(
+        JSON.stringify({ type: "unsubscribe", docId, subscriptionId }),
+      );
     }
     this.encryptionKeys.delete(docId);
-    this.subscriptions.delete(docId);
     this.confirmedSubscriptions.delete(docId);
     this.subscriptionMeta.delete(docId);
+    this.clearSnapshotAssemblies(docId);
   }
 
   sendCommentAdd(docId: string, cmtId: string, payload: string): void {
@@ -501,8 +904,15 @@ class RelayConnectionImpl implements RelayConnection {
     ) {
       return;
     }
+    const subscriptionId = this.confirmedSubscriptions.get(docId);
     this.socket.send(
-      JSON.stringify({ type: "comment:add", docId, cmtId, payload }),
+      JSON.stringify({
+        type: "comment:add",
+        docId,
+        cmtId,
+        payload,
+        subscriptionId,
+      }),
     );
   }
 
@@ -513,7 +923,15 @@ class RelayConnectionImpl implements RelayConnection {
     ) {
       return;
     }
-    this.socket.send(JSON.stringify({ type: "comment:resolve", docId, cmtId }));
+    const subscriptionId = this.confirmedSubscriptions.get(docId);
+    this.socket.send(
+      JSON.stringify({
+        type: "comment:resolve",
+        docId,
+        cmtId,
+        subscriptionId,
+      }),
+    );
   }
 
   async send(docId: string, message: RelayMessage): Promise<void> {
@@ -527,11 +945,14 @@ class RelayConnectionImpl implements RelayConnection {
     const encoded = new TextEncoder().encode(JSON.stringify(message));
     const encrypted = await encrypt(encoded, key);
     const payload = arrayBufferToBase64(encrypted);
-    this.socket.send(JSON.stringify({ version: 1, docId, payload }));
+    const subscriptionId = this.confirmedSubscriptions.get(docId);
+    this.socket.send(
+      JSON.stringify({ version: 1, docId, payload, subscriptionId }),
+    );
   }
 
   hasActiveSubscriptions(): boolean {
-    return this.subscriptions.size > 0;
+    return this.subscriptionMeta.size > 0;
   }
 
   isSubscribed(docId: string): boolean {
@@ -548,15 +969,20 @@ class RelayConnectionImpl implements RelayConnection {
     this.socket?.close();
     this.socket = null;
     this.encryptionKeys.clear();
-    this.subscriptions.clear();
     this.confirmedSubscriptions.clear();
     this.subscriptionMeta.clear();
+    this.messageQueues.clear();
+    this.snapshotAssemblies.clear();
     setRelay(null);
   }
 }
 
 function connectRelay(
-  onMessage: (docId: string, event: RelayEvent) => void,
+  onMessage: (
+    docId: string,
+    event: RelayEvent,
+    context: RelayEventContext,
+  ) => Promise<void> | void,
   onStatusChange: (status: "connecting" | "connected" | "disconnected") => void,
 ): RelayConnection {
   const relay = new RelayConnectionImpl(onMessage, onStatusChange);
@@ -569,6 +995,11 @@ async function decryptPeerComment(
   key: CryptoKey,
   expectedCmtId: string,
 ): Promise<PeerComment> {
+  if (
+    encryptedPayloadByteLength(encryptedPayload) > MAX_ENCRYPTED_COMMENT_BYTES
+  ) {
+    throw new Error("Encrypted comment exceeds the 1 MiB safety limit");
+  }
   const raw = Uint8Array.from(atob(encryptedPayload), (char) =>
     char.charCodeAt(0),
   );
@@ -583,28 +1014,30 @@ async function decryptPeerComment(
   return parsed;
 }
 
-function findEncryptionKey(docId: string): CryptoKey | undefined {
+function findEncryptionKey(
+  docId: string,
+  role: RelaySubscriptionRole,
+): CryptoKey | undefined {
   const state = getRelayApplicationState();
-  if (state.isPeerMode) {
+  if (role === "peer") {
     return state.peerShareKeys[docId];
   }
-  for (const tab of state.tabs) {
-    if (tab.shareKeys[docId]) {
-      return tab.shareKeys[docId];
-    }
+  const owners = state.tabs.filter((tab) => tab.shareKeys[docId]);
+  if (owners.length !== 1) {
+    return undefined;
   }
-  return undefined;
+  return owners[0].shareKeys[docId];
 }
 
 function findHostSecret(docId: string): string | undefined {
   const state = getRelayApplicationState();
-  for (const tab of state.tabs) {
-    const record = tab.shares.find((share) => share.docId === docId);
-    if (record) {
-      return record.hostSecret;
-    }
+  const records = state.tabs.flatMap((tab) =>
+    tab.shares.filter((share) => share.docId === docId),
+  );
+  if (records.length !== 1) {
+    return undefined;
   }
-  return undefined;
+  return records[0].hostSecret;
 }
 
 function createShareStorage(): ShareStorage | null {
@@ -636,9 +1069,15 @@ async function decryptAndAddPendingComment(
   docId: string,
   cmtId: string,
   encryptedPayload: string,
+  context: RelayEventContext,
 ): Promise<void> {
-  const key = findEncryptionKey(docId);
+  const key = findEncryptionKey(docId, context.role);
   if (!key) {
+    getRelayApplicationState().quarantinePendingComment(
+      docId,
+      cmtId,
+      "Encryption key is unavailable",
+    );
     return;
   }
   try {
@@ -646,14 +1085,20 @@ async function decryptAndAddPendingComment(
     getRelayApplicationState().addPendingComment(docId, comment);
   } catch (error) {
     console.warn("[relay] failed to decrypt comment:", error);
+    getRelayApplicationState().quarantinePendingComment(
+      docId,
+      cmtId,
+      error instanceof Error ? error.message : "Invalid encrypted comment",
+    );
   }
 }
 
 async function decryptAndReplaceSnapshot(
   docId: string,
   entries: CommentsSnapshotEntry[],
+  context: RelayEventContext,
 ): Promise<void> {
-  const key = findEncryptionKey(docId);
+  const key = findEncryptionKey(docId, context.role);
   if (!key) {
     return;
   }
@@ -664,6 +1109,11 @@ async function decryptAndReplaceSnapshot(
       comments.push(comment);
     } catch (error) {
       console.warn("[relay] failed to decrypt snapshot comment:", error);
+      getRelayApplicationState().quarantinePendingComment(
+        docId,
+        entry.cmtId,
+        error instanceof Error ? error.message : "Invalid snapshot comment",
+      );
     }
   }
   getRelayApplicationState().replaceCommentsSnapshot(docId, comments);
@@ -697,43 +1147,56 @@ export async function applyPeerDocumentUpdate(
   await refreshPeerContent();
 }
 
-function handleIncomingMessage(docId: string, event: RelayEvent): void {
+async function handleIncomingMessage(
+  docId: string,
+  event: RelayEvent,
+  context: RelayEventContext,
+): Promise<void> {
   const state = getRelayApplicationState();
 
   if (event.type === "comment:added") {
-    if (!state.isPeerMode) {
-      void decryptAndAddPendingComment(docId, event.cmtId, event.payload);
+    if (context.role === "host") {
+      await decryptAndAddPendingComment(
+        docId,
+        event.cmtId,
+        event.payload,
+        context,
+      );
     }
     return;
   }
 
   if (event.type === "comments:snapshot") {
-    if (!state.isPeerMode) {
-      void decryptAndReplaceSnapshot(docId, event.comments);
+    if (context.role === "host") {
+      await decryptAndReplaceSnapshot(docId, event.comments, context);
     }
     return;
   }
 
   if (event.type === "comment:add:ack") {
-    state.confirmPeerCommentSubmitted(event.cmtId);
+    if (context.role === "peer") {
+      state.confirmPeerCommentSubmitted(event.cmtId);
+    }
     return;
   }
 
   if (event.type === "comment:resolve:ack") {
-    state.confirmPendingResolve(docId, event.cmtId);
+    if (context.role === "host") {
+      state.confirmPendingResolve(docId, event.cmtId);
+    }
     return;
   }
 
   if (event.type === "comment:resolved") {
-    if (state.isPeerMode) {
+    if (context.role === "peer") {
       state.deletePeerComment(event.cmtId);
     }
     return;
   }
 
   if (event.type === "document:updated") {
-    if (state.isPeerMode) {
-      void applyPeerDocumentUpdate(event.updatedAt);
+    if (context.role === "peer") {
+      await applyPeerDocumentUpdate(event.updatedAt);
     }
   }
 }
@@ -763,14 +1226,28 @@ function handleStatusChange(
   status: "connecting" | "connected" | "disconnected",
 ): void {
   getRelayApplicationState().setRelayStatus(status);
-  if (status === "connected") {
-    void performReconnectCatchUp();
-  }
 }
 
-function handleSubscribeConfirmed(docId: string): void {
+function handleSubscriptionState(
+  docId: string,
+  role: RelaySubscriptionRole,
+  subscription: RelaySubscriptionState,
+): void {
   const state = getRelayApplicationState();
-  if (state.isPeerMode) {
+  if (role === "peer") {
+    state.setPeerSubmissionSubscription(subscription);
+    return;
+  }
+  state.setIncomingReviewSubscription(docId, subscription);
+}
+
+function handleSubscribeConfirmed(
+  docId: string,
+  context: RelayEventContext,
+): void {
+  const state = getRelayApplicationState();
+  if (context.role === "peer") {
+    void performReconnectCatchUp();
     state.syncPeerComments().catch((error: unknown) => {
       console.warn("[relay] peer comment resend failed:", error);
     });
@@ -786,18 +1263,20 @@ export function startRelay(): void {
   connectRelay(handleIncomingMessage, handleStatusChange);
 }
 
-export function subscribeToDoc(docId: string): void {
+function subscribeToDocWithRole(
+  docId: string,
+  role: RelaySubscriptionRole,
+): void {
   const relay = getRelay();
   if (!relay) {
     return;
   }
-  const key = findEncryptionKey(docId);
+  const key = findEncryptionKey(docId, role);
   if (!key) {
     console.warn("[relay] no key for docId:", docId);
     return;
   }
-  const state = getRelayApplicationState();
-  if (state.isPeerMode) {
+  if (role === "peer") {
     relay.subscribe(docId, key, "peer");
     return;
   }
@@ -807,6 +1286,13 @@ export function subscribeToDoc(docId: string): void {
     return;
   }
   relay.subscribe(docId, key, "host", hostSecret);
+}
+
+export function subscribeToDoc(docId: string): void {
+  const role: RelaySubscriptionRole = getRelayApplicationState().isPeerMode
+    ? "peer"
+    : "host";
+  subscribeToDocWithRole(docId, role);
 }
 
 export function unsubscribeFromDoc(docId: string): void {
@@ -847,13 +1333,19 @@ export function ensureRelaySubscriptions(
   }
   startRelay();
   for (const share of activeShares) {
-    subscribeToDoc(share.docId);
+    subscribeToDocWithRole(share.docId, "host");
   }
 }
 
-export function startRelayForDoc(docId: string): void {
+export function startRelayForDoc(
+  docId: string,
+  role?: RelaySubscriptionRole,
+): void {
   startRelay();
-  subscribeToDoc(docId);
+  subscribeToDocWithRole(
+    docId,
+    role ?? (getRelayApplicationState().isPeerMode ? "peer" : "host"),
+  );
 }
 
 export function relayCommentResolve(docId: string, cmtId: string): void {

--- a/src/modules/relay/diagnostics.ts
+++ b/src/modules/relay/diagnostics.ts
@@ -1,0 +1,35 @@
+import type {
+  RelaySubscriptionPhase,
+  RelaySubscriptionRole,
+} from "../../types/relay";
+
+export interface RelayDiagnosticEntry {
+  at: string;
+  kind: "frame" | "subscription" | "rejection";
+  docId: string | null;
+  subscriptionId: string | null;
+  role: RelaySubscriptionRole | null;
+  frameType: string | null;
+  frameBytes: number | null;
+  phase: RelaySubscriptionPhase | null;
+  reason: string | null;
+}
+
+const MAX_DIAGNOSTIC_ENTRIES = 100;
+let entries: RelayDiagnosticEntry[] = [];
+
+export function recordRelayDiagnostic(
+  entry: Omit<RelayDiagnosticEntry, "at">,
+): void {
+  entries = [...entries, { ...entry, at: new Date().toISOString() }].slice(
+    -MAX_DIAGNOSTIC_ENTRIES,
+  );
+}
+
+export function getRelayDiagnostics(): RelayDiagnosticEntry[] {
+  return [...entries];
+}
+
+export function resetRelayDiagnostics(): void {
+  entries = [];
+}

--- a/src/modules/relay/index.ts
+++ b/src/modules/relay/index.ts
@@ -1,5 +1,6 @@
 export * from "./applicationPort";
 export * from "./controller";
+export * from "./diagnostics";
 export * from "./selectors";
 export * from "./state";
 export * from "./types";

--- a/src/modules/relay/test/doCommentStore.test.ts
+++ b/src/modules/relay/test/doCommentStore.test.ts
@@ -101,6 +101,40 @@ class FakeSqlStorage implements SqlStorage {
       return new FakeSqlCursor(rows);
     }
 
+    if (
+      normalizedQuery.startsWith(
+        "SELECT 1 AS found FROM comments WHERE doc_id = ? AND cmt_id = ? LIMIT 1",
+      )
+    ) {
+      const docId = this.expectString(params[0]);
+      const cmtId = this.expectString(params[1]);
+      const found = this.commentRows.some(
+        (commentRow) =>
+          commentRow.docId === docId && commentRow.cmtId === cmtId,
+      );
+      return new FakeSqlCursor(found ? [{ found: 1 }] : []);
+    }
+
+    if (
+      normalizedQuery.startsWith(
+        "SELECT COUNT(*) AS comment_count, COALESCE(SUM(LENGTH(payload)), 0) AS payload_chars FROM comments WHERE doc_id = ?",
+      )
+    ) {
+      const docId = this.expectString(params[0]);
+      const rows = this.commentRows.filter(
+        (commentRow) => commentRow.docId === docId,
+      );
+      return new FakeSqlCursor([
+        {
+          comment_count: rows.length,
+          payload_chars: rows.reduce(
+            (total, commentRow) => total + commentRow.payload.length,
+            0,
+          ),
+        },
+      ]);
+    }
+
     if (normalizedQuery.startsWith("INSERT OR IGNORE INTO comments")) {
       const docId = this.expectString(params[0]);
       const cmtId = this.expectString(params[1]);
@@ -320,6 +354,10 @@ class FakeWebSocket extends EventTarget implements WebSocket {
 
   sentFrames(): Array<Record<string, unknown>> {
     return this.sentMessages.map(parseSocketFrame);
+  }
+
+  rawSentMessages(): string[] {
+    return [...this.sentMessages];
   }
 
   dispatchOpen(): void {
@@ -568,7 +606,11 @@ describe("RelayHubSqlite", () => {
     );
 
     expect(unsubscribedSocket.sentFrames()).toEqual([
-      { type: "error", docId: "doc-1", message: "Not subscribed" },
+      {
+        type: "error",
+        docId: "doc-1",
+        message: "Not subscribed as peer",
+      },
     ]);
     expect(state.sql.hasComment("doc-1", "c-1")).toBe(false);
   });
@@ -633,6 +675,301 @@ describe("RelayHubSqlite", () => {
       { type: "comment:resolved", docId: "doc-1", cmtId: "c-1" },
     ]);
   });
+
+  it("echoes each recipient subscription generation on snapshots and live events", async () => {
+    const { relayHub, kv, createSocket } = createRelayHarness();
+    const hostSecret = "host-secret";
+    kv.set(
+      "share:doc-1:meta",
+      createShareMetaJson(await sha256hex(hostSecret)),
+    );
+    const hostSocket = createSocket();
+    const peerSocket = createSocket();
+
+    await relayHub.webSocketMessage(
+      hostSocket,
+      JSON.stringify({
+        type: "subscribe",
+        docId: "doc-1",
+        role: "host",
+        hostSecret,
+        subscriptionId: "host-generation",
+      }),
+    );
+    expect(hostSocket.sentFrames()).toEqual([
+      {
+        type: "subscribe:ok",
+        docId: "doc-1",
+        subscriptionId: "host-generation",
+      },
+      {
+        type: "comments:snapshot",
+        docId: "doc-1",
+        comments: [],
+        subscriptionId: "host-generation",
+        snapshotId: expect.any(String),
+        chunkIndex: 0,
+        chunkCount: 1,
+      },
+    ]);
+    hostSocket.resetSentFrames();
+
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({
+        type: "subscribe",
+        docId: "doc-1",
+        role: "peer",
+        subscriptionId: "peer-generation",
+      }),
+    );
+    peerSocket.resetSentFrames();
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({
+        type: "comment:add",
+        docId: "doc-1",
+        cmtId: "c-generation",
+        payload: "ciphertext",
+        subscriptionId: "peer-generation",
+      }),
+    );
+
+    expect(peerSocket.sentFrames()).toEqual([
+      {
+        type: "comment:add:ack",
+        docId: "doc-1",
+        cmtId: "c-generation",
+        subscriptionId: "peer-generation",
+      },
+    ]);
+    expect(hostSocket.sentFrames()).toEqual([
+      {
+        type: "comment:added",
+        docId: "doc-1",
+        cmtId: "c-generation",
+        payload: "ciphertext",
+        subscriptionId: "host-generation",
+      },
+    ]);
+  });
+
+  it("chunks a generation-scoped snapshot below the inbound frame limit", async () => {
+    const { relayHub, state, kv, createSocket } = createRelayHarness();
+    const hostSecret = "host-secret";
+    kv.set(
+      "share:doc-1:meta",
+      createShareMetaJson(await sha256hex(hostSecret)),
+    );
+    const expiresAt = Date.now() + 60_000;
+    state.sql.seedComment({
+      docId: "doc-1",
+      cmtId: "large-1",
+      payload: "a".repeat(800_000),
+      createdAt: 1,
+      expiresAt,
+    });
+    state.sql.seedComment({
+      docId: "doc-1",
+      cmtId: "large-2",
+      payload: "b".repeat(800_000),
+      createdAt: 2,
+      expiresAt,
+    });
+    const hostSocket = createSocket();
+
+    await relayHub.webSocketMessage(
+      hostSocket,
+      JSON.stringify({
+        type: "subscribe",
+        docId: "doc-1",
+        role: "host",
+        hostSecret,
+        subscriptionId: "chunked-generation",
+      }),
+    );
+
+    const frames = hostSocket.sentFrames();
+    const snapshotFrames = frames.filter(
+      (frame) => frame["type"] === "comments:snapshot",
+    );
+    expect(snapshotFrames).toHaveLength(2);
+    expect(snapshotFrames.map((frame) => frame["chunkIndex"])).toEqual([0, 1]);
+    expect(snapshotFrames.every((frame) => frame["chunkCount"] === 2)).toBe(
+      true,
+    );
+    expect(
+      hostSocket
+        .rawSentMessages()
+        .slice(1)
+        .every((message) => {
+          return new TextEncoder().encode(message).byteLength < 1_500_000;
+        }),
+    ).toBe(true);
+  });
+
+  it("echoes a stale operation generation without failing the current one", async () => {
+    const { relayHub, state, kv, createSocket } = createRelayHarness();
+    kv.set(
+      "share:doc-1:meta",
+      createShareMetaJson(await sha256hex("host-secret")),
+    );
+    const peerSocket = createSocket();
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({
+        type: "subscribe",
+        docId: "doc-1",
+        role: "peer",
+        subscriptionId: "current-generation",
+      }),
+    );
+    peerSocket.resetSentFrames();
+
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({
+        type: "comment:add",
+        docId: "doc-1",
+        cmtId: "stale-comment",
+        payload: "ciphertext",
+        subscriptionId: "old-generation",
+      }),
+    );
+
+    expect(peerSocket.sentFrames()).toEqual([
+      {
+        type: "error",
+        docId: "doc-1",
+        cmtId: "stale-comment",
+        scope: "operation",
+        message: "Stale subscription generation",
+        subscriptionId: "old-generation",
+      },
+    ]);
+    expect(state.sql.hasComment("doc-1", "stale-comment")).toBe(false);
+  });
+
+  it("forwards encrypted document updates only from a subscribed host", async () => {
+    const { relayHub, kv, createSocket } = createRelayHarness();
+    const hostSecret = "host-secret";
+    kv.set(
+      "share:doc-1:meta",
+      createShareMetaJson(await sha256hex(hostSecret)),
+    );
+    const hostSocket = createSocket();
+    const peerSocket = createSocket();
+    await relayHub.webSocketMessage(
+      hostSocket,
+      JSON.stringify({
+        type: "subscribe",
+        docId: "doc-1",
+        role: "host",
+        hostSecret,
+        subscriptionId: "host-generation",
+      }),
+    );
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({
+        type: "subscribe",
+        docId: "doc-1",
+        role: "peer",
+        subscriptionId: "peer-generation",
+      }),
+    );
+    hostSocket.resetSentFrames();
+    peerSocket.resetSentFrames();
+
+    await relayHub.webSocketMessage(
+      hostSocket,
+      JSON.stringify({
+        version: 1,
+        docId: "doc-1",
+        payload: "encrypted-update",
+        subscriptionId: "host-generation",
+      }),
+    );
+
+    expect(hostSocket.sentFrames()).toEqual([]);
+    expect(peerSocket.sentFrames()).toEqual([
+      {
+        version: 1,
+        docId: "doc-1",
+        payload: "encrypted-update",
+        subscriptionId: "peer-generation",
+      },
+    ]);
+  });
+
+  it("rejects oversized encrypted comment payloads before persistence", async () => {
+    const { relayHub, state, kv, createSocket } = createRelayHarness();
+    kv.set(
+      "share:doc-1:meta",
+      createShareMetaJson(await sha256hex("host-secret")),
+    );
+    const peerSocket = createSocket();
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({ type: "subscribe", docId: "doc-1", role: "peer" }),
+    );
+    peerSocket.resetSentFrames();
+
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({
+        type: "comment:add",
+        docId: "doc-1",
+        cmtId: "c-oversized",
+        payload: "A".repeat(1_400_000),
+      }),
+    );
+
+    expect(state.sql.hasComment("doc-1", "c-oversized")).toBe(false);
+    expect(peerSocket.sentFrames()).toEqual([
+      {
+        type: "error",
+        docId: "doc-1",
+        cmtId: "c-oversized",
+        scope: "operation",
+        message: "Comment payload too large",
+      },
+    ]);
+  });
+
+  it("rate limits comment writes per socket", async () => {
+    const { relayHub, kv, createSocket } = createRelayHarness();
+    kv.set(
+      "share:doc-1:meta",
+      createShareMetaJson(await sha256hex("host-secret")),
+    );
+    const peerSocket = createSocket();
+    await relayHub.webSocketMessage(
+      peerSocket,
+      JSON.stringify({ type: "subscribe", docId: "doc-1", role: "peer" }),
+    );
+    peerSocket.resetSentFrames();
+
+    for (let commentIndex = 0; commentIndex < 61; commentIndex += 1) {
+      await relayHub.webSocketMessage(
+        peerSocket,
+        JSON.stringify({
+          type: "comment:add",
+          docId: "doc-1",
+          cmtId: `c-${commentIndex}`,
+          payload: "ciphertext",
+        }),
+      );
+    }
+
+    expect(peerSocket.sentFrames().at(-1)).toEqual({
+      type: "error",
+      docId: "doc-1",
+      cmtId: "c-60",
+      scope: "operation",
+      message: "Comment rate limit exceeded",
+    });
+  });
 });
 
 describe("relay client snapshot validation", () => {
@@ -675,6 +1012,9 @@ describe("relay client snapshot validation", () => {
         .getState()
         .tabs.find((tab) => tab.id === "test-tab");
       expect(activeTab?.pendingComments["doc-1"]).toBeUndefined();
+      expect(
+        activeTab?.incomingReviewSessions["doc-1"]?.quarantinedItems,
+      ).toHaveLength(1);
       expect(warnSpy).toHaveBeenCalledWith(
         "[relay] failed to decrypt snapshot comment:",
         expect.any(Error),

--- a/src/modules/relay/test/ordering.test.ts
+++ b/src/modules/relay/test/ordering.test.ts
@@ -1,0 +1,312 @@
+import { waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const decryptedComments = new Map<string, string>();
+let releaseSlowDecrypt = (): void => undefined;
+let slowDecrypt = Promise.resolve();
+
+vi.mock("../../../services/crypto", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../services/crypto")>();
+  return {
+    ...actual,
+    decrypt: vi.fn(async (buffer: ArrayBuffer) => {
+      const marker = new TextDecoder().decode(buffer);
+      if (marker === "slow") {
+        await slowDecrypt;
+      }
+      const commentJson = decryptedComments.get(marker);
+      if (!commentJson) {
+        throw new Error("Unknown encrypted test marker");
+      }
+      return new TextEncoder().encode(commentJson).buffer;
+    }),
+  };
+});
+
+vi.mock("../../../config", () => ({
+  WORKER_URL: "https://mock-worker.test",
+}));
+
+import { generateKey } from "../../../services/crypto";
+import { startRelayForDoc, stopRelay, subscribeToDoc } from "../controller";
+import { useAppStore } from "../../../store";
+import {
+  makePeerComment,
+  makeShare,
+  resetTestStore,
+  setTestState,
+} from "../../../testing/testHelpers";
+
+function parseFrame(message: string): Record<string, unknown> {
+  const value: unknown = JSON.parse(message);
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Expected object frame");
+  }
+  return value;
+}
+
+class OrderingWebSocket extends EventTarget {
+  static readonly OPEN = 1;
+
+  static latest: OrderingWebSocket | null = null;
+
+  readyState = 0;
+
+  sent: string[] = [];
+
+  constructor(readonly url: string) {
+    super();
+    OrderingWebSocket.latest = this;
+  }
+
+  send(message: string): void {
+    this.sent.push(message);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.dispatchEvent(new CloseEvent("close"));
+  }
+
+  open(): void {
+    this.readyState = OrderingWebSocket.OPEN;
+    this.dispatchEvent(new Event("open"));
+  }
+
+  receive(frame: Record<string, unknown>): void {
+    this.dispatchEvent(
+      new MessageEvent("message", { data: JSON.stringify(frame) }),
+    );
+  }
+
+  latestSubscriptionId(): string {
+    const subscribeFrames = this.sent
+      .map(parseFrame)
+      .filter((frame) => frame["type"] === "subscribe");
+    const subscriptionId = subscribeFrames.at(-1)?.["subscriptionId"];
+    if (typeof subscriptionId !== "string") {
+      throw new Error("Expected subscription id");
+    }
+    return subscriptionId;
+  }
+}
+
+function markerPayload(marker: string): string {
+  return btoa(marker);
+}
+
+beforeEach(async () => {
+  resetTestStore();
+  decryptedComments.clear();
+  slowDecrypt = new Promise<void>((resolve) => {
+    releaseSlowDecrypt = resolve;
+  });
+  vi.stubGlobal("WebSocket", OrderingWebSocket);
+  const key = await generateKey();
+  setTestState(
+    {
+      shares: [makeShare()],
+      shareKeys: { "doc-1": key },
+    },
+    { isPeerMode: false },
+  );
+});
+
+afterEach(() => {
+  releaseSlowDecrypt();
+  stopRelay();
+  vi.unstubAllGlobals();
+  OrderingWebSocket.latest = null;
+});
+
+describe("relay subscription ordering", () => {
+  it("reassembles a chunked snapshot before marking the host subscription live", async () => {
+    const firstComment = makePeerComment({ id: "first-comment" });
+    const secondComment = makePeerComment({ id: "second-comment" });
+    decryptedComments.set("first", JSON.stringify(firstComment));
+    decryptedComments.set("second", JSON.stringify(secondComment));
+
+    startRelayForDoc("doc-1", "host");
+    const socket = OrderingWebSocket.latest;
+    if (!socket) {
+      throw new Error("Expected relay socket");
+    }
+    socket.open();
+    const subscriptionId = socket.latestSubscriptionId();
+    socket.receive({ type: "subscribe:ok", docId: "doc-1", subscriptionId });
+    socket.receive({
+      type: "comments:snapshot",
+      docId: "doc-1",
+      subscriptionId,
+      snapshotId: "snapshot-1",
+      chunkIndex: 0,
+      chunkCount: 2,
+      comments: [{ cmtId: firstComment.id, payload: markerPayload("first") }],
+    });
+
+    await waitFor(() => {
+      const tab = useAppStore
+        .getState()
+        .tabs.find((item) => item.id === "test-tab");
+      expect(tab?.incomingReviewSessions["doc-1"]?.subscription.phase).toBe(
+        "syncing",
+      );
+      expect(tab?.pendingComments["doc-1"]).toBeUndefined();
+    });
+
+    socket.receive({
+      type: "comments:snapshot",
+      docId: "doc-1",
+      subscriptionId,
+      snapshotId: "snapshot-1",
+      chunkIndex: 1,
+      chunkCount: 2,
+      comments: [{ cmtId: secondComment.id, payload: markerPayload("second") }],
+    });
+
+    await waitFor(() => {
+      const tab = useAppStore
+        .getState()
+        .tabs.find((item) => item.id === "test-tab");
+      expect(
+        tab?.pendingComments["doc-1"]?.map((comment) => comment.id),
+      ).toEqual([firstComment.id, secondComment.id]);
+      expect(tab?.incomingReviewSessions["doc-1"]?.subscription.phase).toBe(
+        "live",
+      );
+    });
+  });
+
+  it("applies a snapshot before a later live comment for the same generation", async () => {
+    const snapshotComment = makePeerComment({ id: "snapshot-comment" });
+    const liveComment = makePeerComment({ id: "live-comment" });
+    decryptedComments.set("slow", JSON.stringify(snapshotComment));
+    decryptedComments.set("fast", JSON.stringify(liveComment));
+
+    startRelayForDoc("doc-1", "host");
+    const socket = OrderingWebSocket.latest;
+    if (!socket) {
+      throw new Error("Expected relay socket");
+    }
+    socket.open();
+    const subscriptionId = socket.latestSubscriptionId();
+    socket.receive({
+      type: "subscribe:ok",
+      docId: "doc-1",
+      subscriptionId,
+    });
+    socket.receive({
+      type: "comments:snapshot",
+      docId: "doc-1",
+      subscriptionId,
+      comments: [{ cmtId: snapshotComment.id, payload: markerPayload("slow") }],
+    });
+    socket.receive({
+      type: "comment:added",
+      docId: "doc-1",
+      subscriptionId,
+      cmtId: liveComment.id,
+      payload: markerPayload("fast"),
+    });
+
+    releaseSlowDecrypt();
+
+    await waitFor(() => {
+      const tab = useAppStore
+        .getState()
+        .tabs.find((item) => item.id === "test-tab");
+      expect(
+        tab?.pendingComments["doc-1"]?.map((comment) => comment.id),
+      ).toEqual([snapshotComment.id, liveComment.id]);
+      expect(tab?.incomingReviewSessions["doc-1"]?.subscription.phase).toBe(
+        "live",
+      );
+    });
+  });
+
+  it("ignores events from a superseded subscription generation", async () => {
+    const staleComment = makePeerComment({ id: "stale-comment" });
+    decryptedComments.set("fast", JSON.stringify(staleComment));
+
+    startRelayForDoc("doc-1", "host");
+    const socket = OrderingWebSocket.latest;
+    if (!socket) {
+      throw new Error("Expected relay socket");
+    }
+    socket.open();
+    const oldSubscriptionId = socket.latestSubscriptionId();
+    subscribeToDoc("doc-1");
+    const currentSubscriptionId = socket.latestSubscriptionId();
+    expect(currentSubscriptionId).not.toBe(oldSubscriptionId);
+
+    socket.receive({
+      type: "comment:added",
+      docId: "doc-1",
+      subscriptionId: oldSubscriptionId,
+      cmtId: staleComment.id,
+      payload: markerPayload("fast"),
+    });
+    socket.receive({
+      type: "subscribe:ok",
+      docId: "doc-1",
+      subscriptionId: currentSubscriptionId,
+    });
+    socket.receive({
+      type: "comments:snapshot",
+      docId: "doc-1",
+      subscriptionId: currentSubscriptionId,
+      comments: [],
+    });
+
+    await waitFor(() => {
+      const tab = useAppStore
+        .getState()
+        .tabs.find((item) => item.id === "test-tab");
+      expect(tab?.pendingComments["doc-1"]).toBeUndefined();
+      expect(
+        tab?.incomingReviewSessions["doc-1"]?.subscription.subscriptionId,
+      ).toBe(currentSubscriptionId);
+    });
+  });
+
+  it("keeps a confirmed subscription live after an operation-level rejection", async () => {
+    startRelayForDoc("doc-1", "host");
+    const socket = OrderingWebSocket.latest;
+    if (!socket) {
+      throw new Error("Expected relay socket");
+    }
+    socket.open();
+    const subscriptionId = socket.latestSubscriptionId();
+    socket.receive({
+      type: "subscribe:ok",
+      docId: "doc-1",
+      subscriptionId,
+    });
+    socket.receive({
+      type: "comments:snapshot",
+      docId: "doc-1",
+      subscriptionId,
+      comments: [],
+    });
+    socket.receive({
+      type: "error",
+      docId: "doc-1",
+      subscriptionId,
+      scope: "operation",
+      cmtId: "c-too-large",
+      message: "Comment payload too large",
+    });
+
+    await waitFor(() => {
+      const tab = useAppStore
+        .getState()
+        .tabs.find((item) => item.id === "test-tab");
+      expect(tab?.incomingReviewSessions["doc-1"]?.subscription.phase).toBe(
+        "live",
+      );
+      expect(useAppStore.getState().relayStatus).toBe("connected");
+      expect(useAppStore.getState().toast).toBe("Comment payload too large");
+    });
+  });
+});

--- a/src/modules/sharing/README.md
+++ b/src/modules/sharing/README.md
@@ -12,6 +12,8 @@ Owns host-side share lifecycle and unresolved incoming peer review state.
 - shared panel state
 - pending peer comments per shared document
 - queued resolve IDs
+- stable workspace-to-share ownership
+- per-share subscription and quarantine state
 
 ## Does not own
 
@@ -28,13 +30,15 @@ Owns host-side share lifecycle and unresolved incoming peer review state.
 - `sharedPanelOpen`
 - `pendingComments`
 - `pendingResolveCommentIds`
+- `incomingReviewSessions`
 
 ## Public API
 
 - `createSharingTabState`
 - `createSharingActions`
 - sharing selectors
-- share persistence helpers (`saveShares`, `loadAndCleanShares`, `restoreShareKeys`)
+- stable share registry and additive legacy migration in `registry.ts`
+- durable resolve outbox in `resolveOutbox.ts`
 - `ShareStorage` via module-local `storage.ts`
 
 ## Side Effects
@@ -44,6 +48,7 @@ Owns host-side share lifecycle and unresolved incoming peer review state.
 - share session restore
 - local share-record persistence
 - pending incoming peer-comment reconcile
+- fail-closed merge orchestration against the exact owning tab
 
 ## Related Docs
 
@@ -55,8 +60,14 @@ Owns host-side share lifecycle and unresolved incoming peer review state.
 
 - unresolved incoming peer comments are keyed by `docId`
 - queued resolve IDs must survive reconnect behavior without resurrecting removed comments
+- a resolve must be persisted before its incoming item is hidden
+- share ownership is a stable workspace ID, never a display-name or active-tab guess
+- merge must revalidate owner, file target, content, and anchor before writing;
+  its embedded peer-comment ID is idempotent on retry
 
 ## Common Failure Modes
 
 - mixing relay connection logic into share state
 - coupling share CRUD directly to peer review draft state
+- first-match ownership when workspace names collide
+- hiding review work before resolve intent is durable

--- a/src/modules/sharing/controller.ts
+++ b/src/modules/sharing/controller.ts
@@ -9,13 +9,11 @@ import {
 import { WORKER_URL } from "../../config";
 import { base64urlToKey } from "../../services/crypto";
 import { readFile } from "../../runtime";
-import { isBrowserFileHandle } from "../../types/fileTree";
 import type { FileTreeNode } from "../../types/fileTree";
-import { isShareRecordArray } from "../../types/share";
 import type { PeerComment, ShareRecord } from "../../types/share";
 import type { TabState } from "../../types/tab";
 import { buildShareUrlFromOrigin } from "../../utils/shareUrl";
-import { writeAndUpdate } from "../host-review";
+import { writeAndUpdateTab } from "../host-review";
 import {
   ensureRelaySubscriptions,
   relayCommentResolve,
@@ -27,12 +25,11 @@ import {
 } from "./state";
 import { ShareStorage } from "./storage";
 import { prepareShareIdentity } from "./shareIdentity";
+import { saveShares } from "./registry";
 import type { ShareContentOptions, SharingActions } from "./types";
 
 type SetState<StoreState> = StoreApi<StoreState>["setState"];
 type GetState<StoreState> = StoreApi<StoreState>["getState"];
-
-const SHARES_KEY = "markreview-shares";
 
 interface SharingControllerStoreState {
   tabs: TabState[];
@@ -57,101 +54,6 @@ interface SharingControllerDeps<
     updater: (tab: TabState) => Partial<TabState>,
   ) => TabState[];
   getLiveFileTree: (tab: TabState) => FileTreeNode[];
-}
-
-function isShareRecordMap(
-  value: unknown,
-): value is Record<string, ShareRecord[]> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-  return Object.values(value).every(isShareRecordArray);
-}
-
-function loadAllShares(): Record<string, ShareRecord[]> {
-  try {
-    const raw = localStorage.getItem(SHARES_KEY);
-    if (!raw) {
-      return {};
-    }
-    const parsed: unknown = JSON.parse(raw);
-    if (isShareRecordMap(parsed)) {
-      return parsed;
-    }
-    return {};
-  } catch (error) {
-    console.warn("[sharing] failed to load persisted shares:", error);
-    return {};
-  }
-}
-
-function saveAllShares(allShares: Record<string, ShareRecord[]>) {
-  localStorage.setItem(SHARES_KEY, JSON.stringify(allShares));
-}
-
-export function stableShareKey(tab: {
-  directoryName: string | null;
-  fileName: string | null;
-  id: string;
-}): string {
-  return tab.directoryName ?? tab.fileName ?? tab.id;
-}
-
-export function saveShares(key: string, shares: ShareRecord[]) {
-  const allShares = loadAllShares();
-  allShares[key] = shares;
-  saveAllShares(allShares);
-}
-
-export function loadAndCleanShares(
-  tabs: {
-    id: string;
-    directoryName: string | null;
-    fileName: string | null;
-  }[],
-): Record<string, ShareRecord[]> {
-  const allShares = loadAllShares();
-  let changed = false;
-
-  for (const tab of tabs) {
-    const stableKey = stableShareKey(tab);
-    if (tab.id === stableKey) {
-      continue;
-    }
-    const oldShares = allShares[tab.id];
-    if (!oldShares || oldShares.length === 0) {
-      continue;
-    }
-    const existingShares = allShares[stableKey] ?? [];
-    const existingDocIds = new Set(existingShares.map((share) => share.docId));
-    const mergedShares = [
-      ...existingShares,
-      ...oldShares.filter((share) => !existingDocIds.has(share.docId)),
-    ];
-    allShares[stableKey] = mergedShares;
-    delete allShares[tab.id];
-    changed = true;
-  }
-
-  const now = new Date();
-  for (const key of Object.keys(allShares)) {
-    const liveShares = allShares[key].filter(
-      (share) => new Date(share.expiresAt) > now,
-    );
-    if (liveShares.length !== allShares[key].length) {
-      changed = true;
-    }
-    if (liveShares.length === 0) {
-      delete allShares[key];
-    } else {
-      allShares[key] = liveShares;
-    }
-  }
-
-  if (changed) {
-    saveAllShares(allShares);
-  }
-  return allShares;
 }
 
 export async function collectTreeContents(
@@ -298,10 +200,19 @@ function findSharingTabByDocId(
   tabs: TabState[],
   docId: string,
 ): TabState | null {
-  return (
-    tabs.find((tab) => tab.shares.some((share) => share.docId === docId)) ??
-    null
+  const owners = tabs.filter((tab) =>
+    tab.shares.some((share) => share.docId === docId),
   );
+  if (owners.length !== 1) {
+    if (owners.length > 1) {
+      console.warn("[sharing] share owner is ambiguous", {
+        docId,
+        ownerWorkspaceIds: owners.map((tab) => tab.workspaceId),
+      });
+    }
+    return null;
+  }
+  return owners[0];
 }
 
 type UpdateSharingTabStateOptions<StoreState extends { tabs: TabState[] }> = {
@@ -349,13 +260,35 @@ export function buildMergedPeerCommentContent(
     parsed.cleanMarkdown,
     comment.blockRef.blockIndex,
   );
+  if (!blockMap) {
+    throw new Error("The commented block no longer exists");
+  }
+  const stableCommentId = `mr-peer-${comment.id}`;
+  if (
+    parsed.comments.some(
+      (existingComment) =>
+        existingComment.thread?.commentId === stableCommentId,
+    )
+  ) {
+    return rawContent;
+  }
   const peerAnchor =
-    blockMap && comment.blockRef.quote && comment.blockRef.occurrence
+    comment.blockRef.quote && comment.blockRef.occurrence
       ? resolveCommentAnchor(blockMap.plainText, {
           quote: comment.blockRef.quote,
           occurrence: comment.blockRef.occurrence,
         })
       : undefined;
+  if (peerAnchor?.orphaned) {
+    throw new Error("The selected text changed since this comment was sent");
+  }
+  if (
+    !peerAnchor &&
+    comment.blockRef.contentPreview &&
+    !blockMap.plainText.startsWith(comment.blockRef.contentPreview)
+  ) {
+    throw new Error("The commented block changed since this comment was sent");
+  }
   const newBody = insertCommentService({
     rawContent: document.body,
     existingComments: parsed.comments,
@@ -364,9 +297,36 @@ export function buildMergedPeerCommentContent(
     type: comment.commentType,
     text: comment.text,
     authorLabel: comment.peerName,
-    anchor: peerAnchor?.orphaned ? undefined : peerAnchor,
+    stableCommentId,
+    anchor: peerAnchor,
   });
-  return rawContent.slice(0, document.bodyStart) + newBody;
+  const nextRawContent = rawContent.slice(0, document.bodyStart) + newBody;
+  if (nextRawContent === rawContent) {
+    throw new Error("The comment could not be inserted safely");
+  }
+  return nextRawContent;
+}
+
+async function hashContent(content: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(content),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function isDeterministicallyMerged(
+  rawContent: string,
+  comment: PeerComment,
+): boolean {
+  const document = parseMarkdownFrontmatter(rawContent);
+  const parsed = parseCriticMarkup(document.body);
+  const stableCommentId = `mr-peer-${comment.id}`;
+  return parsed.comments.some(
+    (existingComment) => existingComment.thread?.commentId === stableCommentId,
+  );
 }
 
 export function createSharingControllerActions<
@@ -444,7 +404,19 @@ export function createSharingControllerActions<
       }
 
       const shares = [...currentTab.shares, record];
-      saveShares(stableShareKey(currentTab), shares);
+      if (!saveShares(currentTab.workspaceId, shares)) {
+        try {
+          await storage.deleteContent(docId, record.hostSecret);
+        } catch (cleanupError) {
+          console.warn(
+            "[sharing] failed to revoke an unpersisted share:",
+            cleanupError,
+          );
+        }
+        throw new Error(
+          "The share could not be saved in this browser. No review link was created.",
+        );
+      }
       updateSharingTabState({
         set,
         buildUpdatedTabs,
@@ -478,7 +450,7 @@ export function createSharingControllerActions<
       }
 
       const updatedShares = tab.shares.filter((share) => share.docId !== docId);
-      saveShares(stableShareKey(tab), updatedShares);
+      saveShares(tab.workspaceId, updatedShares);
       updateSharingTabState({
         set,
         buildUpdatedTabs,
@@ -508,7 +480,7 @@ export function createSharingControllerActions<
     },
 
     mergeComment: async (docId, comment) => {
-      const tab = getActiveTab(get);
+      const tab = findSharingTabByDocId(get().tabs, docId);
       if (!tab?.fileHandle) {
         console.error("[mergeComment] no active tab or fileHandle", {
           hasTab: !!tab,
@@ -522,7 +494,7 @@ export function createSharingControllerActions<
             hasHandle: !!currentTab.fileHandle,
           })),
         });
-        return;
+        return false;
       }
 
       const currentPath = tab.activeFilePath ?? tab.fileName ?? "";
@@ -531,97 +503,135 @@ export function createSharingControllerActions<
           commentPath: comment.path,
           currentPath,
         });
-        return;
+        return false;
       }
+      const ownerTabId = tab.id;
+      const expectedFileHandle = tab.fileHandle;
+      const expectedPath = currentPath;
+      const expectedRawContent = tab.rawContent;
 
-      const readPermission = isBrowserFileHandle(tab.fileHandle)
-        ? await tab.fileHandle.queryPermission({
-            mode: "read",
-          })
-        : "native";
-      const writePermission = isBrowserFileHandle(tab.fileHandle)
-        ? await tab.fileHandle.queryPermission({
-            mode: "readwrite",
-          })
-        : "native";
-      console.log("[mergeComment] proceeding", {
-        tabId: tab.id,
-        fileName: tab.fileName,
-        activeFilePath: tab.activeFilePath,
-        readPermission,
-        writePermission,
-        commentPath: comment.path,
-        blockIndex: comment.blockRef.blockIndex,
-      });
+      try {
+        const [expectedHash, liveRawContent] = await Promise.all([
+          hashContent(expectedRawContent),
+          readFile(expectedFileHandle),
+        ]);
+        const liveHash = await hashContent(liveRawContent);
+        const currentOwner = get().tabs.find(
+          (candidate) => candidate.id === ownerTabId,
+        );
+        const ownerStillMatches =
+          currentOwner?.fileHandle === expectedFileHandle &&
+          (currentOwner.activeFilePath ?? currentOwner.fileName ?? "") ===
+            expectedPath;
+        if (!ownerStillMatches || liveHash !== expectedHash) {
+          console.warn("[mergeComment] document changed before merge", {
+            docId,
+            cmtId: comment.id,
+            ownerTabId,
+          });
+          return false;
+        }
 
-      const newRaw = buildMergedPeerCommentContent(tab.rawContent, comment);
-      if (newRaw === tab.rawContent) {
-        console.error("[mergeComment] insert had no effect", {
-          blockIndex: comment.blockRef.blockIndex,
-          commentType: comment.commentType,
-          contentLength: tab.rawContent.length,
+        const alreadyMerged = isDeterministicallyMerged(
+          liveRawContent,
+          comment,
+        );
+        const newRawContent = alreadyMerged
+          ? liveRawContent
+          : buildMergedPeerCommentContent(liveRawContent, comment);
+        if (!alreadyMerged) {
+          const writeSucceeded = await writeAndUpdateTab({
+            set,
+            buildUpdatedTabs,
+            tabId: ownerTabId,
+            fileHandle: expectedFileHandle,
+            expectedRawContent,
+            newRawContent,
+          });
+          if (!writeSucceeded) {
+            return false;
+          }
+        }
+
+        if (!queuePendingResolve(docId, comment.id)) {
+          console.warn("[mergeComment] resolve outbox is unavailable", {
+            docId,
+            cmtId: comment.id,
+          });
+          return false;
+        }
+
+        const latestOwner = get().tabs.find(
+          (candidate) => candidate.id === ownerTabId,
+        );
+        if (!latestOwner) {
+          return false;
+        }
+        const nextTabState = removePendingCommentState(
+          latestOwner,
+          docId,
+          comment.id,
+        );
+        saveShares(latestOwner.workspaceId, nextTabState.shares);
+        updateSharingTabState({
+          set,
+          buildUpdatedTabs,
+          tabId: ownerTabId,
+          updater: () => nextTabState,
         });
+        flushPendingCommentResolvesForDoc(get().tabs, docId);
+        return true;
+      } catch (error) {
+        console.warn("[mergeComment] merge rejected:", error);
+        return false;
       }
-
-      const writeSucceeded = await writeAndUpdate({
-        set,
-        buildUpdatedActiveTabs,
-        fileHandle: tab.fileHandle,
-        newRawContent: newRaw,
-      });
-      if (!writeSucceeded) {
-        return;
-      }
-
-      const latestTab = getActiveTab(get);
-      if (!latestTab) {
-        return;
-      }
-
-      const nextTabState = removePendingCommentState(
-        latestTab,
-        docId,
-        comment.id,
-      );
-      saveShares(stableShareKey(latestTab), nextTabState.shares);
-      updateSharingTabState({
-        set,
-        buildUpdatedTabs,
-        tabId: latestTab.id,
-        updater: () => nextTabState,
-      });
-      queuePendingResolve(docId, comment.id);
-      flushPendingCommentResolvesForDoc(get().tabs, docId);
     },
 
     dismissComment: (docId, cmtId) => {
-      const tab = getActiveTab(get);
+      const tab = findSharingTabByDocId(get().tabs, docId);
       if (!tab) {
         return;
       }
 
-      const nextTabState = removePendingCommentState(tab, docId, cmtId);
-      saveShares(stableShareKey(tab), nextTabState.shares);
+      if (!queuePendingResolve(docId, cmtId)) {
+        return;
+      }
+
+      const queuedTab = get().tabs.find((candidate) => candidate.id === tab.id);
+      if (!queuedTab) {
+        return;
+      }
+      const nextTabState = removePendingCommentState(queuedTab, docId, cmtId);
+      saveShares(tab.workspaceId, nextTabState.shares);
       updateSharingTabState({
         set,
         buildUpdatedTabs,
         tabId: tab.id,
         updater: () => nextTabState,
       });
-      queuePendingResolve(docId, cmtId);
       flushPendingCommentResolvesForDoc(get().tabs, docId);
     },
 
     clearPendingComments: (docId) => {
-      const tab = getActiveTab(get);
+      const tab = findSharingTabByDocId(get().tabs, docId);
       if (!tab) {
         return;
       }
 
       const pendingForDoc = tab.pendingComments[docId] ?? [];
       const clearedIds = pendingForDoc.map((comment) => comment.id);
-      const nextTabState = replacePendingCommentsState(tab, docId, []);
-      saveShares(stableShareKey(tab), nextTabState.shares);
+      const allQueued = clearedIds.every((clearedId) =>
+        queuePendingResolve(docId, clearedId),
+      );
+      if (!allQueued) {
+        return;
+      }
+      const queuedTab = get().tabs.find((candidate) => candidate.id === tab.id);
+      if (!queuedTab) {
+        return;
+      }
+      const nextTabState = replacePendingCommentsState(queuedTab, docId, []);
+      saveShares(tab.workspaceId, nextTabState.shares);
       updateSharingTabState({
         set,
         buildUpdatedTabs,
@@ -629,9 +639,6 @@ export function createSharingControllerActions<
         updater: () => nextTabState,
       });
 
-      for (const clearedId of clearedIds) {
-        queuePendingResolve(docId, clearedId);
-      }
       flushPendingCommentResolvesForDoc(get().tabs, docId);
     },
 
@@ -655,13 +662,13 @@ export function createSharingControllerActions<
         ...existingComments,
         comment,
       ]);
-      saveShares(stableShareKey(targetTab), nextTabState.shares);
       updateSharingTabState({
         set,
         buildUpdatedTabs,
         tabId: targetTab.id,
         updater: () => nextTabState,
       });
+      saveShares(targetTab.workspaceId, nextTabState.shares);
     },
 
     replaceCommentsSnapshot: (docId, comments) => {
@@ -679,13 +686,13 @@ export function createSharingControllerActions<
         docId,
         filteredComments,
       );
-      saveShares(stableShareKey(targetTab), nextTabState.shares);
       updateSharingTabState({
         set,
         buildUpdatedTabs,
         tabId: targetTab.id,
         updater: () => nextTabState,
       });
+      saveShares(targetTab.workspaceId, nextTabState.shares);
     },
 
     flushPendingCommentResolves: (docId) => {

--- a/src/modules/sharing/index.ts
+++ b/src/modules/sharing/index.ts
@@ -2,6 +2,8 @@ export * from "./controller";
 export * from "./selectors";
 export * from "./sharePayload";
 export * from "./shareIdentity";
+export * from "./registry";
+export * from "./resolveOutbox";
 export * from "./sync";
 export * from "./state";
 export * from "./storage";

--- a/src/modules/sharing/registry.ts
+++ b/src/modules/sharing/registry.ts
@@ -1,0 +1,216 @@
+import { isShareRecordArray } from "../../types/share";
+import type { ShareRecord } from "../../types/share";
+
+const LEGACY_SHARES_KEY = "markreview-shares";
+const SHARE_REGISTRY_KEY = "markreview-shares-v2";
+
+interface ShareBinding {
+  ownerWorkspaceId: string;
+  share: ShareRecord;
+}
+
+interface ShareRegistry {
+  version: 2;
+  bindings: Record<string, ShareBinding>;
+  unboundLegacy: Record<string, ShareRecord[]>;
+}
+
+interface ShareRegistryRead {
+  ok: boolean;
+  registry: ShareRegistry;
+}
+
+interface WorkspaceIdentity {
+  id: string;
+  workspaceId: string;
+  directoryName: string | null;
+  fileName: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isShareBinding(value: unknown): value is ShareBinding {
+  return (
+    isRecord(value) &&
+    typeof value["ownerWorkspaceId"] === "string" &&
+    "share" in value &&
+    isShareRecordArray([value["share"]])
+  );
+}
+
+function isShareBindingMap(
+  value: unknown,
+): value is Record<string, ShareBinding> {
+  return isRecord(value) && Object.values(value).every(isShareBinding);
+}
+
+function isShareRecordMap(
+  value: unknown,
+): value is Record<string, ShareRecord[]> {
+  return isRecord(value) && Object.values(value).every(isShareRecordArray);
+}
+
+function isShareRegistry(value: unknown): value is ShareRegistry {
+  return (
+    isRecord(value) &&
+    value["version"] === 2 &&
+    isShareBindingMap(value["bindings"]) &&
+    isShareRecordMap(value["unboundLegacy"])
+  );
+}
+
+function emptyRegistry(): ShareRegistry {
+  return { version: 2, bindings: {}, unboundLegacy: {} };
+}
+
+function readJson(key: string): unknown {
+  const raw = localStorage.getItem(key);
+  if (!raw) {
+    return null;
+  }
+  return JSON.parse(raw);
+}
+
+function loadRegistry(): ShareRegistryRead {
+  try {
+    const parsed = readJson(SHARE_REGISTRY_KEY);
+    if (parsed === null) {
+      return { ok: true, registry: emptyRegistry() };
+    }
+    if (!isShareRegistry(parsed)) {
+      console.warn("[sharing] invalid v2 share registry; ignoring it");
+      return { ok: false, registry: emptyRegistry() };
+    }
+    return { ok: true, registry: parsed };
+  } catch (error) {
+    console.warn("[sharing] failed to load v2 share registry:", error);
+    return { ok: false, registry: emptyRegistry() };
+  }
+}
+
+function saveRegistry(registry: ShareRegistry): boolean {
+  try {
+    localStorage.setItem(SHARE_REGISTRY_KEY, JSON.stringify(registry));
+    return true;
+  } catch (error) {
+    console.warn("[sharing] failed to persist v2 share registry:", error);
+    return false;
+  }
+}
+
+function matchesLegacyKey(tab: WorkspaceIdentity, key: string): boolean {
+  return tab.id === key || tab.directoryName === key || tab.fileName === key;
+}
+
+function migrateLegacyRegistry(
+  registry: ShareRegistry,
+  tabs: WorkspaceIdentity[],
+): ShareRegistry {
+  if (
+    Object.keys(registry.bindings).length > 0 ||
+    Object.keys(registry.unboundLegacy).length > 0
+  ) {
+    return registry;
+  }
+
+  let legacy: unknown;
+  try {
+    legacy = readJson(LEGACY_SHARES_KEY);
+  } catch (error) {
+    console.warn("[sharing] failed to read legacy share registry:", error);
+    return registry;
+  }
+  if (!isShareRecordMap(legacy)) {
+    return registry;
+  }
+
+  const migrated = emptyRegistry();
+  for (const [legacyKey, shares] of Object.entries(legacy)) {
+    const matchingTabs = tabs.filter((tab) => matchesLegacyKey(tab, legacyKey));
+    if (matchingTabs.length !== 1) {
+      migrated.unboundLegacy[legacyKey] = shares;
+      continue;
+    }
+    const ownerWorkspaceId = matchingTabs[0].workspaceId;
+    for (const share of shares) {
+      migrated.bindings[share.docId] = { ownerWorkspaceId, share };
+    }
+  }
+
+  saveRegistry(migrated);
+  return migrated;
+}
+
+function pruneExpired(registry: ShareRegistry): ShareRegistry {
+  const now = Date.now();
+  const bindings: Record<string, ShareBinding> = {};
+  for (const [docId, binding] of Object.entries(registry.bindings)) {
+    if (Date.parse(binding.share.expiresAt) > now) {
+      bindings[docId] = binding;
+    }
+  }
+  return { ...registry, bindings };
+}
+
+export function stableShareKey(tab: {
+  directoryName: string | null;
+  fileName: string | null;
+  id: string;
+}): string {
+  return tab.directoryName ?? tab.fileName ?? tab.id;
+}
+
+export function saveShares(
+  ownerWorkspaceId: string,
+  shares: ShareRecord[],
+): boolean {
+  const loaded = loadRegistry();
+  if (!loaded.ok) {
+    return false;
+  }
+  const registry = loaded.registry;
+  const bindings = Object.fromEntries(
+    Object.entries(registry.bindings).filter(
+      ([, binding]) => binding.ownerWorkspaceId !== ownerWorkspaceId,
+    ),
+  );
+  for (const share of shares) {
+    bindings[share.docId] = { ownerWorkspaceId, share };
+  }
+  return saveRegistry({ ...registry, bindings });
+}
+
+export function loadAndCleanShares(
+  tabs: WorkspaceIdentity[],
+): Record<string, ShareRecord[]> {
+  const loaded = loadRegistry();
+  if (!loaded.ok) {
+    return {};
+  }
+  const migrated = migrateLegacyRegistry(loaded.registry, tabs);
+  const pruned = pruneExpired(migrated);
+  if (
+    Object.keys(pruned.bindings).length !==
+    Object.keys(migrated.bindings).length
+  ) {
+    saveRegistry(pruned);
+  }
+
+  const sharesByWorkspace: Record<string, ShareRecord[]> = {};
+  for (const binding of Object.values(pruned.bindings)) {
+    const existing = sharesByWorkspace[binding.ownerWorkspaceId] ?? [];
+    sharesByWorkspace[binding.ownerWorkspaceId] = [...existing, binding.share];
+  }
+  return sharesByWorkspace;
+}
+
+export function getUnboundLegacyShareKeys(tabs: WorkspaceIdentity[]): string[] {
+  const loaded = loadRegistry();
+  if (!loaded.ok) {
+    return [];
+  }
+  const registry = migrateLegacyRegistry(loaded.registry, tabs);
+  return Object.keys(registry.unboundLegacy);
+}

--- a/src/modules/sharing/resolveOutbox.ts
+++ b/src/modules/sharing/resolveOutbox.ts
@@ -1,0 +1,81 @@
+const RESOLVE_OUTBOX_KEY = "markreview-resolve-outbox-v1";
+
+function isStringArrayMap(value: unknown): value is Record<string, string[]> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(
+    (entry) =>
+      Array.isArray(entry) && entry.every((item) => typeof item === "string"),
+  );
+}
+
+interface ResolveOutboxRead {
+  ok: boolean;
+  value: Record<string, string[]>;
+}
+
+function readResolveOutbox(): ResolveOutboxRead {
+  try {
+    const raw = localStorage.getItem(RESOLVE_OUTBOX_KEY);
+    if (!raw) {
+      return { ok: true, value: {} };
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!isStringArrayMap(parsed)) {
+      console.warn("[sharing] invalid resolve outbox; ignoring it");
+      return { ok: false, value: {} };
+    }
+    return { ok: true, value: parsed };
+  } catch (error) {
+    console.warn("[sharing] failed to load resolve outbox:", error);
+    return { ok: false, value: {} };
+  }
+}
+
+export function loadResolveOutbox(): Record<string, string[]> {
+  return readResolveOutbox().value;
+}
+
+export function saveResolveOutbox(outbox: Record<string, string[]>): boolean {
+  try {
+    localStorage.setItem(RESOLVE_OUTBOX_KEY, JSON.stringify(outbox));
+    return true;
+  } catch (error) {
+    console.warn("[sharing] failed to persist resolve outbox:", error);
+    return false;
+  }
+}
+
+export function queueResolveInOutbox(docId: string, cmtId: string): boolean {
+  const read = readResolveOutbox();
+  if (!read.ok) {
+    return false;
+  }
+  const outbox = read.value;
+  const existing = outbox[docId] ?? [];
+  if (existing.includes(cmtId)) {
+    return true;
+  }
+  return saveResolveOutbox({
+    ...outbox,
+    [docId]: [...existing, cmtId],
+  });
+}
+
+export function confirmResolveInOutbox(docId: string, cmtId: string): boolean {
+  const read = readResolveOutbox();
+  if (!read.ok) {
+    return false;
+  }
+  const outbox = read.value;
+  const existing = outbox[docId] ?? [];
+  const remaining = existing.filter((item) => item !== cmtId);
+  const next = { ...outbox };
+  if (remaining.length > 0) {
+    next[docId] = remaining;
+  } else {
+    delete next[docId];
+  }
+  return saveResolveOutbox(next);
+}

--- a/src/modules/sharing/state.ts
+++ b/src/modules/sharing/state.ts
@@ -3,6 +3,7 @@ import type { PeerComment } from "../../types/share";
 import type { TabState } from "../../types/tab";
 import { tabRequiresRestoreAccess } from "../../types/tab";
 import type { SharingActions, SharingTabState } from "./types";
+import { confirmResolveInOutbox, queueResolveInOutbox } from "./resolveOutbox";
 
 type SetState<StoreState> = StoreApi<StoreState>["setState"];
 type GetState<StoreState> = StoreApi<StoreState>["getState"];
@@ -91,7 +92,12 @@ export function createSharingActions<StoreState extends SharingStoreState>(
   deps: SharingActionDeps<StoreState>,
 ): Pick<
   SharingActions,
-  "toggleSharedPanel" | "queuePendingResolve" | "confirmPendingResolve"
+  | "toggleSharedPanel"
+  | "queuePendingResolve"
+  | "confirmPendingResolve"
+  | "setIncomingReviewSubscription"
+  | "quarantinePendingComment"
+  | "dismissQuarantinedComment"
 > {
   const { set, get, buildUpdatedTabs, buildUpdatedActiveTabs } = deps;
 
@@ -112,16 +118,24 @@ export function createSharingActions<StoreState extends SharingStoreState>(
     },
 
     queuePendingResolve: (docId, cmtId) => {
-      const targetTab = get().tabs.find((tab) =>
+      const targetTabs = get().tabs.filter((tab) =>
         tab.shares.some((share) => share.docId === docId),
       );
-      if (!targetTab) {
-        return;
+      if (targetTabs.length !== 1) {
+        console.warn("[sharing] resolve owner is missing or ambiguous", {
+          docId,
+          ownerCount: targetTabs.length,
+        });
+        return false;
       }
+      const targetTab = targetTabs[0];
       const existingIds = targetTab.pendingResolveCommentIds[docId] ?? [];
       const nextIds = mergeQueuedCommentIds(existingIds, [cmtId]);
       if (nextIds.length === existingIds.length) {
-        return;
+        return true;
+      }
+      if (!queueResolveInOutbox(docId, cmtId)) {
+        return false;
       }
       set((state) => ({
         tabs: buildUpdatedTabs(state.tabs, targetTab.id, (tabState) => ({
@@ -131,6 +145,7 @@ export function createSharingActions<StoreState extends SharingStoreState>(
           },
         })),
       }));
+      return true;
     },
 
     confirmPendingResolve: (docId, cmtId) => {
@@ -142,6 +157,9 @@ export function createSharingActions<StoreState extends SharingStoreState>(
       }
       const existingIds = targetTab.pendingResolveCommentIds[docId] ?? [];
       if (!existingIds.includes(cmtId)) {
+        return;
+      }
+      if (!confirmResolveInOutbox(docId, cmtId)) {
         return;
       }
       const remainingIds = existingIds.filter(
@@ -162,6 +180,117 @@ export function createSharingActions<StoreState extends SharingStoreState>(
           };
         }),
       }));
+    },
+
+    setIncomingReviewSubscription: (docId, subscription) => {
+      const targetTabs = get().tabs.filter((tab) =>
+        tab.shares.some((share) => share.docId === docId),
+      );
+      if (targetTabs.length !== 1) {
+        return;
+      }
+      const targetTab = targetTabs[0];
+      set((state) => ({
+        tabs: buildUpdatedTabs(state.tabs, targetTab.id, (tabState) => {
+          const previousSession = tabState.incomingReviewSessions[docId];
+          return {
+            incomingReviewSessions: {
+              ...tabState.incomingReviewSessions,
+              [docId]: {
+                ownerWorkspaceId: tabState.workspaceId,
+                subscription,
+                quarantinedItems: previousSession?.quarantinedItems ?? [],
+              },
+            },
+          };
+        }),
+      }));
+    },
+
+    quarantinePendingComment: (docId, cmtId, reason) => {
+      const targetTabs = get().tabs.filter((tab) =>
+        tab.shares.some((share) => share.docId === docId),
+      );
+      if (targetTabs.length !== 1) {
+        return;
+      }
+      const targetTab = targetTabs[0];
+      set((state) => ({
+        tabs: buildUpdatedTabs(state.tabs, targetTab.id, (tabState) => {
+          const previousSession = tabState.incomingReviewSessions[docId];
+          const subscription = previousSession?.subscription ?? {
+            subscriptionId: "unknown",
+            phase: "failed",
+            lastError: reason,
+          };
+          const existing = previousSession?.quarantinedItems ?? [];
+          if (existing.some((item) => item.cmtId === cmtId)) {
+            return {};
+          }
+          const item = {
+            id: crypto.randomUUID(),
+            cmtId,
+            reason,
+            receivedAt: new Date().toISOString(),
+          };
+          return {
+            incomingReviewSessions: {
+              ...tabState.incomingReviewSessions,
+              [docId]: {
+                ownerWorkspaceId: tabState.workspaceId,
+                subscription,
+                quarantinedItems: [...existing, item].slice(-20),
+              },
+            },
+          };
+        }),
+      }));
+    },
+
+    dismissQuarantinedComment: (docId, itemId) => {
+      const targetTabs = get().tabs.filter((tab) =>
+        tab.shares.some((share) => share.docId === docId),
+      );
+      if (targetTabs.length !== 1) {
+        return false;
+      }
+      const targetTab = targetTabs[0];
+      const session = targetTab.incomingReviewSessions[docId];
+      const item = session?.quarantinedItems.find(
+        (candidate) => candidate.id === itemId,
+      );
+      if (!item) {
+        return false;
+      }
+      if (!queueResolveInOutbox(docId, item.cmtId)) {
+        return false;
+      }
+      set((state) => ({
+        tabs: buildUpdatedTabs(state.tabs, targetTab.id, (tabState) => {
+          const currentSession = tabState.incomingReviewSessions[docId];
+          if (!currentSession) {
+            return {};
+          }
+          const existingResolveIds =
+            tabState.pendingResolveCommentIds[docId] ?? [];
+          return {
+            pendingResolveCommentIds: {
+              ...tabState.pendingResolveCommentIds,
+              [docId]: mergeQueuedCommentIds(existingResolveIds, [item.cmtId]),
+            },
+            incomingReviewSessions: {
+              ...tabState.incomingReviewSessions,
+              [docId]: {
+                ...currentSession,
+                quarantinedItems: currentSession.quarantinedItems.filter(
+                  (item) => item.id !== itemId,
+                ),
+              },
+            },
+          };
+        }),
+      }));
+      return true;
     },
   };
 }

--- a/src/modules/sharing/test/peerRangeMerge.test.ts
+++ b/src/modules/sharing/test/peerRangeMerge.test.ts
@@ -54,6 +54,10 @@ describe("peer range comment merge", () => {
       "A paragraph for review.\n",
       makePeerComment({
         peerName: 'Alice "QA" & Bob <ops>',
+        blockRef: {
+          blockIndex: 0,
+          contentPreview: "A paragraph for review.",
+        },
       }),
     );
     const parsed = parseCriticMarkup(result);

--- a/src/modules/sharing/test/shareRegistry.test.ts
+++ b/src/modules/sharing/test/shareRegistry.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultTab } from "../../../types/tab";
+import { makeShare } from "../../../testing/testHelpers";
+import {
+  getUnboundLegacyShareKeys,
+  loadAndCleanShares,
+  saveShares,
+} from "../registry";
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("workspace-owned share registry", () => {
+  it("keeps same-name workspaces separate", () => {
+    const firstTab = createDefaultTab({
+      id: "tab-a",
+      workspaceId: "workspace-a",
+      label: "project",
+      directoryName: "project",
+    });
+    const secondTab = createDefaultTab({
+      id: "tab-b",
+      workspaceId: "workspace-b",
+      label: "project",
+      directoryName: "project",
+    });
+
+    expect(
+      saveShares(firstTab.workspaceId, [makeShare({ docId: "doc-a" })]),
+    ).toBe(true);
+    expect(
+      saveShares(secondTab.workspaceId, [makeShare({ docId: "doc-b" })]),
+    ).toBe(true);
+
+    const restored = loadAndCleanShares([firstTab, secondTab]);
+
+    expect(restored[firstTab.workspaceId]?.map((share) => share.docId)).toEqual(
+      ["doc-a"],
+    );
+    expect(
+      restored[secondTab.workspaceId]?.map((share) => share.docId),
+    ).toEqual(["doc-b"]);
+  });
+
+  it("leaves ambiguous legacy name bindings unbound instead of choosing a tab", () => {
+    const firstTab = createDefaultTab({
+      id: "tab-a",
+      workspaceId: "workspace-a",
+      label: "project",
+      directoryName: "project",
+    });
+    const secondTab = createDefaultTab({
+      id: "tab-b",
+      workspaceId: "workspace-b",
+      label: "project",
+      directoryName: "project",
+    });
+    localStorage.setItem(
+      "markreview-shares",
+      JSON.stringify({ project: [makeShare({ docId: "legacy-doc" })] }),
+    );
+
+    const restored = loadAndCleanShares([firstTab, secondTab]);
+
+    expect(restored).toEqual({});
+    expect(getUnboundLegacyShareKeys([firstTab, secondTab])).toEqual([
+      "project",
+    ]);
+    expect(localStorage.getItem("markreview-shares")).not.toBeNull();
+  });
+
+  it("reports persistence failure without throwing", () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+
+    expect(saveShares("workspace-a", [makeShare()])).toBe(false);
+    expect(warning).toHaveBeenCalledWith(
+      "[sharing] failed to persist v2 share registry:",
+      expect.any(DOMException),
+    );
+  });
+
+  it("refuses to overwrite the registry when the existing value cannot be read", () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const originalGetItem = Storage.prototype.getItem;
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(function (
+      key: string,
+    ) {
+      if (key === "markreview-shares-v2") {
+        throw new DOMException("storage unavailable", "SecurityError");
+      }
+      return originalGetItem.call(this, key);
+    });
+
+    expect(saveShares("workspace-a", [makeShare()])).toBe(false);
+    expect(warning).toHaveBeenCalledWith(
+      "[sharing] failed to load v2 share registry:",
+      expect.any(DOMException),
+    );
+  });
+});

--- a/src/modules/sharing/test/storeShareActions.test.ts
+++ b/src/modules/sharing/test/storeShareActions.test.ts
@@ -8,6 +8,7 @@ import {
   makePeerComment,
   makeTestFileHandle,
 } from "../../../testing/testHelpers";
+import { createDefaultTab } from "../../../types/tab";
 
 beforeEach(() => {
   resetTestStore();
@@ -121,6 +122,217 @@ describe("store.mergeComment", () => {
     expect(errorLog).toHaveBeenCalledWith(
       "[mergeComment] path mismatch",
       expect.any(Object),
+    );
+  });
+
+  it("keeps an async merge owned by its original tab after the user switches tabs", async () => {
+    let finishRead: ((content: string) => void) | null = null;
+    const readContent = new Promise<string>((resolve) => {
+      finishRead = resolve;
+    });
+    const writable = { write: vi.fn(), close: vi.fn() };
+    const fileHandle = makeTestFileHandle({
+      getFile: vi.fn().mockResolvedValue({ text: () => readContent }),
+      createWritable: vi.fn().mockResolvedValue(writable),
+    });
+    const comment = makePeerComment({
+      id: "cmt-owned",
+      path: "a.md",
+      blockRef: { blockIndex: 0, contentPreview: "Hello" },
+    });
+    const firstTab = createDefaultTab({
+      id: "tab-a",
+      workspaceId: "workspace-a",
+      label: "a.md",
+      fileHandle,
+      fileName: "a.md",
+      activeFilePath: "a.md",
+      rawContent: "# Hello\n",
+      shares: [makeShare()],
+      pendingComments: { "doc-1": [comment] },
+    });
+    const secondTab = createDefaultTab({
+      id: "tab-b",
+      workspaceId: "workspace-b",
+      label: "b.md",
+      fileName: "b.md",
+      rawContent: "# Other\n",
+    });
+    useAppStore.setState({
+      tabs: [firstTab, secondTab],
+      activeTabId: firstTab.id,
+    });
+
+    const mergePromise = useAppStore.getState().mergeComment("doc-1", comment);
+    useAppStore.setState({ activeTabId: secondTab.id });
+    if (!finishRead) {
+      throw new Error("Expected deferred file read");
+    }
+    finishRead("# Hello\n");
+
+    await expect(mergePromise).resolves.toBe(true);
+    const state = useAppStore.getState();
+    const updatedFirst = state.tabs.find((tab) => tab.id === firstTab.id);
+    const unchangedSecond = state.tabs.find((tab) => tab.id === secondTab.id);
+    expect(updatedFirst?.rawContent).toContain("mr-peer-cmt-owned");
+    expect(updatedFirst?.pendingComments["doc-1"]).toBeUndefined();
+    expect(unchangedSecond?.rawContent).toBe("# Other\n");
+    expect(state.activeTabId).toBe(secondTab.id);
+  });
+
+  it("fails closed when the file changed after the comment was displayed", async () => {
+    const writable = { write: vi.fn(), close: vi.fn() };
+    const fileHandle = makeTestFileHandle({
+      getFile: vi.fn().mockResolvedValue({
+        text: vi.fn().mockResolvedValue("# Changed elsewhere\n"),
+      }),
+      createWritable: vi.fn().mockResolvedValue(writable),
+    });
+    const comment = makePeerComment({
+      id: "cmt-stale",
+      path: "test.md",
+      blockRef: { blockIndex: 0, contentPreview: "Hello" },
+    });
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    setTestState({
+      fileHandle,
+      fileName: "test.md",
+      activeFilePath: "test.md",
+      rawContent: "# Hello\n",
+      shares: [makeShare()],
+      pendingComments: { "doc-1": [comment] },
+    });
+
+    await expect(
+      useAppStore.getState().mergeComment("doc-1", comment),
+    ).resolves.toBe(false);
+
+    expect(writable.write).not.toHaveBeenCalled();
+    expect(
+      getActiveTab(useAppStore.getState())?.pendingComments["doc-1"],
+    ).toEqual([comment]);
+    expect(warning).toHaveBeenCalledWith(
+      "[mergeComment] document changed before merge",
+      expect.any(Object),
+    );
+  });
+
+  it("recovers a retry after the file write without inserting a duplicate", async () => {
+    let diskContent = "# Hello\n";
+    const writable = {
+      write: vi.fn((content: string) => {
+        diskContent = content;
+      }),
+      close: vi.fn(),
+    };
+    const fileHandle = makeTestFileHandle({
+      getFile: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          text: () => Promise.resolve(diskContent),
+        }),
+      ),
+      createWritable: vi.fn().mockResolvedValue(writable),
+    });
+    const comment = makePeerComment({
+      id: "cmt-idempotent",
+      path: "test.md",
+      blockRef: { blockIndex: 0, contentPreview: "Hello" },
+    });
+    setTestState({
+      fileHandle,
+      fileName: "test.md",
+      activeFilePath: "test.md",
+      rawContent: diskContent,
+      shares: [makeShare()],
+      pendingComments: { "doc-1": [comment] },
+    });
+
+    await expect(
+      useAppStore.getState().mergeComment("doc-1", comment),
+    ).resolves.toBe(true);
+    await expect(
+      useAppStore.getState().mergeComment("doc-1", comment),
+    ).resolves.toBe(true);
+
+    expect(writable.write).toHaveBeenCalledOnce();
+    expect(diskContent.match(/mr-peer-cmt-idempotent/g)).toHaveLength(2);
+  });
+});
+
+describe("incoming comment persistence failures", () => {
+  it("still displays a valid incoming comment when local storage is unavailable", () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+    const comment = makePeerComment({ id: "cmt-visible" });
+    setTestState({ shares: [makeShare()] });
+
+    expect(() =>
+      useAppStore.getState().addPendingComment("doc-1", comment),
+    ).not.toThrow();
+
+    expect(
+      getActiveTab(useAppStore.getState())?.pendingComments["doc-1"],
+    ).toEqual([comment]);
+    expect(warning).toHaveBeenCalled();
+  });
+
+  it("keeps a dismissed comment visible when the resolve outbox cannot persist", () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const comment = makePeerComment({ id: "cmt-retry" });
+    setTestState({
+      shares: [makeShare()],
+      pendingComments: { "doc-1": [comment] },
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+
+    useAppStore.getState().dismissComment("doc-1", comment.id);
+
+    expect(
+      getActiveTab(useAppStore.getState())?.pendingComments["doc-1"],
+    ).toEqual([comment]);
+    expect(warning).toHaveBeenCalledWith(
+      "[sharing] failed to persist resolve outbox:",
+      expect.any(DOMException),
+    );
+  });
+
+  it("keeps a dismissed comment visible when the resolve outbox cannot be read", () => {
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const comment = makePeerComment({ id: "cmt-read-retry" });
+    setTestState({
+      shares: [makeShare()],
+      pendingComments: { "doc-1": [comment] },
+    });
+    const originalGetItem = Storage.prototype.getItem;
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(function (
+      key: string,
+    ) {
+      if (key === "markreview-resolve-outbox-v1") {
+        throw new DOMException("storage unavailable", "SecurityError");
+      }
+      return originalGetItem.call(this, key);
+    });
+
+    useAppStore.getState().dismissComment("doc-1", comment.id);
+
+    expect(
+      getActiveTab(useAppStore.getState())?.pendingComments["doc-1"],
+    ).toEqual([comment]);
+    expect(warning).toHaveBeenCalledWith(
+      "[sharing] failed to load resolve outbox:",
+      expect.any(DOMException),
     );
   });
 });

--- a/src/modules/sharing/types.ts
+++ b/src/modules/sharing/types.ts
@@ -1,5 +1,10 @@
 import type { FileTreeNode } from "../../types/fileTree";
-import type { PeerComment, ShareRecord } from "../../types/share";
+import type {
+  PeerComment,
+  QuarantinedPeerComment,
+  ShareRecord,
+} from "../../types/share";
+import type { RelaySubscriptionState } from "../../types/relay";
 
 export interface SharingTabState {
   shares: ShareRecord[];
@@ -8,6 +13,14 @@ export interface SharingTabState {
   pendingResolveCommentIds: Record<string, string[]>;
   shareKeys: Record<string, CryptoKey>;
   activeDocId: string | null;
+  incomingReviewSessions: Record<
+    string,
+    {
+      ownerWorkspaceId: string;
+      subscription: RelaySubscriptionState;
+      quarantinedItems: QuarantinedPeerComment[];
+    }
+  >;
 }
 
 export function createSharingTabState(): SharingTabState {
@@ -18,6 +31,7 @@ export function createSharingTabState(): SharingTabState {
     pendingResolveCommentIds: {},
     shareKeys: {},
     activeDocId: null,
+    incomingReviewSessions: {},
   };
 }
 
@@ -38,13 +52,23 @@ export interface SharingActions {
   restoreShareSessions: () => Promise<void>;
   shareContent: (opts: ShareContentOptions) => Promise<string>;
   revokeShare: (docId: string) => Promise<void>;
-  mergeComment: (docId: string, comment: PeerComment) => Promise<void>;
+  mergeComment: (docId: string, comment: PeerComment) => Promise<boolean>;
   dismissComment: (docId: string, cmtId: string) => void;
   clearPendingComments: (docId: string) => void;
   toggleSharedPanel: () => void;
   addPendingComment: (docId: string, comment: PeerComment) => void;
   replaceCommentsSnapshot: (docId: string, comments: PeerComment[]) => void;
-  queuePendingResolve: (docId: string, cmtId: string) => void;
+  queuePendingResolve: (docId: string, cmtId: string) => boolean;
   confirmPendingResolve: (docId: string, cmtId: string) => void;
   flushPendingCommentResolves: (docId: string) => void;
+  setIncomingReviewSubscription: (
+    docId: string,
+    subscription: RelaySubscriptionState,
+  ) => void;
+  quarantinePendingComment: (
+    docId: string,
+    cmtId: string,
+    reason: string,
+  ) => void;
+  dismissQuarantinedComment: (docId: string, itemId: string) => boolean;
 }

--- a/src/modules/workspace/README.md
+++ b/src/modules/workspace/README.md
@@ -14,6 +14,7 @@ Owns host-side tab lifecycle and file-session state.
 - file tree
 - active file path
 - restore and refresh orchestration
+- stable workspace identity and scoped document-content persistence
 
 ## Does not own
 
@@ -29,6 +30,7 @@ Owns host-side tab lifecycle and file-session state.
 - `history`
 - `historyDropdownOpen`
 - tab-level file session fields
+- per-tab `workspaceId`
 
 ## Public API
 
@@ -45,6 +47,7 @@ Current side effects:
 - directory open
 - file refresh
 - restore from persisted handles
+- per-workspace content-cache read/write
 
 File and folder operations should go through the runtime workspace capability
 boundary rather than importing browser filesystem services directly.
@@ -58,6 +61,8 @@ boundary rather than importing browser filesystem services directly.
 
 - workspace state is host-mode state
 - file-session orchestration must not leak peer-mode state into tabs
+- display names may collide; persistence and share ownership use `workspaceId`
+- document text must not be reserialized in the root state for unrelated inbox updates
 
 ## Common Failure Modes
 

--- a/src/modules/workspace/contentCache.ts
+++ b/src/modules/workspace/contentCache.ts
@@ -1,0 +1,27 @@
+const CONTENT_CACHE_PREFIX = "markreview-workspace-content-v1:";
+
+function contentCacheKey(workspaceId: string): string {
+  return `${CONTENT_CACHE_PREFIX}${workspaceId}`;
+}
+
+export function loadWorkspaceContent(workspaceId: string): string | null {
+  try {
+    return localStorage.getItem(contentCacheKey(workspaceId));
+  } catch (error) {
+    console.warn("[workspace] failed to load cached content:", error);
+    return null;
+  }
+}
+
+export function saveWorkspaceContent(
+  workspaceId: string,
+  rawContent: string,
+): boolean {
+  try {
+    localStorage.setItem(contentCacheKey(workspaceId), rawContent);
+    return true;
+  } catch (error) {
+    console.warn("[workspace] failed to persist cached content:", error);
+    return false;
+  }
+}

--- a/src/modules/workspace/controller.ts
+++ b/src/modules/workspace/controller.ts
@@ -3,8 +3,10 @@ import { findResolvedComments } from "../host-review";
 import { ensureRelaySubscriptions, unsubscribeFromDoc } from "../relay";
 import {
   loadAndCleanShares,
+  getUnboundLegacyShareKeys,
+  loadResolveOutbox,
+  mergeQueuedCommentIds,
   restoreShareKeys,
-  stableShareKey,
 } from "../sharing";
 import {
   findLiveFileInTree,
@@ -375,7 +377,8 @@ function createHistoryEntry(tab: TabState): HistoryEntry | null {
     id: crypto.randomUUID(),
     type: isDirectory ? "directory" : "file",
     name,
-    stableKey: stableShareKey(tab),
+    stableKey: tab.workspaceId,
+    workspaceId: tab.workspaceId,
     closedAt: new Date().toISOString(),
     activeFilePath: tab.activeFilePath,
     hasActiveShares,
@@ -678,6 +681,7 @@ export function createWorkspaceControllerActions<
         }
 
         const tab = createDefaultTab({
+          workspaceId: entry.workspaceId,
           label: entry.name,
           directoryHandle: handle,
           directoryName: entry.name,
@@ -723,6 +727,7 @@ export function createWorkspaceControllerActions<
 
         const rawContent = await readFile(handle);
         const tab = createDefaultTab({
+          workspaceId: entry.workspaceId,
           label: entry.name,
           fileHandle: handle,
           fileName: entry.name,
@@ -752,12 +757,13 @@ export function createWorkspaceControllerActions<
         return;
       }
 
-      const tabShares = allShares[stableShareKey(currentTab)] ?? [];
+      const tabShares = allShares[currentTab.workspaceId] ?? [];
       if (tabShares.length === 0) {
         return;
       }
 
       const restoredKeys = await restoreShareKeys(tabShares);
+      const resolveOutbox = loadResolveOutbox();
       set((state) => ({
         tabs: buildUpdatedActiveTabs(
           state.tabs,
@@ -765,6 +771,15 @@ export function createWorkspaceControllerActions<
           (tabState) => ({
             shares: tabShares,
             shareKeys: { ...tabState.shareKeys, ...restoredKeys },
+            pendingResolveCommentIds: Object.fromEntries(
+              tabShares.map((share) => [
+                share.docId,
+                mergeQueuedCommentIds(
+                  tabState.pendingResolveCommentIds[share.docId] ?? [],
+                  resolveOutbox[share.docId] ?? [],
+                ),
+              ]),
+            ),
           }),
         ),
       }));
@@ -1306,10 +1321,16 @@ export function createWorkspaceControllerActions<
       }
 
       const allShares = loadAndCleanShares(get().tabs);
+      if (getUnboundLegacyShareKeys(get().tabs).length > 0) {
+        showToast(
+          "Some older shares could not be matched safely. Recreate those links from the correct workspace.",
+        );
+      }
+      const resolveOutbox = loadResolveOutbox();
       const now = new Date();
 
       for (const tab of get().tabs) {
-        const tabShares = allShares[stableShareKey(tab)] ?? [];
+        const tabShares = allShares[tab.workspaceId] ?? [];
         if (tabShares.length === 0) {
           continue;
         }
@@ -1326,6 +1347,18 @@ export function createWorkspaceControllerActions<
           tabs: buildUpdatedTabs(state.tabs, tab.id, (tabState) => ({
             shares: activeShares,
             shareKeys: { ...tabState.shareKeys, ...restoredKeys },
+            pendingResolveCommentIds: {
+              ...tabState.pendingResolveCommentIds,
+              ...Object.fromEntries(
+                activeShares.map((share) => [
+                  share.docId,
+                  mergeQueuedCommentIds(
+                    tabState.pendingResolveCommentIds[share.docId] ?? [],
+                    resolveOutbox[share.docId] ?? [],
+                  ),
+                ]),
+              ),
+            },
           })),
         }));
       }

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -1,4 +1,5 @@
 export * from "./controller";
+export * from "./contentCache";
 export * from "./helpers";
 export * from "./state";
 export * from "./storage";

--- a/src/modules/workspace/test/history.test.ts
+++ b/src/modules/workspace/test/history.test.ts
@@ -84,20 +84,30 @@ describe("store.removeTab — history archival", () => {
 
   it("deduplicates by stableKey — keeps most recent", () => {
     // Close first tab
-    setTestState({ fileName: "doc.md" });
+    setTestState({ fileName: "doc.md", workspaceId: "same-workspace" });
     const tab1Id = getActiveTab(useAppStore.getState())!.id;
     useAppStore.getState().removeTab(tab1Id);
     expect(useAppStore.getState().history).toHaveLength(1);
     const firstEntryId = useAppStore.getState().history[0].id;
 
     // Close second tab with same name
-    setTestState({ fileName: "doc.md" });
+    setTestState({ fileName: "doc.md", workspaceId: "same-workspace" });
     const tab2Id = getActiveTab(useAppStore.getState())!.id;
     useAppStore.getState().removeTab(tab2Id);
 
     const { history } = useAppStore.getState();
     expect(history).toHaveLength(1);
     expect(history[0].id).not.toBe(firstEntryId);
+  });
+
+  it("keeps same-name workspaces distinct when their workspace identities differ", () => {
+    setTestState({ fileName: "doc.md", workspaceId: "workspace-a" });
+    useAppStore.getState().removeTab(getActiveTab(useAppStore.getState())!.id);
+
+    setTestState({ fileName: "doc.md", workspaceId: "workspace-b" });
+    useAppStore.getState().removeTab(getActiveTab(useAppStore.getState())!.id);
+
+    expect(useAppStore.getState().history).toHaveLength(2);
   });
 
   it("enforces 20-entry limit", () => {

--- a/src/modules/workspace/test/tabRestore.test.ts
+++ b/src/modules/workspace/test/tabRestore.test.ts
@@ -370,6 +370,30 @@ describe("store.restoreTabs", () => {
     expect(persistedBrowserTab["directoryHandle"]).toBeNull();
   });
 
+  it("stores document content in a workspace-scoped cache instead of the root state blob", () => {
+    localStorage.removeItem("markreview-store");
+    const tab = createDefaultTab({
+      id: "cached-tab",
+      workspaceId: "cached-workspace",
+      label: "notes.md",
+      fileName: "notes.md",
+      rawContent: "# Cached document\n",
+    });
+
+    useAppStore.setState({ tabs: [tab], activeTabId: tab.id });
+
+    const persistedState = getPersistedStoreState();
+    const persistedTabs = persistedState["tabs"];
+    if (!isUnknownArray(persistedTabs)) {
+      throw new Error("Expected persisted tabs array");
+    }
+    const persistedTab = findRecordById(persistedTabs, tab.id);
+    expect(persistedTab["rawContent"]).toBeUndefined();
+    expect(
+      localStorage.getItem("markreview-workspace-content-v1:cached-workspace"),
+    ).toBe("# Cached document\n");
+  });
+
   it("sets restoreError on file tab when handle is missing from IndexedDB", async () => {
     const fileTab = createDefaultTab({
       id: "file-tab",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 import {
   createAgentWorkflowActions,
   createAgentWorkflowControllerActions,
@@ -52,6 +52,8 @@ import {
   getActiveTab as getWorkspaceActiveTab,
   getLiveFileTree,
   loadWorkspaceHistory,
+  loadWorkspaceContent,
+  saveWorkspaceContent,
 } from "../modules/workspace";
 import type { WorkspaceActions, WorkspaceState } from "../modules/workspace";
 import { toPersistedTree } from "../types/fileTree";
@@ -69,6 +71,31 @@ import { isShareRecordArray } from "../types/share";
 import type { ShareRecord } from "../types/share";
 
 const SHARES_KEY = "markreview-shares";
+
+const safeLocalStorage = {
+  getItem: (name: string): string | null => {
+    try {
+      return localStorage.getItem(name);
+    } catch (error) {
+      console.warn("[store] failed to read persisted state:", error);
+      return null;
+    }
+  },
+  setItem: (name: string, value: string): void => {
+    try {
+      localStorage.setItem(name, value);
+    } catch (error) {
+      console.warn("[store] failed to persist state:", error);
+    }
+  },
+  removeItem: (name: string): void => {
+    try {
+      localStorage.removeItem(name);
+    } catch (error) {
+      console.warn("[store] failed to remove persisted state:", error);
+    }
+  },
+};
 
 interface AppState
   extends
@@ -252,7 +279,8 @@ export const useAppStore = create<AppState>()(
     },
     {
       name: "markreview-store",
-      version: 2,
+      storage: createJSONStorage(() => safeLocalStorage),
+      version: 3,
       migrate: (persisted, version) => {
         if (version === 0 || version === 1) {
           // Old flat format → wrap into single tab
@@ -265,6 +293,7 @@ export const useAppStore = create<AppState>()(
               ? [
                   {
                     id: tabId,
+                    workspaceId: crypto.randomUUID(),
                     label:
                       persisted.directoryName ??
                       persisted.fileName ??
@@ -292,6 +321,7 @@ export const useAppStore = create<AppState>()(
                     shareKeys: {},
                     activeDocId: null,
                     pendingResolveCommentIds: {},
+                    incomingReviewSessions: {},
                     restoreError: null,
                   },
                 ]
@@ -338,10 +368,10 @@ export const useAppStore = create<AppState>()(
       partialize: (s) => ({
         tabs: s.tabs.map((t) => ({
           id: t.id,
+          workspaceId: t.workspaceId,
           label: t.label,
           fileHandle: getPersistedNativeFileTarget(t),
           fileName: t.fileName,
-          rawContent: t.rawContent,
           directoryHandle: getPersistedNativeDirectoryTarget(t),
           directoryName: t.directoryName,
           activeFilePath: t.activeFilePath,
@@ -366,13 +396,17 @@ export const useAppStore = create<AppState>()(
         const p: Partial<AppState> = persisted;
         // Tabs need special handling: fill in defaults for non-persisted fields
         const tabs = Array.isArray(p.tabs)
-          ? p.tabs.map((t) =>
-              createDefaultTab({
+          ? p.tabs.map((t) => {
+              const workspaceId = t.workspaceId ?? crypto.randomUUID();
+              return createDefaultTab({
                 ...t,
+                workspaceId,
                 label: t.label ?? "document",
                 fileTree: getPersistedTabFileTree(t),
-              }),
-            )
+                rawContent:
+                  loadWorkspaceContent(workspaceId) ?? t.rawContent ?? "",
+              });
+            })
           : current.tabs;
         const relayDefaults = createRelayState();
         const peerReviewDefaults = createPeerReviewState();
@@ -409,5 +443,16 @@ useAppStore.subscribe((state) => {
   const title = name ? `${name} — ${APP_TITLE}` : APP_TITLE;
   if (document.title !== title) {
     document.title = title;
+  }
+});
+
+const cachedRawContentByWorkspace = new Map<string, string>();
+useAppStore.subscribe((state) => {
+  for (const tab of state.tabs) {
+    if (cachedRawContentByWorkspace.get(tab.workspaceId) === tab.rawContent) {
+      continue;
+    }
+    cachedRawContentByWorkspace.set(tab.workspaceId, tab.rawContent);
+    saveWorkspaceContent(tab.workspaceId, tab.rawContent);
   }
 });

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -3,6 +3,7 @@ export interface HistoryEntry {
   type: "file" | "directory";
   name: string;
   stableKey: string;
+  workspaceId?: string;
   closedAt: string;
   activeFilePath: string | null;
   hasActiveShares: boolean;

--- a/src/types/relay.ts
+++ b/src/types/relay.ts
@@ -9,6 +9,7 @@ export interface RelayFrame {
 export interface SubscribeFrame {
   type: "subscribe";
   docId: string;
+  subscriptionId?: string;
   role: "host" | "peer";
   hostSecret?: string;
 }
@@ -16,6 +17,7 @@ export interface SubscribeFrame {
 export interface UnsubscribeFrame {
   type: "unsubscribe";
   docId: string;
+  subscriptionId?: string;
 }
 
 export interface CommentAddFrame {
@@ -23,35 +25,43 @@ export interface CommentAddFrame {
   docId: string;
   cmtId: string;
   payload: string;
+  subscriptionId?: string;
 }
 
 export interface CommentResolveFrame {
   type: "comment:resolve";
   docId: string;
   cmtId: string;
+  subscriptionId?: string;
 }
 
 export interface ErrorFrame {
   type: "error";
   docId: string;
   message: string;
+  subscriptionId?: string;
+  scope?: "subscription" | "operation";
+  cmtId?: string;
 }
 
 export interface SubscribeOkFrame {
   type: "subscribe:ok";
   docId: string;
+  subscriptionId?: string;
 }
 
 export interface CommentAddAckFrame {
   type: "comment:add:ack";
   docId: string;
   cmtId: string;
+  subscriptionId?: string;
 }
 
 export interface CommentResolveAckFrame {
   type: "comment:resolve:ack";
   docId: string;
   cmtId: string;
+  subscriptionId?: string;
 }
 
 export interface CommentsSnapshotEntry {
@@ -63,6 +73,10 @@ export interface CommentsSnapshotFrame {
   type: "comments:snapshot";
   docId: string;
   comments: CommentsSnapshotEntry[];
+  subscriptionId?: string;
+  snapshotId?: string;
+  chunkIndex?: number;
+  chunkCount?: number;
 }
 
 export interface CommentAddedFrame {
@@ -70,12 +84,14 @@ export interface CommentAddedFrame {
   docId: string;
   cmtId: string;
   payload: string;
+  subscriptionId?: string;
 }
 
 export interface CommentResolvedFrame {
   type: "comment:resolved";
   docId: string;
   cmtId: string;
+  subscriptionId?: string;
 }
 
 export interface PingFrame {
@@ -118,6 +134,21 @@ export type RelayEvent =
   | { type: "comment:added"; cmtId: string; payload: string }
   | { type: "comment:resolved"; cmtId: string }
   | DocumentUpdatedMessage;
+
+export type RelaySubscriptionRole = "host" | "peer";
+
+export type RelaySubscriptionPhase =
+  | "idle"
+  | "subscribing"
+  | "syncing"
+  | "live"
+  | "failed";
+
+export interface RelaySubscriptionState {
+  subscriptionId: string;
+  phase: RelaySubscriptionPhase;
+  lastError: string | null;
+}
 
 export interface DecryptedCommentEvent {
   type: "comment:added";

--- a/src/types/share.ts
+++ b/src/types/share.ts
@@ -13,6 +13,13 @@ export interface ShareRecord {
   sharedPaths?: string[]; // original file paths included in the share
 }
 
+export interface QuarantinedPeerComment {
+  id: string;
+  cmtId: string;
+  reason: string;
+  receivedAt: string;
+}
+
 function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((entry) => typeof entry === "string")

--- a/src/types/tab.ts
+++ b/src/types/tab.ts
@@ -13,6 +13,7 @@ export type { FileCommentEntry } from "../modules/host-review/types";
 
 export interface TabState extends SharingTabState, HostReviewTabState {
   id: string;
+  workspaceId: string;
   label: string;
 
   fileHandle: FileTarget | null;
@@ -33,6 +34,7 @@ export function createDefaultTab(
 ): TabState {
   return {
     id: crypto.randomUUID(),
+    workspaceId: overrides.workspaceId ?? crypto.randomUUID(),
     label: overrides.label,
     fileHandle: null,
     fileName: null,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -20,6 +20,7 @@ import { findLiveFileInTree } from "../types/fileTree";
 import type { SidebarTreeNode } from "../types/fileTree";
 import { RestoreError } from "./components/RestoreError";
 import { ContentUpdateBanner } from "./components/ContentUpdateBanner";
+import { ReviewErrorBoundary } from "./components/ReviewErrorBoundary";
 import {
   getRestoreAccessActionLabel,
   getRestoreOpenOtherLabel,
@@ -111,6 +112,7 @@ function ShareUnavailable() {
 function PeerViewer() {
   const sharedContent = useAppStore((s) => s.sharedContent);
   const rawContent = useAppStore((s) => s.peerRawContent);
+  const activePath = useAppStore((s) => s.peerActiveFilePath);
 
   if (!sharedContent) {
     return <ShareUnavailable />;
@@ -119,7 +121,14 @@ function PeerViewer() {
     return <ShareUnavailable />;
   }
 
-  return <MarkdownRenderer />;
+  return (
+    <ReviewErrorBoundary
+      title="This shared document could not be displayed"
+      resetKey={activePath}
+    >
+      <MarkdownRenderer />
+    </ReviewErrorBoundary>
+  );
 }
 
 const FILE_OBSERVER_TYPES = ["modified", "appeared"];
@@ -421,7 +430,12 @@ function App() {
               }}
             />
           ) : tab?.fileName ? (
-            <MarkdownRenderer />
+            <ReviewErrorBoundary
+              title="This document could not be displayed"
+              resetKey={`${tab.id}:${tab.activeFilePath ?? tab.fileName}`}
+            >
+              <MarkdownRenderer />
+            </ReviewErrorBoundary>
           ) : (
             <NoFileSelected
               directoryName={tab?.directoryName ?? null}

--- a/src/ui/components/CommentPanel/CommentPanel.tsx
+++ b/src/ui/components/CommentPanel/CommentPanel.tsx
@@ -81,7 +81,6 @@ export function CommentPanel({ peerMode = false }: Props) {
     () => getActiveRootCommentId(comments, activeCommentId),
     [activeCommentId, comments],
   );
-  // The selected question thread, expanded inline in the panel (host mode).
   const activeHostThread = useMemo(() => {
     if (peerMode || !activeRootCommentId) {
       return null;
@@ -112,10 +111,16 @@ export function CommentPanel({ peerMode = false }: Props) {
       ? commentFilter
       : "all";
   const pendingComments = tab?.pendingComments ?? {};
-  const incomingCount = Object.values(pendingComments).reduce(
+  const incomingReviewSessions = tab?.incomingReviewSessions ?? {};
+  const pendingIncomingCount = Object.values(pendingComments).reduce(
     (total, commentsForShare) => total + commentsForShare.length,
     0,
   );
+  const quarantinedIncomingCount = Object.values(incomingReviewSessions).reduce(
+    (total, session) => total + session.quarantinedItems.length,
+    0,
+  );
+  const incomingCount = pendingIncomingCount + quarantinedIncomingCount;
   const {
     openAll: handleOpenAllComments,
     selectType: handleSelectCommentType,
@@ -408,6 +413,7 @@ export function CommentPanel({ peerMode = false }: Props) {
           <IncomingCommentList
             pendingComments={pendingComments}
             shares={tab?.shares ?? []}
+            sessions={incomingReviewSessions}
           />
         ) : resolvedView ? (
           <SingleFileList

--- a/src/ui/components/CommentPanel/IncomingCommentList.tsx
+++ b/src/ui/components/CommentPanel/IncomingCommentList.tsx
@@ -1,15 +1,33 @@
 import type { PeerComment, ShareRecord } from "../../../types/share";
+import type { SharingTabState } from "../../../modules/sharing";
 import { PendingCommentReview } from "../PendingCommentReview";
+import { ReviewErrorBoundary } from "../ReviewErrorBoundary";
 
 interface Props {
   pendingComments: Record<string, PeerComment[]>;
   shares: ShareRecord[];
+  sessions: SharingTabState["incomingReviewSessions"];
 }
 
-export function IncomingCommentList({ pendingComments, shares }: Props) {
-  const groups = Object.entries(pendingComments)
-    .filter(([, comments]) => comments.length > 0)
-    .map(([docId, comments]) => {
+export function IncomingCommentList({
+  pendingComments,
+  shares,
+  sessions,
+}: Props) {
+  const docIds = new Set([
+    ...Object.keys(pendingComments),
+    ...Object.entries(sessions)
+      .filter(([, session]) => session.quarantinedItems.length > 0)
+      .map(([docId]) => docId),
+  ]);
+  const groups = [...docIds]
+    .filter(
+      (docId) =>
+        (pendingComments[docId]?.length ?? 0) > 0 ||
+        (sessions[docId]?.quarantinedItems.length ?? 0) > 0,
+    )
+    .map((docId) => {
+      const comments = pendingComments[docId] ?? [];
       const share = shares.find((candidate) => candidate.docId === docId);
       return {
         docId,
@@ -35,7 +53,12 @@ export function IncomingCommentList({ pendingComments, shares }: Props) {
           aria-label={`Incoming comments for ${group.label}`}
         >
           <h3 title={group.label}>{group.label}</h3>
-          <PendingCommentReview docId={group.docId} />
+          <ReviewErrorBoundary
+            title="Incoming comments could not be displayed"
+            resetKey={pendingComments[group.docId]?.length ?? 0}
+          >
+            <PendingCommentReview docId={group.docId} />
+          </ReviewErrorBoundary>
         </section>
       ))}
     </div>

--- a/src/ui/components/ConnectionStatus/ConnectionStatus.test.tsx
+++ b/src/ui/components/ConnectionStatus/ConnectionStatus.test.tsx
@@ -13,7 +13,18 @@ beforeEach(() => {
 
 describe("ConnectionStatus - peer mode", () => {
   it("renders the healthy live state in peer mode", () => {
-    setTestState({}, { isPeerMode: true, relayStatus: "connected" });
+    setTestState(
+      {},
+      {
+        isPeerMode: true,
+        relayStatus: "connected",
+        peerSubmissionSubscription: {
+          subscriptionId: "peer-sub",
+          phase: "live",
+          lastError: null,
+        },
+      },
+    );
     render(<ConnectionStatus />);
     expect(screen.getByText("Live")).toBeInTheDocument();
   });
@@ -22,6 +33,13 @@ describe("ConnectionStatus - peer mode", () => {
     setTestState({}, { isPeerMode: true, relayStatus: "connecting" });
     render(<ConnectionStatus />);
     expect(screen.getByText("Connecting…")).toBeInTheDocument();
+  });
+
+  it("does not claim Live when the socket is open but the document is unconfirmed", () => {
+    setTestState({}, { isPeerMode: true, relayStatus: "connected" });
+    render(<ConnectionStatus />);
+    expect(screen.getByText("Connecting…")).toBeInTheDocument();
+    expect(screen.queryByText("Live")).not.toBeInTheDocument();
   });
 
   it('renders "Offline" when relayStatus is disconnected in peer mode', () => {
@@ -46,7 +64,20 @@ describe("ConnectionStatus - host mode with active shares", () => {
       expiresAt: new Date(Date.now() + 86400000).toISOString(),
     });
     setTestState(
-      { shares: [activeShare] },
+      {
+        shares: [activeShare],
+        incomingReviewSessions: {
+          [activeShare.docId]: {
+            ownerWorkspaceId: "test-workspace",
+            subscription: {
+              subscriptionId: "host-sub",
+              phase: "live",
+              lastError: null,
+            },
+            quarantinedItems: [],
+          },
+        },
+      },
       { isPeerMode: false, relayStatus: "connected" },
     );
     render(<ConnectionStatus />);

--- a/src/ui/components/ConnectionStatus/ConnectionStatus.tsx
+++ b/src/ui/components/ConnectionStatus/ConnectionStatus.tsx
@@ -1,22 +1,52 @@
 import type { TabState } from "../../../types/tab";
-import { selectRelayStatus } from "../../../modules/relay";
+import type { RelayStatus } from "../../../modules/relay";
 import { useAppStore } from "../../../store";
 import "./ConnectionStatus.css";
 
-function selectActiveTabHasShares(state: {
+function selectVisibleConnectionStatus(state: {
   isPeerMode: boolean;
   tabs: TabState[];
   activeTabId: string | null;
-}): boolean {
+  relayStatus: RelayStatus;
+  peerSubmissionSubscription: {
+    phase: "idle" | "subscribing" | "syncing" | "live" | "failed";
+  } | null;
+}): RelayStatus | null {
   if (state.isPeerMode) {
-    return false;
+    const phase = state.peerSubmissionSubscription?.phase;
+    if (phase === "live") {
+      return "connected";
+    }
+    if (phase === "subscribing" || phase === "syncing") {
+      return "connecting";
+    }
+    return state.relayStatus === "disconnected" ? "disconnected" : "connecting";
   }
   const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
   if (!activeTab) {
-    return false;
+    return null;
   }
   const now = new Date();
-  return activeTab.shares.some((share) => new Date(share.expiresAt) > now);
+  const activeShares = activeTab.shares.filter(
+    (share) => new Date(share.expiresAt) > now,
+  );
+  if (activeShares.length === 0) {
+    return null;
+  }
+  const phases = activeShares.map(
+    (share) =>
+      activeTab.incomingReviewSessions[share.docId]?.subscription.phase,
+  );
+  if (phases.every((phase) => phase === "live")) {
+    return "connected";
+  }
+  if (
+    phases.some((phase) => phase === "subscribing" || phase === "syncing") ||
+    state.relayStatus !== "disconnected"
+  ) {
+    return "connecting";
+  }
+  return "disconnected";
 }
 
 const statusLabels: Record<string, string> = {
@@ -26,11 +56,9 @@ const statusLabels: Record<string, string> = {
 };
 
 export function ConnectionStatus() {
-  const relayStatus = useAppStore(selectRelayStatus);
-  const isPeerMode = useAppStore((state) => state.isPeerMode);
-  const activeTabHasShares = useAppStore(selectActiveTabHasShares);
+  const relayStatus = useAppStore(selectVisibleConnectionStatus);
 
-  if (!isPeerMode && !activeTabHasShares) {
+  if (!relayStatus) {
     return null;
   }
 

--- a/src/ui/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/ui/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -214,7 +214,7 @@ function MarkdownRendererContent({
       if (!isCommentType(type)) {
         return;
       }
-      void postPeerCommentAction({
+      const posted = postPeerCommentAction({
         blockIndex,
         type,
         text,
@@ -223,8 +223,13 @@ function MarkdownRendererContent({
           ? { quote: anchor.quote, occurrence: anchor.occurrence }
           : undefined,
       });
+      if (!posted) {
+        showToast(
+          "Comment is too large to send safely, or this document needs refresh.",
+        );
+      }
     },
-    [activeFilePath, fileName, postPeerCommentAction],
+    [activeFilePath, fileName, postPeerCommentAction, showToast],
   );
   const handleRestoreAccess = useCallback(() => {
     if (hostTabId) {

--- a/src/ui/components/PeerCommentCard/PeerCommentCard.tsx
+++ b/src/ui/components/PeerCommentCard/PeerCommentCard.tsx
@@ -18,10 +18,20 @@ export function PeerCommentCard({ docId, comment, currentPath }: Props) {
   const dismissComment = useAppStore((s) => s.dismissComment);
   const navigateToBlock = useAppStore((s) => s.navigateToBlock);
   const setHighlight = useAppStore((s) => s.setHoveredBlockHighlight);
+  const showToast = useAppStore((s) => s.showToast);
   const canMerge = comment.path === currentPath;
 
   function handleNavigate() {
     navigateToBlock(comment.path, comment.blockRef.blockIndex);
+  }
+
+  async function handleMerge() {
+    const merged = await mergeComment(docId, comment);
+    if (!merged) {
+      showToast(
+        "Comment could not be merged safely. Refresh the file and retry.",
+      );
+    }
   }
 
   return (
@@ -70,7 +80,7 @@ export function PeerCommentCard({ docId, comment, currentPath }: Props) {
         <button
           className="peer-card__btn peer-card__btn--merge"
           onClick={() => {
-            void mergeComment(docId, comment);
+            void handleMerge();
           }}
           disabled={!canMerge}
           title={

--- a/src/ui/components/PendingCommentReview/PendingCommentReview.css
+++ b/src/ui/components/PendingCommentReview/PendingCommentReview.css
@@ -12,6 +12,31 @@
   margin-bottom: 0.5rem;
 }
 
+.pending-review__issues {
+  display: grid;
+  gap: 0.375rem;
+  margin-bottom: 0.5rem;
+  padding: 0.625rem;
+  color: var(--text-primary);
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.pending-review__issues span {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+
+.pending-review__issues button {
+  justify-self: start;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .pending-review__count {
   flex: 1 0 100%;
   font-size: 0.75rem;

--- a/src/ui/components/PendingCommentReview/PendingCommentReview.test.tsx
+++ b/src/ui/components/PendingCommentReview/PendingCommentReview.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   makePeerComment,
+  makeShare,
   resetTestStore,
   setTestState,
 } from "../../../testing/testHelpers";
@@ -12,6 +13,7 @@ import { PendingCommentReview } from "./PendingCommentReview";
 beforeEach(() => {
   resetTestStore();
   setTestState({
+    shares: [makeShare()],
     pendingComments: {
       "doc-1": [
         makePeerComment({
@@ -74,5 +76,43 @@ describe("PendingCommentReview", () => {
         screen.queryByRole("button", { name: "Copy agent prompt" }),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("isolates and dismisses an incoming comment that could not be parsed", async () => {
+    const user = userEvent.setup();
+    setTestState({
+      incomingReviewSessions: {
+        "doc-1": {
+          ownerWorkspaceId: "test-workspace",
+          subscription: {
+            subscriptionId: "host-sub",
+            phase: "live",
+            lastError: null,
+          },
+          quarantinedItems: [
+            {
+              id: "issue-1",
+              cmtId: "bad-comment",
+              reason: "Invalid peer comment shape",
+              receivedAt: new Date().toISOString(),
+            },
+          ],
+        },
+      },
+    });
+
+    render(<PendingCommentReview docId="doc-1" />);
+
+    expect(
+      screen.getByText("One incoming comment couldn’t be loaded"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Fix the intro")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Dismiss notice" }));
+
+    expect(
+      screen.queryByText("One incoming comment couldn’t be loaded"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Fix the intro")).toBeInTheDocument();
   });
 });

--- a/src/ui/components/PendingCommentReview/PendingCommentReview.tsx
+++ b/src/ui/components/PendingCommentReview/PendingCommentReview.tsx
@@ -38,6 +38,12 @@ export function PendingCommentReview({ docId }: Props) {
   const clearPendingComments = useAppStore(
     (state) => state.clearPendingComments,
   );
+  const dismissQuarantinedComment = useAppStore(
+    (state) => state.dismissQuarantinedComment,
+  );
+  const flushPendingCommentResolves = useAppStore(
+    (state) => state.flushPendingCommentResolves,
+  );
   const showToast = useAppStore((state) => state.showToast);
   const openAgentSettings = useAppStore((state) => state.openAgentSettings);
   const agentSettingsOpen = useAppStore((state) => state.agentSettingsOpen);
@@ -54,6 +60,8 @@ export function PendingCommentReview({ docId }: Props) {
   );
 
   const comments = pendingComments[docId] ?? EMPTY_PEER_COMMENTS;
+  const quarantinedItems =
+    tab?.incomingReviewSessions[docId]?.quarantinedItems ?? [];
   const currentPath = activeFilePath ?? fileName ?? "";
   const pendingTargets = useMemo(
     () => getPendingPeerCommentTargets(comments),
@@ -133,53 +141,82 @@ export function PendingCommentReview({ docId }: Props) {
     };
   }, [agentSettingsOpen]);
 
-  if (comments.length === 0) {
+  if (comments.length === 0 && quarantinedItems.length === 0) {
     return <p className="pending-review__empty">No pending comments.</p>;
   }
 
   return (
     <div className="pending-review">
-      <div className="pending-review__toolbar">
-        <span className="pending-review__count">
-          {comments.length} comment{comments.length !== 1 ? "s" : ""}
-        </span>
-        {!canStopAgentRun && (
-          <button
-            className="pending-review__btn"
-            onClick={() => {
-              void handlePeerCommentsAgentAction();
-            }}
-            title={peerCommentsAgentAction.title}
-          >
-            {peerCommentsAgentAction.label}
-          </button>
-        )}
-        <button
-          className="pending-review__btn pending-review__btn--merge-all"
-          onClick={() => {
-            void handleMergeAll();
-          }}
-        >
-          Merge all
-        </button>
-        <button
-          className="pending-review__btn pending-review__btn--clear"
-          onClick={() => clearPendingComments(docId)}
-        >
-          Clear all
-        </button>
-      </div>
+      {quarantinedItems.length > 0 && (
+        <div className="pending-review__issues" role="status">
+          <strong>
+            {quarantinedItems.length === 1
+              ? "One incoming comment couldn’t be loaded"
+              : `${quarantinedItems.length} incoming comments couldn’t be loaded`}
+          </strong>
+          <span>
+            The invalid data was isolated so the rest of the review stays
+            available.
+          </span>
+          {quarantinedItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => {
+                if (dismissQuarantinedComment(docId, item.id)) {
+                  flushPendingCommentResolves(docId);
+                }
+              }}
+            >
+              Dismiss notice
+            </button>
+          ))}
+        </div>
+      )}
+      {comments.length > 0 && (
+        <>
+          <div className="pending-review__toolbar">
+            <span className="pending-review__count">
+              {comments.length} comment{comments.length !== 1 ? "s" : ""}
+            </span>
+            {!canStopAgentRun && (
+              <button
+                className="pending-review__btn"
+                onClick={() => {
+                  void handlePeerCommentsAgentAction();
+                }}
+                title={peerCommentsAgentAction.title}
+              >
+                {peerCommentsAgentAction.label}
+              </button>
+            )}
+            <button
+              className="pending-review__btn pending-review__btn--merge-all"
+              onClick={() => {
+                void handleMergeAll();
+              }}
+            >
+              Merge all
+            </button>
+            <button
+              className="pending-review__btn pending-review__btn--clear"
+              onClick={() => clearPendingComments(docId)}
+            >
+              Clear all
+            </button>
+          </div>
 
-      <div className="pending-review__list">
-        {comments.map((comment) => (
-          <PeerCommentCard
-            key={comment.id}
-            docId={docId}
-            comment={comment}
-            currentPath={currentPath}
-          />
-        ))}
-      </div>
+          <div className="pending-review__list">
+            {comments.map((comment) => (
+              <PeerCommentCard
+                key={comment.id}
+                docId={docId}
+                comment={comment}
+                currentPath={currentPath}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/ui/components/ReviewErrorBoundary/ReviewErrorBoundary.css
+++ b/src/ui/components/ReviewErrorBoundary/ReviewErrorBoundary.css
@@ -1,0 +1,24 @@
+.review-error {
+  display: grid;
+  gap: 8px;
+  margin: 16px;
+  padding: 16px;
+  color: var(--text-primary);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.review-error span {
+  color: var(--text-secondary);
+}
+
+.review-error button {
+  justify-self: start;
+  padding: 6px 10px;
+  color: var(--on-accent);
+  background: var(--accent);
+  border: 0;
+  border-radius: var(--radius);
+  cursor: pointer;
+}

--- a/src/ui/components/ReviewErrorBoundary/ReviewErrorBoundary.test.tsx
+++ b/src/ui/components/ReviewErrorBoundary/ReviewErrorBoundary.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ReviewErrorBoundary } from "./ReviewErrorBoundary";
+
+function CrashingReviewSurface(): never {
+  throw new Error("malformed review item");
+}
+
+describe("ReviewErrorBoundary", () => {
+  it("contains a review-surface crash and offers recovery", () => {
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <ReviewErrorBoundary title="Incoming comments could not be displayed">
+        <CrashingReviewSurface />
+      </ReviewErrorBoundary>,
+    );
+
+    expect(
+      screen.getByText("Incoming comments could not be displayed"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(error).toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/ReviewErrorBoundary/ReviewErrorBoundary.tsx
+++ b/src/ui/components/ReviewErrorBoundary/ReviewErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import "./ReviewErrorBoundary.css";
+
+interface Props {
+  children: ReactNode;
+  title: string;
+  resetKey?: string | number | null;
+}
+
+interface State {
+  failed: boolean;
+}
+
+export class ReviewErrorBoundary extends Component<Props, State> {
+  state: State = { failed: false };
+
+  static getDerivedStateFromError(): State {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[ReviewErrorBoundary] review surface failed:", error, {
+      componentStack: info.componentStack,
+    });
+  }
+
+  componentDidUpdate(previousProps: Props): void {
+    if (this.state.failed && previousProps.resetKey !== this.props.resetKey) {
+      this.setState({ failed: false });
+    }
+  }
+
+  render(): ReactNode {
+    if (!this.state.failed) {
+      return this.props.children;
+    }
+
+    return (
+      <section className="review-error" role="alert">
+        <strong>{this.props.title}</strong>
+        <span>
+          Your document is safe. Retry this view to continue reviewing.
+        </span>
+        <button onClick={() => this.setState({ failed: false })}>Retry</button>
+      </section>
+    );
+  }
+}

--- a/src/ui/components/ReviewErrorBoundary/index.ts
+++ b/src/ui/components/ReviewErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export { ReviewErrorBoundary } from "./ReviewErrorBoundary";

--- a/src/ui/hooks/useHashRouter.test.tsx
+++ b/src/ui/hooks/useHashRouter.test.tsx
@@ -1,0 +1,31 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config", () => ({
+  WORKER_URL: "https://mock-worker.test",
+}));
+
+import { useHashRouter } from "./useHashRouter";
+import { useAppStore } from "../../store";
+import { resetTestStore, setTestState } from "../../testing/testHelpers";
+
+beforeEach(() => {
+  window.location.hash = "";
+  resetTestStore();
+  setTestState({}, { isPeerMode: false });
+  vi.restoreAllMocks();
+});
+
+describe("useHashRouter", () => {
+  it("leaves peer mode before restoring host workspaces", async () => {
+    const restoreTabs = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ isPeerMode: true, restoreTabs });
+
+    renderHook(() => useHashRouter());
+
+    await waitFor(() => {
+      expect(useAppStore.getState().isPeerMode).toBe(false);
+      expect(restoreTabs).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/ui/hooks/useHashRouter.ts
+++ b/src/ui/hooks/useHashRouter.ts
@@ -2,10 +2,12 @@ import { useEffect, useState } from "react";
 import { useAppStore } from "../../store";
 import { isShareHash } from "../../utils/shareUrl";
 import { WORKER_URL } from "../../config";
+import { stopRelay } from "../../modules/relay";
 
 export function useHashRouter(): boolean {
   const loadSharedContent = useAppStore((s) => s.loadSharedContent);
   const restoreTabs = useAppStore((s) => s.restoreTabs);
+  const leavePeerMode = useAppStore((s) => s.leavePeerMode);
   const [peerModeChecked, setPeerModeChecked] = useState(false);
 
   useEffect(() => {
@@ -19,6 +21,9 @@ export function useHashRouter(): boolean {
 
     function checkHash() {
       if (isShareHash() && WORKER_URL) {
+        if (!useAppStore.getState().isPeerMode) {
+          stopRelay();
+        }
         loadSharedContent()
           .catch((error: unknown) => {
             console.warn(
@@ -28,6 +33,10 @@ export function useHashRouter(): boolean {
           })
           .finally(() => setPeerModeChecked(true));
       } else {
+        if (useAppStore.getState().isPeerMode) {
+          stopRelay();
+          leavePeerMode();
+        }
         setPeerModeChecked(true);
         void restoreWorkspace();
       }

--- a/worker/src/relay.ts
+++ b/worker/src/relay.ts
@@ -8,9 +8,16 @@ interface RelayShareMeta {
   ttl: number;
 }
 
+interface SocketSubscription {
+  docId: string;
+  role: "host" | "peer";
+  subscriptionId?: string;
+}
+
 interface SocketAttachment {
-  subscriptions: string[];
-  hostDocs: string[];
+  subscriptions: SocketSubscription[];
+  writeWindowStartedAt: number;
+  writesInWindow: number;
 }
 
 interface ClearDocRequest {
@@ -69,15 +76,88 @@ function getStringArray(
   return value.filter((entry): entry is string => typeof entry === "string");
 }
 
+const MAX_RELAY_FRAME_BYTES = 1_500_000;
+const MAX_ENCRYPTED_COMMENT_BYTES = 1024 * 1024;
+const COMMENT_RATE_WINDOW_MS = 60_000;
+const MAX_COMMENT_WRITES_PER_WINDOW = 60;
+const MAX_IDENTIFIER_LENGTH = 256;
+const MAX_PENDING_COMMENTS_PER_DOC = 500;
+const MAX_PENDING_PAYLOAD_CHARS_PER_DOC = 8 * 1024 * 1024;
+const MAX_SNAPSHOT_CHUNK_BYTES = 1_450_000;
+const COMMENT_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+function isValidIdentifier(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_IDENTIFIER_LENGTH &&
+    COMMENT_ID_RE.test(value)
+  );
+}
+
+function getOptionalSubscriptionId(
+  frame: Record<string, unknown>,
+): string | undefined {
+  const value = frame["subscriptionId"];
+  if (!isValidIdentifier(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function hasInvalidSubscriptionId(frame: Record<string, unknown>): boolean {
+  return (
+    "subscriptionId" in frame && !isValidIdentifier(frame["subscriptionId"])
+  );
+}
+
+function isSocketSubscription(value: unknown): value is SocketSubscription {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const role = value["role"];
+  const subscriptionId = value["subscriptionId"];
+  return (
+    typeof value["docId"] === "string" &&
+    (role === "host" || role === "peer") &&
+    (subscriptionId === undefined || typeof subscriptionId === "string")
+  );
+}
+
+function parseSubscriptions(
+  record: Record<string, unknown>,
+): SocketSubscription[] {
+  const value = record["subscriptions"];
+  if (Array.isArray(value) && value.every(isSocketSubscription)) {
+    return value;
+  }
+
+  const legacySubscriptions = getStringArray(record, "subscriptions");
+  const legacyHostDocs = new Set(getStringArray(record, "hostDocs"));
+  return legacySubscriptions.map((docId) => ({
+    docId,
+    role: legacyHostDocs.has(docId) ? "host" : "peer",
+  }));
+}
+
 function getAttachment(ws: WebSocket): SocketAttachment {
   const raw = ws.deserializeAttachment();
   if (isRecord(raw)) {
     return {
-      subscriptions: getStringArray(raw, "subscriptions"),
-      hostDocs: getStringArray(raw, "hostDocs"),
+      subscriptions: parseSubscriptions(raw),
+      writeWindowStartedAt:
+        typeof raw["writeWindowStartedAt"] === "number"
+          ? raw["writeWindowStartedAt"]
+          : Date.now(),
+      writesInWindow:
+        typeof raw["writesInWindow"] === "number" ? raw["writesInWindow"] : 0,
     };
   }
-  return { subscriptions: [], hostDocs: [] };
+  return {
+    subscriptions: [],
+    writeWindowStartedAt: Date.now(),
+    writesInWindow: 0,
+  };
 }
 
 function setAttachment(ws: WebSocket, attachment: SocketAttachment): void {
@@ -102,6 +182,16 @@ function parseMessage(
   try {
     const text =
       typeof message === "string" ? message : new TextDecoder().decode(message);
+    if (new TextEncoder().encode(text).byteLength > MAX_RELAY_FRAME_BYTES) {
+      ws.send(
+        JSON.stringify({
+          type: "error",
+          docId: "",
+          message: "Frame too large",
+        }),
+      );
+      return null;
+    }
     data = JSON.parse(text);
   } catch (parseError) {
     console.error("[RelayHubSqlite] invalid JSON from client:", parseError);
@@ -117,6 +207,82 @@ function parseMessage(
     return null;
   }
   return data;
+}
+
+function findSubscription(
+  attachment: SocketAttachment,
+  docId: string,
+): SocketSubscription | undefined {
+  return attachment.subscriptions.find(
+    (subscription) => subscription.docId === docId,
+  );
+}
+
+function withSubscriptionId(
+  message: Record<string, unknown>,
+  subscription: SocketSubscription | undefined,
+): Record<string, unknown> {
+  if (!subscription?.subscriptionId) {
+    return message;
+  }
+  return { ...message, subscriptionId: subscription.subscriptionId };
+}
+
+function sendDocFrame(
+  ws: WebSocket,
+  docId: string,
+  message: Record<string, unknown>,
+): void {
+  const subscription = findSubscription(getAttachment(ws), docId);
+  ws.send(JSON.stringify(withSubscriptionId(message, subscription)));
+}
+
+function sendRequestFrame(
+  ws: WebSocket,
+  requestFrame: Record<string, unknown>,
+  responseFrame: Record<string, unknown>,
+): void {
+  const subscriptionId = getOptionalSubscriptionId(requestFrame);
+  ws.send(
+    JSON.stringify(
+      subscriptionId ? { ...responseFrame, subscriptionId } : responseFrame,
+    ),
+  );
+}
+
+function subscriptionMatchesFrame(
+  subscription: SocketSubscription | undefined,
+  frame: Record<string, unknown>,
+): boolean {
+  if (!subscription) {
+    return false;
+  }
+  const frameSubscriptionId = getOptionalSubscriptionId(frame);
+  return (
+    !frameSubscriptionId ||
+    !subscription.subscriptionId ||
+    frameSubscriptionId === subscription.subscriptionId
+  );
+}
+
+function consumeCommentWrite(ws: WebSocket): boolean {
+  const attachment = getAttachment(ws);
+  const now = Date.now();
+  if (now - attachment.writeWindowStartedAt >= COMMENT_RATE_WINDOW_MS) {
+    attachment.writeWindowStartedAt = now;
+    attachment.writesInWindow = 0;
+  }
+  if (attachment.writesInWindow >= MAX_COMMENT_WRITES_PER_WINDOW) {
+    return false;
+  }
+  attachment.writesInWindow += 1;
+  setAttachment(ws, attachment);
+  return true;
+}
+
+function encryptedPayloadByteLength(payload: string): number {
+  const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+  return Math.floor((payload.length * 3) / 4) - padding;
 }
 
 export class RelayHubSqlite implements DurableObject {
@@ -172,7 +338,11 @@ export class RelayHubSqlite implements DurableObject {
       const client = pair[0];
       const server = pair[1];
       this.state.acceptWebSocket(server);
-      setAttachment(server, { subscriptions: [], hostDocs: [] });
+      setAttachment(server, {
+        subscriptions: [],
+        writeWindowStartedAt: Date.now(),
+        writesInWindow: 0,
+      });
       return new Response(null, { status: 101, webSocket: client });
     }
 
@@ -204,6 +374,21 @@ export class RelayHubSqlite implements DurableObject {
       return;
     }
     const frameType = typeof frame.type === "string" ? frame.type : "";
+    if (hasInvalidSubscriptionId(frame)) {
+      ws.send(
+        JSON.stringify({
+          type: "error",
+          docId: isValidIdentifier(frame.docId) ? frame.docId : "",
+          scope: "operation",
+          message: "Invalid subscription id",
+        }),
+      );
+      return;
+    }
+    if (frame.version === 1) {
+      this.handleRelayBroadcast(ws, frame);
+      return;
+    }
     const handler = this.frameHandlers[frameType];
     if (!handler) {
       ws.send(
@@ -223,39 +408,47 @@ export class RelayHubSqlite implements DurableObject {
     ws: WebSocket,
     frame: Record<string, unknown>,
   ): Promise<void> {
-    if (typeof frame.docId !== "string") {
+    if (!isValidIdentifier(frame.docId)) {
+      sendRequestFrame(ws, frame, {
+        type: "error",
+        docId: "",
+        message: "Invalid document id",
+      });
       return;
     }
 
     const docId = frame.docId;
     const role = frame.role === "host" ? "host" : "peer";
+    const subscriptionId = getOptionalSubscriptionId(frame);
     const metaJson = await this.env.LOLLIPOP_DRAGON.get(`share:${docId}:meta`);
     if (!metaJson) {
       this.clearDoc(docId);
-      ws.send(
-        JSON.stringify({ type: "error", docId, message: "Doc not found" }),
-      );
+      sendRequestFrame(ws, frame, {
+        type: "error",
+        docId,
+        message: "Doc not found",
+      });
       return;
     }
 
     const meta = parseShareMeta(metaJson);
     if (!meta) {
-      ws.send(
-        JSON.stringify({
-          type: "error",
-          docId,
-          message: "Invalid share metadata",
-        }),
-      );
+      sendRequestFrame(ws, frame, {
+        type: "error",
+        docId,
+        message: "Invalid share metadata",
+      });
       return;
     }
 
     const expiresAt = new Date(meta.createdAt).getTime() + meta.ttl * 1000;
     if (expiresAt <= Date.now()) {
       this.clearDoc(docId);
-      ws.send(
-        JSON.stringify({ type: "error", docId, message: "Share expired" }),
-      );
+      sendRequestFrame(ws, frame, {
+        type: "error",
+        docId,
+        message: "Share expired",
+      });
       return;
     }
 
@@ -263,7 +456,11 @@ export class RelayHubSqlite implements DurableObject {
     if (role === "host") {
       isHost = await this.verifyHostRole(frame, meta.hostSecretHash);
       if (!isHost) {
-        ws.send(JSON.stringify({ type: "error", docId, message: "Forbidden" }));
+        sendRequestFrame(ws, frame, {
+          type: "error",
+          docId,
+          message: "Forbidden",
+        });
         return;
       }
     }
@@ -280,15 +477,17 @@ export class RelayHubSqlite implements DurableObject {
     );
 
     const attachment = getAttachment(ws);
-    if (!attachment.subscriptions.includes(docId)) {
-      attachment.subscriptions.push(docId);
-    }
-    if (isHost && !attachment.hostDocs.includes(docId)) {
-      attachment.hostDocs.push(docId);
-    }
+    attachment.subscriptions = attachment.subscriptions.filter(
+      (subscription) => subscription.docId !== docId,
+    );
+    attachment.subscriptions.push({
+      docId,
+      role: isHost ? "host" : "peer",
+      ...(subscriptionId ? { subscriptionId } : {}),
+    });
     setAttachment(ws, attachment);
 
-    ws.send(JSON.stringify({ type: "subscribe:ok", docId }));
+    sendDocFrame(ws, docId, { type: "subscribe:ok", docId });
     if (isHost) {
       this.sendSnapshot(ws, docId);
     }
@@ -309,16 +508,20 @@ export class RelayHubSqlite implements DurableObject {
     ws: WebSocket,
     frame: Record<string, unknown>,
   ): void {
-    if (typeof frame.docId !== "string") {
+    if (!isValidIdentifier(frame.docId)) {
       return;
     }
     const docId = frame.docId;
+    const subscriptionId = getOptionalSubscriptionId(frame);
     const attachment = getAttachment(ws);
     attachment.subscriptions = attachment.subscriptions.filter(
-      (subscriptionId) => subscriptionId !== docId,
-    );
-    attachment.hostDocs = attachment.hostDocs.filter(
-      (hostDocId) => hostDocId !== docId,
+      (subscription) =>
+        subscription.docId !== docId ||
+        Boolean(
+          subscriptionId &&
+          subscription.subscriptionId &&
+          subscription.subscriptionId !== subscriptionId,
+        ),
     );
     setAttachment(ws, attachment);
   }
@@ -338,7 +541,49 @@ export class RelayHubSqlite implements DurableObject {
       cmtId: String(row.cmt_id),
       payload: String(row.payload),
     }));
-    ws.send(JSON.stringify({ type: "comments:snapshot", docId, comments }));
+    const subscription = findSubscription(getAttachment(ws), docId);
+    if (!subscription?.subscriptionId) {
+      sendDocFrame(ws, docId, {
+        type: "comments:snapshot",
+        docId,
+        comments,
+      });
+      return;
+    }
+    const chunks: Array<typeof comments> = [];
+    let currentChunk: typeof comments = [];
+    for (const comment of comments) {
+      const candidate = [...currentChunk, comment];
+      const candidateBytes = new TextEncoder().encode(
+        JSON.stringify({
+          type: "comments:snapshot",
+          docId,
+          comments: candidate,
+          subscriptionId: subscription.subscriptionId,
+        }),
+      ).byteLength;
+      if (
+        candidateBytes > MAX_SNAPSHOT_CHUNK_BYTES &&
+        currentChunk.length > 0
+      ) {
+        chunks.push(currentChunk);
+        currentChunk = [comment];
+      } else {
+        currentChunk = candidate;
+      }
+    }
+    chunks.push(currentChunk);
+    const snapshotId = crypto.randomUUID();
+    for (const [chunkIndex, chunk] of chunks.entries()) {
+      sendDocFrame(ws, docId, {
+        type: "comments:snapshot",
+        docId,
+        comments: chunk,
+        snapshotId,
+        chunkIndex,
+        chunkCount: chunks.length,
+      });
+    }
   }
 
   private handleCommentAdd(
@@ -346,10 +591,20 @@ export class RelayHubSqlite implements DurableObject {
     frame: Record<string, unknown>,
   ): void {
     if (
-      typeof frame.docId !== "string" ||
+      !isValidIdentifier(frame.docId) ||
       typeof frame.cmtId !== "string" ||
       typeof frame.payload !== "string"
     ) {
+      return;
+    }
+    if (!isValidIdentifier(frame.cmtId)) {
+      sendDocFrame(ws, frame.docId, {
+        type: "error",
+        docId: frame.docId,
+        cmtId: frame.cmtId,
+        scope: "operation",
+        message: "Invalid comment id",
+      });
       return;
     }
 
@@ -357,10 +612,89 @@ export class RelayHubSqlite implements DurableObject {
     const cmtId = frame.cmtId;
     const payload = frame.payload;
     const attachment = getAttachment(ws);
-    if (!attachment.subscriptions.includes(docId)) {
+    const subscription = findSubscription(attachment, docId);
+    const frameSubscriptionId = getOptionalSubscriptionId(frame);
+    if (
+      frameSubscriptionId &&
+      subscription?.subscriptionId &&
+      frameSubscriptionId !== subscription.subscriptionId
+    ) {
+      sendRequestFrame(ws, frame, {
+        type: "error",
+        docId,
+        cmtId,
+        scope: "operation",
+        message: "Stale subscription generation",
+      });
+      return;
+    }
+    if (
+      !subscriptionMatchesFrame(subscription, frame) ||
+      subscription?.role !== "peer"
+    ) {
       ws.send(
-        JSON.stringify({ type: "error", docId, message: "Not subscribed" }),
+        JSON.stringify(
+          withSubscriptionId(
+            { type: "error", docId, message: "Not subscribed as peer" },
+            subscription,
+          ),
+        ),
       );
+      return;
+    }
+    if (encryptedPayloadByteLength(payload) > MAX_ENCRYPTED_COMMENT_BYTES) {
+      sendDocFrame(ws, docId, {
+        type: "error",
+        docId,
+        cmtId,
+        scope: "operation",
+        message: "Comment payload too large",
+      });
+      return;
+    }
+    const existingRows = this.sql
+      .exec(
+        "SELECT 1 AS found FROM comments WHERE doc_id = ? AND cmt_id = ? LIMIT 1",
+        docId,
+        cmtId,
+      )
+      .toArray();
+    if (existingRows.length > 0) {
+      sendDocFrame(ws, docId, { type: "comment:add:ack", docId, cmtId });
+      return;
+    }
+    const usageRows = this.sql
+      .exec(
+        `SELECT COUNT(*) AS comment_count,
+                COALESCE(SUM(LENGTH(payload)), 0) AS payload_chars
+         FROM comments
+         WHERE doc_id = ?`,
+        docId,
+      )
+      .toArray();
+    const commentCount = Number(usageRows[0]?.comment_count ?? 0);
+    const payloadChars = Number(usageRows[0]?.payload_chars ?? 0);
+    if (
+      commentCount >= MAX_PENDING_COMMENTS_PER_DOC ||
+      payloadChars + payload.length > MAX_PENDING_PAYLOAD_CHARS_PER_DOC
+    ) {
+      sendDocFrame(ws, docId, {
+        type: "error",
+        docId,
+        cmtId,
+        scope: "operation",
+        message: "Review inbox capacity exceeded",
+      });
+      return;
+    }
+    if (!consumeCommentWrite(ws)) {
+      sendDocFrame(ws, docId, {
+        type: "error",
+        docId,
+        cmtId,
+        scope: "operation",
+        message: "Comment rate limit exceeded",
+      });
       return;
     }
 
@@ -391,7 +725,7 @@ export class RelayHubSqlite implements DurableObject {
       expiresAt,
     );
 
-    ws.send(JSON.stringify({ type: "comment:add:ack", docId, cmtId }));
+    sendDocFrame(ws, docId, { type: "comment:add:ack", docId, cmtId });
     this.forwardToHostSockets(ws, docId, {
       type: "comment:added",
       docId,
@@ -405,14 +739,50 @@ export class RelayHubSqlite implements DurableObject {
     ws: WebSocket,
     frame: Record<string, unknown>,
   ): void {
-    if (typeof frame.docId !== "string" || typeof frame.cmtId !== "string") {
+    if (!isValidIdentifier(frame.docId) || typeof frame.cmtId !== "string") {
+      return;
+    }
+    if (!isValidIdentifier(frame.cmtId)) {
+      sendDocFrame(ws, frame.docId, {
+        type: "error",
+        docId: frame.docId,
+        cmtId: frame.cmtId,
+        scope: "operation",
+        message: "Invalid comment id",
+      });
       return;
     }
 
     const docId = frame.docId;
     const cmtId = frame.cmtId;
-    if (!this.isHostSocketForDoc(ws, docId)) {
-      ws.send(JSON.stringify({ type: "error", docId, message: "Forbidden" }));
+    const subscription = findSubscription(getAttachment(ws), docId);
+    const frameSubscriptionId = getOptionalSubscriptionId(frame);
+    if (
+      frameSubscriptionId &&
+      subscription?.subscriptionId &&
+      frameSubscriptionId !== subscription.subscriptionId
+    ) {
+      sendRequestFrame(ws, frame, {
+        type: "error",
+        docId,
+        cmtId,
+        scope: "operation",
+        message: "Stale subscription generation",
+      });
+      return;
+    }
+    if (
+      !subscriptionMatchesFrame(subscription, frame) ||
+      subscription?.role !== "host"
+    ) {
+      ws.send(
+        JSON.stringify(
+          withSubscriptionId(
+            { type: "error", docId, message: "Forbidden" },
+            subscription,
+          ),
+        ),
+      );
       return;
     }
 
@@ -421,7 +791,11 @@ export class RelayHubSqlite implements DurableObject {
       docId,
       cmtId,
     );
-    ws.send(JSON.stringify({ type: "comment:resolve:ack", docId, cmtId }));
+    sendDocFrame(ws, docId, {
+      type: "comment:resolve:ack",
+      docId,
+      cmtId,
+    });
     this.forwardToSubscribers(ws, docId, {
       type: "comment:resolved",
       docId,
@@ -430,9 +804,39 @@ export class RelayHubSqlite implements DurableObject {
     void this.scheduleNextAlarm();
   }
 
-  private isHostSocketForDoc(ws: WebSocket, docId: string): boolean {
-    const attachment = getAttachment(ws);
-    return attachment.hostDocs.includes(docId);
+  private handleRelayBroadcast(
+    ws: WebSocket,
+    frame: Record<string, unknown>,
+  ): void {
+    if (!isValidIdentifier(frame.docId) || typeof frame.payload !== "string") {
+      return;
+    }
+    const docId = frame.docId;
+    const subscription = findSubscription(getAttachment(ws), docId);
+    const frameSubscriptionId = getOptionalSubscriptionId(frame);
+    if (
+      frameSubscriptionId &&
+      subscription?.subscriptionId &&
+      frameSubscriptionId !== subscription.subscriptionId
+    ) {
+      return;
+    }
+    if (
+      !subscriptionMatchesFrame(subscription, frame) ||
+      subscription?.role !== "host"
+    ) {
+      sendDocFrame(ws, docId, {
+        type: "error",
+        docId,
+        message: "Forbidden",
+      });
+      return;
+    }
+    this.forwardToSubscribers(ws, docId, {
+      version: 1,
+      docId,
+      payload: frame.payload,
+    });
   }
 
   private forwardToHostSockets(
@@ -441,14 +845,14 @@ export class RelayHubSqlite implements DurableObject {
     message: Record<string, unknown>,
   ): void {
     const sockets = this.state.getWebSockets();
-    const serialized = JSON.stringify(message);
     for (const peer of sockets) {
       if (peer === sender) {
         continue;
       }
       const attachment = getAttachment(peer);
-      if (attachment.hostDocs.includes(docId)) {
-        peer.send(serialized);
+      const subscription = findSubscription(attachment, docId);
+      if (subscription?.role === "host") {
+        peer.send(JSON.stringify(withSubscriptionId(message, subscription)));
       }
     }
   }
@@ -459,14 +863,14 @@ export class RelayHubSqlite implements DurableObject {
     message: Record<string, unknown>,
   ): void {
     const sockets = this.state.getWebSockets();
-    const serialized = JSON.stringify(message);
     for (const peer of sockets) {
       if (peer === sender) {
         continue;
       }
       const attachment = getAttachment(peer);
-      if (attachment.subscriptions.includes(docId)) {
-        peer.send(serialized);
+      const subscription = findSubscription(attachment, docId);
+      if (subscription) {
+        peer.send(JSON.stringify(withSubscriptionId(message, subscription)));
       }
     }
   }


### PR DESCRIPTION
## Summary

- make relay subscriptions generation-scoped, ordered, bounded, and truthful about document readiness
- persist stable workspace ownership and resolve intent without rewriting all document content on inbox updates
- make incoming merge fail closed and idempotent, while quarantining malformed feedback and containing render failures
- retain additive compatibility for legacy share records and relay clients during migration

## Validation

- `npm run validate`
- 86 test files, 685 tests passed
- app and Worker typechecks passed
- architecture validation passed
- production build and bundle budgets passed

## Local scope

The unrelated untracked `uavSelection.diagnostic.test.tsx` file is not included.